### PR TITLE
chore: rename PowerTools to Powertools

### DIFF
--- a/libraries/tests/AWS.Lambda.Powertools.Common.Tests/Core/PowertoolsConfigurationsTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Common.Tests/Core/PowertoolsConfigurationsTest.cs
@@ -14,7 +14,6 @@
  */
 
 using System;
-using AWS.Lambda.Powertools.Common;
 using Moq;
 using Xunit;
 

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/PowertoolsLoggerTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/PowertoolsLoggerTest.cs
@@ -23,7 +23,7 @@ using Xunit;
 
 namespace AWS.Lambda.Powertools.Logging.Tests
 {
-    public class PowerToolsLoggerTest
+    public class PowertoolsLoggerTest
     {
         private void Log_WhenMinimumLevelIsBelowLogLevel_Logs(LogLevel logLevel, LogLevel minimumLevel)
         {


### PR DESCRIPTION
**Issue #, if available:**

Renamed namespace from PowerTools to Powertools. This naming is consistent with other Powertool runtimes.

<!--- One or two sentences as a summary of what's being changed -->

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-dotnet/#tenets)
* [ ] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-dotnet/blob/develop/.github/semantic.yml)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
