### PR TITLE
refactor: Metrics refactoring after code review

### DIFF
--- a/libraries/src/AWS.Lambda.Powertools.Metrics/IMetrics.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/IMetrics.cs
@@ -51,7 +51,7 @@ public interface IMetrics : IDisposable
     /// </summary>
     /// <param name="key">Metadata key</param>
     /// <param name="value">Metadata value</param>
-    void AddMetadata(string key, dynamic value);
+    void AddMetadata(string key, object value);
 
     /// <summary>
     ///     Pushes a single metric with custom namespace, service and dimensions.

--- a/libraries/src/AWS.Lambda.Powertools.Metrics/Metrics.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/Metrics.cs
@@ -141,7 +141,7 @@ public class Metrics : IMetrics
     ///     'AddMetadata' method requires a valid metadata key. 'Null' or empty
     ///     values are not allowed.
     /// </exception>
-    void IMetrics.AddMetadata(string key, dynamic value)
+    void IMetrics.AddMetadata(string key, object value)
     {
         if (string.IsNullOrWhiteSpace(key))
             throw new ArgumentNullException(
@@ -285,7 +285,7 @@ public class Metrics : IMetrics
     /// </summary>
     /// <param name="key">Metadata key. Must not be null, empty or whitespace</param>
     /// <param name="value">Metadata value</param>
-    public static void AddMetadata(string key, dynamic value)
+    public static void AddMetadata(string key, object value)
     {
         _instance.AddMetadata(key, value);
     }

--- a/libraries/src/AWS.Lambda.Powertools.Metrics/Model/Metadata.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/Model/Metadata.cs
@@ -31,7 +31,7 @@ public class Metadata
     {
         CloudWatchMetrics = new List<MetricDirective> {new()};
         Timestamp = DateTime.Now;
-        CustomMetadata = new Dictionary<string, dynamic>();
+        CustomMetadata = new Dictionary<string, object>();
     }
 
     /// <summary>
@@ -45,7 +45,7 @@ public class Metadata
     ///     Gets the cloud watch metrics.
     /// </summary>
     /// <value>The cloud watch metrics.</value>
-    [JsonPropertyName("CloudWatchMetrics")]
+    [JsonPropertyName(nameof(CloudWatchMetrics))]
     public List<MetricDirective> CloudWatchMetrics { get; }
 
     /// <summary>
@@ -59,7 +59,7 @@ public class Metadata
     /// </summary>
     /// <value>The custom metadata.</value>
     [JsonIgnore]
-    public Dictionary<string, dynamic> CustomMetadata { get; }
+    public Dictionary<string, object> CustomMetadata { get; }
 
     /// <summary>
     ///     Deletes all metrics from memory
@@ -156,7 +156,7 @@ public class Metadata
     /// </summary>
     /// <param name="key">Metadata key. Cannot be null, empty or whitespace</param>
     /// <param name="value">Metadata value</param>
-    internal void AddMetadata(string key, dynamic value)
+    internal void AddMetadata(string key, object value)
     {
         CustomMetadata.Add(key, value);
     }

--- a/libraries/src/AWS.Lambda.Powertools.Metrics/Model/MetricDefinition.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/Model/MetricDefinition.cs
@@ -59,7 +59,7 @@ public class MetricDefinition
     ///     Gets or sets the name.
     /// </summary>
     /// <value>The name.</value>
-    [JsonPropertyName("Name")]
+    [JsonPropertyName(nameof(Name))]
     public string Name { get; set; }
 
     /// <summary>
@@ -73,7 +73,7 @@ public class MetricDefinition
     ///     Gets or sets the unit.
     /// </summary>
     /// <value>The unit.</value>
-    [JsonPropertyName("Unit")]
+    [JsonPropertyName(nameof(Unit))]
     public MetricUnit Unit { get; set; }
 
     /// <summary>

--- a/libraries/src/AWS.Lambda.Powertools.Metrics/Model/MetricDirective.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/Model/MetricDirective.cs
@@ -69,7 +69,7 @@ public class MetricDirective
     ///     Gets the namespace.
     /// </summary>
     /// <value>The namespace.</value>
-    [JsonPropertyName("Namespace")]
+    [JsonPropertyName(nameof(Namespace))]
     public string Namespace { get; private set; }
 
     /// <summary>
@@ -83,7 +83,7 @@ public class MetricDirective
     ///     Gets the metrics.
     /// </summary>
     /// <value>The metrics.</value>
-    [JsonPropertyName("Metrics")]
+    [JsonPropertyName(nameof(Metrics))]
     public List<MetricDefinition> Metrics { get; private set; }
 
     /// <summary>

--- a/libraries/src/AWS.Lambda.Powertools.Metrics/Model/MetricsContext.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/Model/MetricsContext.cs
@@ -148,7 +148,7 @@ public class MetricsContext : IDisposable
     /// </summary>
     /// <param name="key">Metadata key</param>
     /// <param name="value">Metadata value</param>
-    public void AddMetadata(string key, dynamic value)
+    public void AddMetadata(string key, object value)
     {
         _rootNode.AWS.AddMetadata(key, value);
     }

--- a/libraries/src/AWS.Lambda.Powertools.Metrics/Model/RootNode.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/Model/RootNode.cs
@@ -36,11 +36,11 @@ public class RootNode
     /// </summary>
     /// <value>The metric data.</value>
     [JsonExtensionData]
-    public Dictionary<string, dynamic> MetricData
+    public Dictionary<string, object> MetricData
     {
         get
         {
-            var targetMembers = new Dictionary<string, dynamic>();
+            var targetMembers = new Dictionary<string, object>();
 
             foreach (var dimension in AWS.ExpandAllDimensionSets()) targetMembers.Add(dimension.Key, dimension.Value);
 

--- a/libraries/src/AWS.Lambda.Powertools.Metrics/Serializer/UnixMillisecondDateTimeConverter.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/Serializer/UnixMillisecondDateTimeConverter.cs
@@ -27,11 +27,6 @@ namespace AWS.Lambda.Powertools.Metrics;
 public class UnixMillisecondDateTimeConverter : JsonConverter<DateTime>
 {
     /// <summary>
-    ///     The unix epoch
-    /// </summary>
-    private readonly DateTime _unixEpoch = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-
-    /// <summary>
     ///     Writes a specified value as JSON.
     /// </summary>
     /// <param name="writer">The writer to write to.</param>
@@ -40,7 +35,7 @@ public class UnixMillisecondDateTimeConverter : JsonConverter<DateTime>
     /// <exception cref="System.Text.Json.JsonException">Invalid date</exception>
     public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
     {
-        var ms = (long) (value.ToUniversalTime() - _unixEpoch).TotalMilliseconds;
+        var ms = (long) (value.ToUniversalTime() - DateTime.UnixEpoch).TotalMilliseconds;
 
         if (ms < 0) throw new JsonException("Invalid date");
 


### PR DESCRIPTION
Refactored code after review by the .NET team from AWS.

## Description of changes:

- Replaced `_unixEpoch` with `DateTime.UnixEpoch`
- Replace `dynamic` types with `object` types in Metrics metadata implementation
- Use of `nameof` method instead of string property names 

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-dotnet/#tenets)
* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-dotnet/blob/develop/.github/semantic.yml)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
