### PR TITLE
update pipeline to create a new branch instead of push

### DIFF
--- a/.github/workflows/reusable_publish_changelog.yml
+++ b/.github/workflows/reusable_publish_changelog.yml
@@ -30,11 +30,12 @@ jobs:
           git pull origin "${BRANCH}"
       - name: "Generate latest changelog"
         run: make changelog
-      - name: Update Changelog in trunk
+      - name: Update Changelog with PR
         run: |
           HAS_CHANGE=$(git status --porcelain)
           test -z "${HAS_CHANGE}" && echo "Nothing to update" && exit 0
+          git checkout -b update-changelog-${{github.run_id}}
           git add CHANGELOG.md
           git commit -m "update changelog with latest changes"
           git pull origin "${BRANCH}" # prevents concurrent branch update failing push
-          git push origin HEAD:refs/heads/"${BRANCH}"
+          git push origin update-changelog-${{github.run_id}}


### PR DESCRIPTION
> Please provide the issue number

Issue number: 238

## Summary

Change needed since we have branch protection with approvals the build was failing

![image](https://user-images.githubusercontent.com/999396/231810851-dad235a9-339e-4176-87d0-f35eb1147c38.png)


### Changes

Instead of force push to develop we create a new branch and go through the normal pr/review process

### User experience

Nothing changes

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://awslabs.github.io/aws-lambda-powertools-dotnet/tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
