### PR TITLE
chore: Removed Newtonsoft package and added key null checkers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ docs/public
 .vs/
 
 examples/SimpleLambda/.aws-sam
+examples/SimpleLambda/samconfig.toml
 
 AWS.Lambda.Powertools.sln.DotSettings.user
 [Oo]bj/**

--- a/libraries/src/AWS.Lambda.PowerTools.Metrics.Web/Extensions/ApplicationBuilderExtensions.cs
+++ b/libraries/src/AWS.Lambda.PowerTools.Metrics.Web/Extensions/ApplicationBuilderExtensions.cs
@@ -29,7 +29,7 @@ namespace AWS.Lambda.PowerTools.Metrics.Web.Extensions
 
                 // Include X-Ray trace if it is set
                 var xRayTraceId = context.Request.Headers["X-Amzn-Trace-Id"];
-                if(!string.IsNullOrEmpty(xRayTraceId) && xRayTraceId.Count > 0)
+                if(!string.IsNullOrWhiteSpace(xRayTraceId) && xRayTraceId.Count > 0)
                 {
                    logger.AddMetadata("XRayTraceId", xRayTraceId[0]);
                 }
@@ -37,7 +37,7 @@ namespace AWS.Lambda.PowerTools.Metrics.Web.Extensions
                 // Include w3c trace id
                 logger.AddMetadata("TraceId", Activity.Current?.Id ?? context?.TraceIdentifier);
 
-                if (!string.IsNullOrEmpty(Activity.Current?.TraceStateString))
+                if (!string.IsNullOrWhiteSpace(Activity.Current?.TraceStateString))
                 {
                    logger.AddMetadata("TraceState", Activity.Current.TraceStateString);
                 }

--- a/libraries/src/AWS.Lambda.PowerTools.Metrics/AWS.Lambda.PowerTools.Metrics.csproj
+++ b/libraries/src/AWS.Lambda.PowerTools.Metrics/AWS.Lambda.PowerTools.Metrics.csproj
@@ -20,7 +20,6 @@
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/libraries/src/AWS.Lambda.PowerTools.Metrics/Internal/MetricsAspectHandler.cs
+++ b/libraries/src/AWS.Lambda.PowerTools.Metrics/Internal/MetricsAspectHandler.cs
@@ -27,13 +27,13 @@ namespace AWS.Lambda.PowerTools.Metrics.Internal
         public void OnEntry(AspectEventArgs eventArgs)
         {
             if (!_isColdStart || !_captureColdStartEnabled) return;
-            _metrics.AddMetric("ColdStart", 1, MetricUnit.COUNT);
+            _metrics.AddMetric("ColdStart", 1.0, MetricUnit.COUNT);
             _isColdStart = false;
         }
 
         public void OnSuccess(AspectEventArgs eventArgs, object result)
         {
-            // NOT IMPLEMENTED
+            
         }
 
         public T OnException<T>(AspectEventArgs eventArgs, Exception exception)

--- a/libraries/src/AWS.Lambda.PowerTools.Metrics/MetricsAttribute.cs
+++ b/libraries/src/AWS.Lambda.PowerTools.Metrics/MetricsAttribute.cs
@@ -18,9 +18,9 @@ namespace AWS.Lambda.PowerTools.Metrics
         private IMetrics MetricsInstance =>
             _metricsInstance ??= new Metrics(
                 PowerToolsConfigurations.Instance,
-                metricsNamespace: MetricsNamespace,
-                serviceName: ServiceName,
-                captureMetricsEvenIfEmpty: CaptureEmptyMetrics
+                MetricsNamespace,
+                ServiceName,
+                CaptureEmptyMetrics
             );
 
         protected override IMethodAspectHandler CreateHandler()

--- a/libraries/src/AWS.Lambda.PowerTools.Metrics/Model/Metadata.cs
+++ b/libraries/src/AWS.Lambda.PowerTools.Metrics/Model/Metadata.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using AWS.Lambda.PowerTools.Metrics.Serializer;
-using Newtonsoft.Json;
 
 namespace AWS.Lambda.PowerTools.Metrics
 {
@@ -10,7 +10,7 @@ namespace AWS.Lambda.PowerTools.Metrics
         [JsonConverter(typeof(UnixMillisecondDateTimeConverter))]
         public DateTime Timestamp { get; }
 
-        [JsonProperty("CloudWatchMetrics")]
+        [JsonPropertyName("CloudWatchMetrics")]
         public List<MetricDirective> CloudWatchMetrics { get; private set; }
 
         private MetricDirective _metricDirective { get { return CloudWatchMetrics[0]; } }

--- a/libraries/src/AWS.Lambda.PowerTools.Metrics/Model/MetricDefinition.cs
+++ b/libraries/src/AWS.Lambda.PowerTools.Metrics/Model/MetricDefinition.cs
@@ -1,11 +1,11 @@
 ﻿using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace AWS.Lambda.PowerTools.Metrics
 {
     public class MetricDefinition
     {
-        [JsonProperty("Name")]
+        [JsonPropertyName("Name")]
         public string Name
         {
             get;
@@ -18,7 +18,7 @@ namespace AWS.Lambda.PowerTools.Metrics
             get;
         }
 
-        [JsonProperty("Unit")]
+        [JsonPropertyName("Unit")]
         public MetricUnit Unit {
             get;
             set;

--- a/libraries/src/AWS.Lambda.PowerTools.Metrics/Model/MetricDirective.cs
+++ b/libraries/src/AWS.Lambda.PowerTools.Metrics/Model/MetricDirective.cs
@@ -1,18 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json.Serialization;
 using AWS.Lambda.PowerTools.Core;
-using Newtonsoft.Json;
 
 namespace AWS.Lambda.PowerTools.Metrics
 {
     public class MetricDirective
     {
         
-        [JsonProperty("Namespace")]
+        [JsonPropertyName("Namespace")]
         public string Namespace { get; private set; }
         
-        [JsonProperty("Metrics")]
+        [JsonPropertyName("Metrics")]
         public List<MetricDefinition> Metrics
         {
             get; private set;
@@ -38,7 +38,7 @@ namespace AWS.Lambda.PowerTools.Metrics
             DefaultDimensions = defaultDimensions;
         }
 
-        [JsonProperty("Dimensions")]
+        [JsonPropertyName("Dimensions")]
         public List<List<string>> AllDimensionKeys
         {
             get

--- a/libraries/src/AWS.Lambda.PowerTools.Metrics/Model/MetricUnit.cs
+++ b/libraries/src/AWS.Lambda.PowerTools.Metrics/Model/MetricUnit.cs
@@ -1,12 +1,12 @@
 using System.Runtime.Serialization;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
+using AWS.Lambda.PowerTools.Metrics.Serializer;
 
 namespace AWS.Lambda.PowerTools.Metrics
-{
+{       
     [JsonConverter(typeof(StringEnumConverter))]
     public enum MetricUnit
-    {
+    {        
         [EnumMember(Value = "None")]
         NONE,
         [EnumMember(Value = "Seconds")]

--- a/libraries/src/AWS.Lambda.PowerTools.Metrics/Model/RootNode.cs
+++ b/libraries/src/AWS.Lambda.PowerTools.Metrics/Model/RootNode.cs
@@ -1,11 +1,13 @@
 ﻿using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace AWS.Lambda.PowerTools.Metrics
 {
     public class RootNode
     {
-        [JsonProperty("_aws")]
+        [JsonPropertyName("_aws")]
         public Metadata AWS { get; } = new Metadata();
 
         [JsonExtensionData]
@@ -37,12 +39,12 @@ namespace AWS.Lambda.PowerTools.Metrics
 
         public string Serialize()
         {
-            if (string.IsNullOrEmpty(AWS.GetNamespace()))
+            if (string.IsNullOrWhiteSpace(AWS.GetNamespace()))
             {
                 throw new SchemaValidationException("namespace");
             }
 
-            return JsonConvert.SerializeObject(this);
+            return JsonSerializer.Serialize(this);
         }
 
     }

--- a/libraries/src/AWS.Lambda.PowerTools.Metrics/Serializer/StringEnumConverter.cs
+++ b/libraries/src/AWS.Lambda.PowerTools.Metrics/Serializer/StringEnumConverter.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace AWS.Lambda.PowerTools.Metrics.Serializer
+{
+    public class StringEnumConverter : JsonConverterFactory
+    {
+        private readonly JsonNamingPolicy _namingPolicy;
+        private readonly bool _allowIntegerValues;
+        private readonly JsonStringEnumConverter _baseConverter;
+
+        public StringEnumConverter() : this(null) { }
+
+        private StringEnumConverter(JsonNamingPolicy namingPolicy = null, bool allowIntegerValues = true)
+        {
+            _namingPolicy = namingPolicy;
+            _allowIntegerValues = allowIntegerValues;
+            _baseConverter = new JsonStringEnumConverter(namingPolicy, allowIntegerValues);
+        }
+
+        public override bool CanConvert(Type typeToConvert)
+        {
+            return _baseConverter.CanConvert(typeToConvert);
+        }
+
+        public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+        {
+            var query = from field in typeToConvert.GetFields(BindingFlags.Public | BindingFlags.Static)
+                        let attr = field.GetCustomAttribute<EnumMemberAttribute>()
+                        where attr != null
+                        select (field.Name, attr.Value);
+            var dictionary = query.ToDictionary(p => p.Item1, p => p.Item2);
+            return dictionary.Count > 0 ? new JsonStringEnumConverter(new DictionaryLookupNamingPolicy(dictionary, _namingPolicy), _allowIntegerValues).CreateConverter(typeToConvert, options) : _baseConverter.CreateConverter(typeToConvert, options);
+        }
+    }
+
+    public class JsonNamingPolicyDecorator : JsonNamingPolicy
+    {
+        private readonly JsonNamingPolicy _underlyingNamingPolicy;
+
+        protected JsonNamingPolicyDecorator(JsonNamingPolicy underlyingNamingPolicy) => _underlyingNamingPolicy = underlyingNamingPolicy;
+
+        public override string ConvertName(string name) => _underlyingNamingPolicy == null ? name : _underlyingNamingPolicy.ConvertName(name);
+    }
+
+    internal class DictionaryLookupNamingPolicy : JsonNamingPolicyDecorator
+    {
+        private readonly Dictionary<string, string> _dictionary;
+
+        public DictionaryLookupNamingPolicy(Dictionary<string, string> dictionary, JsonNamingPolicy underlyingNamingPolicy) : base(underlyingNamingPolicy) => _dictionary = dictionary ?? throw new ArgumentNullException();
+
+        public override string ConvertName(string name) => _dictionary.TryGetValue(name, out var value) ? value : base.ConvertName(name);
+    }
+}

--- a/libraries/src/AWS.Lambda.PowerTools.Metrics/Serializer/UnixMillisecondDateTimeConverter.cs
+++ b/libraries/src/AWS.Lambda.PowerTools.Metrics/Serializer/UnixMillisecondDateTimeConverter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
-using Newtonsoft.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace AWS.Lambda.PowerTools.Metrics.Serializer
 {
@@ -7,7 +8,7 @@ namespace AWS.Lambda.PowerTools.Metrics.Serializer
     {
         private readonly DateTime UnixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
-        public override void WriteJson(JsonWriter writer, DateTime value, JsonSerializer serializer)
+        public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
         {
             var ms = (long)(value.ToUniversalTime() - UnixEpoch).TotalMilliseconds;
             
@@ -16,11 +17,10 @@ namespace AWS.Lambda.PowerTools.Metrics.Serializer
                 throw new JsonException("Invalid date");
             }
 
-            writer.WriteValue(ms);
+            writer.WriteNumberValue(ms);
         }
 
-        public override DateTime ReadJson(JsonReader reader, Type objectType, DateTime existingValue, bool hasExistingValue,
-            JsonSerializer serializer)
+        public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             throw new NotImplementedException();
         }

--- a/libraries/tests/AWS.Lambda.PowerTools.Metrics.Tests/EMFValidationTests.cs
+++ b/libraries/tests/AWS.Lambda.PowerTools.Metrics.Tests/EMFValidationTests.cs
@@ -206,7 +206,7 @@ namespace AWS.Lambda.PowerTools.Metrics.Tests
 
             // Assert
             Assert.Contains("\"Metrics\":[{\"Name\":\"ColdStart\",\"Unit\":\"Count\"}]", result);
-            Assert.Contains("\"ColdStart\":1.0", result);
+            Assert.Contains("\"ColdStart\":1", result);
 
             Metrics.ResetForTesting();
         }
@@ -384,14 +384,14 @@ namespace AWS.Lambda.PowerTools.Metrics.Tests
             // Act 
             handler.OnEntry(eventArgs);
             Metrics.AddDimension("functionVersion", "$LATEST");
-            Metrics.AddMetric("Time", 100, MetricUnit.MILLISECONDS);
+            Metrics.AddMetric("Time", 100.7, MetricUnit.MILLISECONDS);
             Metrics.AddMetadata("env", "dev");
             handler.OnExit(eventArgs);
 
             var result = consoleOut.ToString();
 
             // Assert
-            Assert.Contains("CloudWatchMetrics\":[{\"Namespace\":\"dotnet-powertools-test\",\"Metrics\":[{\"Name\":\"Time\",\"Unit\":\"Milliseconds\"}],\"Dimensions\":[[\"Service\"],[\"functionVersion\"]]}]},\"Service\":\"testService\",\"functionVersion\":\"$LATEST\",\"env\":\"dev\",\"Time\":100.0}"
+            Assert.Contains("CloudWatchMetrics\":[{\"Namespace\":\"dotnet-powertools-test\",\"Metrics\":[{\"Name\":\"Time\",\"Unit\":\"Milliseconds\"}],\"Dimensions\":[[\"Service\"],[\"functionVersion\"]]}]},\"Service\":\"testService\",\"functionVersion\":\"$LATEST\",\"env\":\"dev\",\"Time\":100.7}"
                 , result);
 
             // Reset
@@ -400,7 +400,7 @@ namespace AWS.Lambda.PowerTools.Metrics.Tests
 
         [Trait("Category", "MetricsImplementation")]
         [Fact]
-        public void WhenMetricsWitSameNameAdded_ValidateMetricArray()
+        public void WhenMetricsWithSameNameAdded_ValidateMetricArray()
         {
             // Arrange
             var methodName = Guid.NewGuid().ToString();
@@ -425,7 +425,7 @@ namespace AWS.Lambda.PowerTools.Metrics.Tests
             // Act 
             handler.OnEntry(eventArgs);
             Metrics.AddDimension("functionVersion", "$LATEST");
-            Metrics.AddMetric("Time", 100, MetricUnit.MILLISECONDS);
+            Metrics.AddMetric("Time", 100.5, MetricUnit.MILLISECONDS);
             Metrics.AddMetric("Time", 200, MetricUnit.MILLISECONDS);            
             handler.OnExit(eventArgs);
 
@@ -434,7 +434,7 @@ namespace AWS.Lambda.PowerTools.Metrics.Tests
             // Assert
             Assert.Contains("\"Metrics\":[{\"Name\":\"Time\",\"Unit\":\"Milliseconds\"}]"
                 , result);
-            Assert.Contains("\"Time\":[100.0,200.0]"
+            Assert.Contains("\"Time\":[100.5,200]"
                 , result);
 
             // Reset


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

- Removed Newtonsoft package dependency.
- Added metrics, metadata and dimension key null checkers.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-dotnet/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-dotnet/blob/develop/.github/semantic.yml)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
