### PR TITLE
fix: docker build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN mkdir $FUNCTION_DIR
 WORKDIR $FUNCTION_DIR
 COPY examples/SimpleLambda/src/HelloWorld/Function.cs examples/SimpleLambda/src/HelloWorld/HelloWorld.csproj examples/SimpleLambda/src/HelloWorld/aws-lambda-tools-defaults.json $FUNCTION_DIR/examples/SimpleLambda/src/HelloWorld/
 COPY libraries/src/ $FUNCTION_DIR/libraries/src/
+COPY libraries/*.png $FUNCTION_DIR/libraries/
 RUN dotnet tool install -g Amazon.Lambda.Tools
 
 # Build and Copy artifacts depending on build mode.


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

This PR adds copy command to copy the file icons into the docker image to fix the build error

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-dotnet/#tenets)
* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-dotnet/blob/develop/.github/semantic.yml)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
