### PR TITLE
improv: improve logger extra keys feature

### DIFF
--- a/docs/core/logging.md
+++ b/docs/core/logging.md
@@ -311,7 +311,7 @@ It accepts any dictionary, and all keyword arguments will be added as part of th
 
 === "Function.cs"
 
-    ```c# hl_lines="15 18 27"
+    ```c# hl_lines="14 17 21 29"
     /**
      * Handler for requests to Lambda function.
      */
@@ -323,28 +323,35 @@ It accepts any dictionary, and all keyword arguments will be added as part of th
         {
             var requestContextRequestId = apigwProxyEvent.RequestContext.RequestId;
             
+            // Pass an object for logging additional data
             var lookupInfo = new { LookupId = requestContextRequestId };
-            
-            // Simply pass an object for logging additional data
-            Logger.LogInformation(lookupInfo, "This is a log with additional data");
+            Logger.LogInformation(lookupInfo, "This is a log with anonymous type object additional data");
 
             // Specify the key name for extra additional data
-            Logger.LogInformation(("LookupInfo", lookupInfo), "This is a log with an extra variable");
+            Logger.LogInformation(("LookupInfo", lookupInfo), "This is a log specifying the key name for additional data");
 
+            // Pass a typed object for logging additional data
+            var vLookupInfo = new LookupInfo { LookupId = requestContextRequestId };
+            Logger.LogInformation(vLookupInfo, "This is a log with typed object additional data");
+
+            // Pass multiple extra key/value pairs
             var extraKeys = new Dictionary<string, object>()
             {
                 { "LookupInfo", lookupInfo },
                 { "CorrelationIds", new { MyCorrelationId = "correlation_id_value" } }
             };
-
-            // Specify the key name for extra additional data
-            Logger.LogInformation(extraKeys, "This is a log with multiple extra variables");
+            Logger.LogInformation(extraKeys, "This is a log with multiple extra key/value pairs");
+            ...
+    }
+    public class LookupInfo
+    {
+        public string? LookupId { get; set; }
     }
     ```
 
 === "Example CloudWatch Logs excerpt"
 
-    ```json hl_lines="4-6 21-23 38-43"
+    ```json hl_lines="4-6 21-23 38-40 55-60"
     {
         "cold_start": true,
         "xray_trace_id": "1-61b7add4-66532bb81441e1b060389429",
@@ -360,7 +367,7 @@ It accepts any dictionary, and all keyword arguments will be added as part of th
         "level": "Information",
         "service": "lambda-example",
         "name": "AWS.Lambda.Powertools.Logging.Logger",
-        "message": "This is a log with additional data",
+        "message": "This is a log with anonymous type object additional data",
     }
     {
         "cold_start": true,
@@ -377,7 +384,24 @@ It accepts any dictionary, and all keyword arguments will be added as part of th
         "level": "Information",
         "service": "lambda-example",
         "name": "AWS.Lambda.Powertools.Logging.Logger",
-        "message": "This is a log with an extra variable",
+        "message": "This is a log specifying the key name for additional data",
+    }
+    {
+        "cold_start": true,
+        "xray_trace_id": "1-61b7add4-66532bb81441e1b060389429",
+        "lookup_info": {
+            "lookup_id": "4c50eace-8b1e-43d3-92ba-0efacf5d1625"
+        },
+        "function_name": "test",
+        "function_version": "$LATEST",
+        "function_memory_size": 128,
+        "function_arn": "arn:aws:lambda:eu-west-1:12345678910:function:test",
+        "function_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72",
+        "timestamp": "2021-12-13T20:32:22.5774262Z",
+        "level": "Information",
+        "service": "lambda-example",
+        "name": "AWS.Lambda.Powertools.Logging.Logger",
+        "message": "This is a log with typed object additional data",
     }
     {
         "cold_start": true,
@@ -397,7 +421,7 @@ It accepts any dictionary, and all keyword arguments will be added as part of th
         "level": "Information",
         "service": "lambda-example",
         "name": "AWS.Lambda.Powertools.Logging.Logger",
-        "message": "This is a log with multiple extra variables",
+        "message": "This is a log with multiple extra key/value pairs",
     }
     ```
 

--- a/docs/core/logging.md
+++ b/docs/core/logging.md
@@ -311,7 +311,7 @@ It accepts any dictionary, and all keyword arguments will be added as part of th
 
 === "Function.cs"
 
-    ```c# hl_lines="16"
+    ```c# hl_lines="15 18 27"
     /**
      * Handler for requests to Lambda function.
      */
@@ -323,16 +323,81 @@ It accepts any dictionary, and all keyword arguments will be added as part of th
         {
             var requestContextRequestId = apigwProxyEvent.RequestContext.RequestId;
             
-            var lookupId = new Dictionary<string, object>()
+            var lookupInfo = new { LookupId = requestContextRequestId };
+            
+            // Simply pass an object for logging additional data
+            Logger.LogInformation(lookupInfo, "This is a log with additional data");
+
+            // Specify the key name for extra additional data
+            Logger.LogInformation(("LookupInfo", lookupInfo), "This is a log with an extra variable");
+
+            var extraKeys = new Dictionary<string, object>()
             {
-                { "LookupId", requestContextRequestId }
+                { "LookupInfo", lookupInfo },
+                { "CorrelationIds", new { MyCorrelationId = "correlation_id_value" } }
             };
 
-            // Appended keys are added to all subsequent log entries in the current execution.
-            // Call this method as early as possible in the Lambda handler.
-            // Typically this is value would be passed into the function via the event.
-            // Set the ClearState = true to force the removal of keys across invocations,
-            Logger.AppendKeys(lookupId);
+            // Specify the key name for extra additional data
+            Logger.LogInformation(extraKeys, "This is a log with multiple extra variables");
+    }
+    ```
+
+=== "Example CloudWatch Logs excerpt"
+
+    ```json hl_lines="4-6 21-23 38-43"
+    {
+        "cold_start": true,
+        "xray_trace_id": "1-61b7add4-66532bb81441e1b060389429",
+        "extra": {
+            "lookup_id": "4c50eace-8b1e-43d3-92ba-0efacf5d1625"
+        },
+        "function_name": "test",
+        "function_version": "$LATEST",
+        "function_memory_size": 128,
+        "function_arn": "arn:aws:lambda:eu-west-1:12345678910:function:test",
+        "function_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72",
+        "timestamp": "2021-12-13T20:32:22.5774262Z",
+        "level": "Information",
+        "service": "lambda-example",
+        "name": "AWS.Lambda.Powertools.Logging.Logger",
+        "message": "This is a log with additional data",
+    }
+    {
+        "cold_start": true,
+        "xray_trace_id": "1-61b7add4-66532bb81441e1b060389429",
+        "lookup_info": {
+            "lookup_id": "4c50eace-8b1e-43d3-92ba-0efacf5d1625"
+        },
+        "function_name": "test",
+        "function_version": "$LATEST",
+        "function_memory_size": 128,
+        "function_arn": "arn:aws:lambda:eu-west-1:12345678910:function:test",
+        "function_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72",
+        "timestamp": "2021-12-13T20:32:22.5774262Z",
+        "level": "Information",
+        "service": "lambda-example",
+        "name": "AWS.Lambda.Powertools.Logging.Logger",
+        "message": "This is a log with an extra variable",
+    }
+    {
+        "cold_start": true,
+        "xray_trace_id": "1-61b7add4-66532bb81441e1b060389429",
+        "lookup_info": {
+            "lookup_id": "4c50eace-8b1e-43d3-92ba-0efacf5d1625"
+        },
+        "correlation_ids": {
+            "my_correlation_id": "correlation_id_value"
+        },
+        "function_name": "test",
+        "function_version": "$LATEST",
+        "function_memory_size": 128,
+        "function_arn": "arn:aws:lambda:eu-west-1:12345678910:function:test",
+        "function_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72",
+        "timestamp": "2021-12-13T20:32:22.5774262Z",
+        "level": "Information",
+        "service": "lambda-example",
+        "name": "AWS.Lambda.Powertools.Logging.Logger",
+        "message": "This is a log with multiple extra variables",
     }
     ```
 

--- a/docs/core/logging.md
+++ b/docs/core/logging.md
@@ -324,20 +324,20 @@ It accepts any dictionary, and all keyword arguments will be added as part of th
             var requestContextRequestId = apigwProxyEvent.RequestContext.RequestId;
             
             // Pass an object for logging additional data
-            var lookupInfo = new { LookupId = requestContextRequestId };
-            Logger.LogInformation(lookupInfo, "This is a log with anonymous type object additional data");
+            var lookupInfo1 = new { LookupId = requestContextRequestId };
+            Logger.LogInformation(lookupInfo1, "This is a log with anonymous type object additional data");
 
             // Specify the key name for extra additional data
-            Logger.LogInformation(("LookupInfo", lookupInfo), "This is a log specifying the key name for additional data");
+            Logger.LogInformation(("LookupInfo", lookupInfo1), "This is a log specifying the key name for additional data");
 
             // Pass a typed object for logging additional data
-            var vLookupInfo = new LookupInfo { LookupId = requestContextRequestId };
-            Logger.LogInformation(vLookupInfo, "This is a log with typed object additional data");
+            var lookupInfo2 = new LookupInfo { LookupId = requestContextRequestId };
+            Logger.LogInformation(lookupInfo2, "This is a log with typed object additional data");
 
             // Pass multiple extra key/value pairs
             var extraKeys = new Dictionary<string, object>()
             {
-                { "LookupInfo", lookupInfo },
+                { "LookupInfo", new { LookupId = requestContextRequestId } },
                 { "CorrelationIds", new { MyCorrelationId = "correlation_id_value" } }
             };
             Logger.LogInformation(extraKeys, "This is a log with multiple extra key/value pairs");

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Internal/LoggingConstants.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Internal/LoggingConstants.cs
@@ -111,4 +111,9 @@ internal static class LoggingConstants
     ///     Constant for key exception
     /// </summary>
     internal const string KeyException = "Exception";
+    
+    /// <summary>
+    ///     Constant for key extra
+    /// </summary>
+    internal const string KeyExtra = "Extra";
 }

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Internal/PowertoolsLogger.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Internal/PowertoolsLogger.cs
@@ -140,10 +140,10 @@ internal sealed class PowertoolsLogger : ILogger
     private static Dictionary<string, object> GetScopeKeys<TState>(TState state)
     {
         var keys = new Dictionary<string, object>();
-        
-        if (state is null) 
+
+        if (state is null)
             return keys;
-        
+
         switch (state)
         {
             case IEnumerable<KeyValuePair<string, string>> pairs:
@@ -153,6 +153,7 @@ internal sealed class PowertoolsLogger : ILogger
                     if (!string.IsNullOrWhiteSpace(key))
                         keys.TryAdd(key, value);
                 }
+
                 break;
             }
             case IEnumerable<KeyValuePair<string, object>> pairs:
@@ -162,6 +163,7 @@ internal sealed class PowertoolsLogger : ILogger
                     if (!string.IsNullOrWhiteSpace(key))
                         keys.TryAdd(key, value);
                 }
+
                 break;
             }
             case KeyValuePair<string, string>(var key, var value):
@@ -186,12 +188,43 @@ internal sealed class PowertoolsLogger : ILogger
             }
             default:
             {
-                keys.TryAdd(LoggingConstants.KeyExtra, state);
+                keys.TryAdd(GetScopeKey(state), state);
                 break;
             }
         }
-        
+
         return keys;
+    }
+
+    /// <summary>
+    ///     Extract provided scope key
+    /// </summary>
+    /// <typeparam name="TState">The type of the t state.</typeparam>
+    /// <param name="state">The state.</param>
+    /// <returns>Key for the provided scope key</returns>
+    private static string GetScopeKey<TState>(TState state)
+    {
+        if (state is null or string)
+            return LoggingConstants.KeyExtra;
+
+        var type = state.GetType();
+        if (type.IsEnum ||
+            type.IsArray ||
+            type.IsPrimitive ||
+            string.IsNullOrWhiteSpace(type.Namespace))
+            return LoggingConstants.KeyExtra;
+
+        var typeName = type.Name;
+        if (type.IsGenericType)
+            typeName = type.Name.Split('`').First();
+
+        if (typeName.Contains('[') ||
+            typeName.Contains(']') ||
+            typeName.Contains('<') ||
+            typeName.Contains('>'))
+            return LoggingConstants.KeyExtra;
+
+        return typeName;
     }
 
     /// <summary>

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Internal/PowertoolsLogger.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Internal/PowertoolsLogger.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using AWS.Lambda.Powertools.Common;
@@ -163,12 +164,29 @@ internal sealed class PowertoolsLogger : ILogger
                 }
                 break;
             }
+            case KeyValuePair<string, string>(var key, var value):
+            {
+                if (!string.IsNullOrWhiteSpace(key))
+                    keys.TryAdd(key, value);
+                break;
+            }
+            case KeyValuePair<string, object>(var key, var value):
+            {
+                if (!string.IsNullOrWhiteSpace(key))
+                    keys.TryAdd(key, value);
+                break;
+            }
+            case ITuple pair:
+            {
+                if (pair.Length == 2 && pair[0] is string key && !string.IsNullOrWhiteSpace(key))
+                    keys.TryAdd(key, pair[1]);
+                else
+                    keys.TryAdd(LoggingConstants.KeyExtra, state);
+                break;
+            }
             default:
             {
-                foreach (var property in state.GetType().GetProperties())
-                {
-                    keys.TryAdd(property.Name, property.GetValue(state));
-                }
+                keys.TryAdd(LoggingConstants.KeyExtra, state);
                 break;
             }
         }

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Logger.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Logger.cs
@@ -768,7 +768,7 @@ public class Logger
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogDebug(extraKeys, 0, exception, "Error while processing request from {Address}", address)</example>
-    public static void LogDebug<T>(T extraKeys, EventId eventId, Exception exception, string message, params object[] args) where T : class
+    public static void LogDebug<T>(T extraKeys, EventId eventId, Exception exception, string message, params object[] args)
     {
         LoggerInstance.LogDebug(extraKeys, eventId, exception, message, args);
     }
@@ -781,7 +781,7 @@ public class Logger
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogDebug(extraKeys, 0, "Processing request from {Address}", address)</example>
-    public static void LogDebug<T>(T extraKeys, EventId eventId, string message, params object[] args) where T : class
+    public static void LogDebug<T>(T extraKeys, EventId eventId, string message, params object[] args)
     {
         LoggerInstance.LogDebug(extraKeys, eventId, message, args);
     }
@@ -794,7 +794,7 @@ public class Logger
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogDebug(extraKeys, exception, "Error while processing request from {Address}", address)</example>
-    public static void LogDebug<T>(T extraKeys, Exception exception, string message, params object[] args) where T : class
+    public static void LogDebug<T>(T extraKeys, Exception exception, string message, params object[] args)
     {
         LoggerInstance.LogDebug(extraKeys, exception, message, args);
     }
@@ -806,7 +806,7 @@ public class Logger
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogDebug(extraKeys, "Processing request from {Address}", address)</example>
-    public static void LogDebug<T>(T extraKeys, string message, params object[] args) where T : class
+    public static void LogDebug<T>(T extraKeys, string message, params object[] args)
     {
         LoggerInstance.LogDebug(extraKeys, message, args);
     }
@@ -824,7 +824,7 @@ public class Logger
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogTrace(extraKeys, 0, exception, "Error while processing request from {Address}", address)</example>
-    public static void LogTrace<T>(T extraKeys, EventId eventId, Exception exception, string message, params object[] args) where T : class
+    public static void LogTrace<T>(T extraKeys, EventId eventId, Exception exception, string message, params object[] args)
     {
         LoggerInstance.LogTrace(extraKeys, eventId, exception, message, args);
     }
@@ -837,7 +837,7 @@ public class Logger
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogTrace(extraKeys, 0, "Processing request from {Address}", address)</example>
-    public static void LogTrace<T>(T extraKeys, EventId eventId, string message, params object[] args) where T : class
+    public static void LogTrace<T>(T extraKeys, EventId eventId, string message, params object[] args)
     {
         LoggerInstance.LogTrace(extraKeys, eventId, message, args);
     }
@@ -850,7 +850,7 @@ public class Logger
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogTrace(extraKeys, exception, "Error while processing request from {Address}", address)</example>
-    public static void LogTrace<T>(T extraKeys, Exception exception, string message, params object[] args) where T : class
+    public static void LogTrace<T>(T extraKeys, Exception exception, string message, params object[] args)
     {
         LoggerInstance.LogTrace(extraKeys, exception, message, args);
     }
@@ -862,7 +862,7 @@ public class Logger
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogTrace(extraKeys, "Processing request from {Address}", address)</example>
-    public static void LogTrace<T>(T extraKeys, string message, params object[] args) where T : class
+    public static void LogTrace<T>(T extraKeys, string message, params object[] args)
     {
         LoggerInstance.LogTrace(extraKeys, message, args);
     }
@@ -880,7 +880,7 @@ public class Logger
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogInformation(extraKeys, 0, exception, "Error while processing request from {Address}", address)</example>
-    public static void LogInformation<T>(T extraKeys, EventId eventId, Exception exception, string message, params object[] args) where T : class
+    public static void LogInformation<T>(T extraKeys, EventId eventId, Exception exception, string message, params object[] args)
     {
         LoggerInstance.LogInformation(extraKeys, eventId, exception, message, args);
     }
@@ -893,7 +893,7 @@ public class Logger
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogInformation(extraKeys, 0, "Processing request from {Address}", address)</example>
-    public static void LogInformation<T>(T extraKeys, EventId eventId, string message, params object[] args) where T : class
+    public static void LogInformation<T>(T extraKeys, EventId eventId, string message, params object[] args)
     {
         LoggerInstance.LogInformation(extraKeys, eventId, message, args);
     }
@@ -906,7 +906,7 @@ public class Logger
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogInformation(extraKeys, exception, "Error while processing request from {Address}", address)</example>
-    public static void LogInformation<T>(T extraKeys, Exception exception, string message, params object[] args) where T : class
+    public static void LogInformation<T>(T extraKeys, Exception exception, string message, params object[] args)
     {
         LoggerInstance.LogInformation(extraKeys, exception, message, args);
     }
@@ -918,7 +918,7 @@ public class Logger
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogInformation(extraKeys, "Processing request from {Address}", address)</example>
-    public static void LogInformation<T>(T extraKeys, string message, params object[] args) where T : class
+    public static void LogInformation<T>(T extraKeys, string message, params object[] args)
     {
         LoggerInstance.LogInformation(extraKeys, message, args);
     }
@@ -936,7 +936,7 @@ public class Logger
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogWarning(extraKeys, 0, exception, "Error while processing request from {Address}", address)</example>
-    public static void LogWarning<T>(T extraKeys, EventId eventId, Exception exception, string message, params object[] args) where T : class
+    public static void LogWarning<T>(T extraKeys, EventId eventId, Exception exception, string message, params object[] args)
     {
         LoggerInstance.LogWarning(extraKeys, eventId, exception, message, args);
     }
@@ -949,7 +949,7 @@ public class Logger
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogWarning(extraKeys, 0, "Processing request from {Address}", address)</example>
-    public static void LogWarning<T>(T extraKeys, EventId eventId, string message, params object[] args) where T : class
+    public static void LogWarning<T>(T extraKeys, EventId eventId, string message, params object[] args)
     {
         LoggerInstance.LogWarning(extraKeys, eventId, message, args);
     }
@@ -962,7 +962,7 @@ public class Logger
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogWarning(extraKeys, exception, "Error while processing request from {Address}", address)</example>
-    public static void LogWarning<T>(T extraKeys, Exception exception, string message, params object[] args) where T : class
+    public static void LogWarning<T>(T extraKeys, Exception exception, string message, params object[] args)
     {
         LoggerInstance.LogWarning(extraKeys, exception, message, args);
     }
@@ -974,7 +974,7 @@ public class Logger
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogWarning(extraKeys, "Processing request from {Address}", address)</example>
-    public static void LogWarning<T>(T extraKeys, string message, params object[] args) where T : class
+    public static void LogWarning<T>(T extraKeys, string message, params object[] args)
     {
         LoggerInstance.LogWarning(extraKeys, message, args);
     }
@@ -992,7 +992,7 @@ public class Logger
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogError(extraKeys, 0, exception, "Error while processing request from {Address}", address)</example>
-    public static void LogError<T>(T extraKeys, EventId eventId, Exception exception, string message, params object[] args) where T : class
+    public static void LogError<T>(T extraKeys, EventId eventId, Exception exception, string message, params object[] args)
     {
         LoggerInstance.LogError(extraKeys, eventId, exception, message, args);
     }
@@ -1005,7 +1005,7 @@ public class Logger
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogError(extraKeys, 0, "Processing request from {Address}", address)</example>
-    public static void LogError<T>(T extraKeys, EventId eventId, string message, params object[] args) where T : class
+    public static void LogError<T>(T extraKeys, EventId eventId, string message, params object[] args)
     {
         LoggerInstance.LogError(extraKeys, eventId, message, args);
     }
@@ -1018,7 +1018,7 @@ public class Logger
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogError(extraKeys, exception, "Error while processing request from {Address}", address)</example>
-    public static void LogError<T>(T extraKeys, Exception exception, string message, params object[] args) where T : class
+    public static void LogError<T>(T extraKeys, Exception exception, string message, params object[] args)
     {
         LoggerInstance.LogError(extraKeys, exception, message, args);
     }
@@ -1030,7 +1030,7 @@ public class Logger
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogError(extraKeys, "Processing request from {Address}", address)</example>
-    public static void LogError<T>(T extraKeys, string message, params object[] args) where T : class
+    public static void LogError<T>(T extraKeys, string message, params object[] args)
     {
         LoggerInstance.LogError(extraKeys, message, args);
     }
@@ -1048,7 +1048,7 @@ public class Logger
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogCritical(extraKeys, 0, exception, "Error while processing request from {Address}", address)</example>
-    public static void LogCritical<T>(T extraKeys, EventId eventId, Exception exception, string message, params object[] args) where T : class
+    public static void LogCritical<T>(T extraKeys, EventId eventId, Exception exception, string message, params object[] args)
     {
         LoggerInstance.LogCritical(extraKeys, eventId, exception, message, args);
     }
@@ -1061,7 +1061,7 @@ public class Logger
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogCritical(extraKeys, 0, "Processing request from {Address}", address)</example>
-    public static void LogCritical<T>(T extraKeys, EventId eventId, string message, params object[] args) where T : class
+    public static void LogCritical<T>(T extraKeys, EventId eventId, string message, params object[] args)
     {
         LoggerInstance.LogCritical(extraKeys, eventId, message, args);
     }
@@ -1074,7 +1074,7 @@ public class Logger
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogCritical(extraKeys, exception, "Error while processing request from {Address}", address)</example>
-    public static void LogCritical<T>(T extraKeys, Exception exception, string message, params object[] args) where T : class
+    public static void LogCritical<T>(T extraKeys, Exception exception, string message, params object[] args)
     {
         LoggerInstance.LogCritical(extraKeys, exception, message, args);
     }
@@ -1086,7 +1086,7 @@ public class Logger
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogCritical(extraKeys, "Processing request from {Address}", address)</example>
-    public static void LogCritical<T>(T extraKeys, string message, params object[] args) where T : class
+    public static void LogCritical<T>(T extraKeys, string message, params object[] args)
     {
         LoggerInstance.LogCritical(extraKeys, message, args);
     }
@@ -1105,7 +1105,7 @@ public class Logger
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.Log(LogLevel.Information, extraKeys, 0, exception, "Error while processing request from {Address}", address)</example>
-    public static void Log<T>(LogLevel logLevel, T extraKeys, EventId eventId, Exception exception, string message, params object[] args) where T : class
+    public static void Log<T>(LogLevel logLevel, T extraKeys, EventId eventId, Exception exception, string message, params object[] args)
     {
         LoggerInstance.Log(logLevel, extraKeys, eventId, exception, message, args);
     }
@@ -1119,7 +1119,7 @@ public class Logger
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.Log(LogLevel.Information, extraKeys, 0, "Processing request from {Address}", address)</example>
-    public static void Log<T>(LogLevel logLevel, T extraKeys, EventId eventId, string message, params object[] args) where T : class
+    public static void Log<T>(LogLevel logLevel, T extraKeys, EventId eventId, string message, params object[] args)
     {
         LoggerInstance.Log(logLevel, extraKeys, eventId, message, args);
     }
@@ -1133,7 +1133,7 @@ public class Logger
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.Log(LogLevel.Information, extraKeys, exception, "Error while processing request from {Address}", address)</example>
-    public static void Log<T>(LogLevel logLevel, T extraKeys, Exception exception, string message, params object[] args) where T : class
+    public static void Log<T>(LogLevel logLevel, T extraKeys, Exception exception, string message, params object[] args)
     {
         LoggerInstance.Log(logLevel, extraKeys, exception, message, args);
     }
@@ -1146,7 +1146,7 @@ public class Logger
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.Log(LogLevel.Information, extraKeys, "Processing request from {Address}", address)</example>
-    public static void Log<T>(LogLevel logLevel, T extraKeys, string message, params object[] args) where T : class
+    public static void Log<T>(LogLevel logLevel, T extraKeys, string message, params object[] args)
     {
         LoggerInstance.Log(logLevel, extraKeys, message, args);
     }

--- a/libraries/src/AWS.Lambda.Powertools.Logging/LoggerExtensions.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/LoggerExtensions.cs
@@ -16,6 +16,7 @@
 using System;
 using AWS.Lambda.Powertools.Logging.Internal;
 using Microsoft.Extensions.Logging;
+using LoggerExt = Microsoft.Extensions.Logging.LoggerExtensions;
 
 namespace AWS.Lambda.Powertools.Logging;
 
@@ -199,7 +200,7 @@ public static class LoggerExtensions
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogDebug(extraKeys, 0, exception, "Error while processing request from {Address}", address)</example>
     public static void LogDebug<T>(this ILogger logger, T extraKeys, EventId eventId, Exception exception,
-        string message, params object[] args) where T : class
+        string message, params object[] args)
     {
         Log(logger, LogLevel.Debug, extraKeys, eventId, exception, message, args);
     }
@@ -214,7 +215,7 @@ public static class LoggerExtensions
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogDebug(extraKeys, 0, "Processing request from {Address}", address)</example>
     public static void LogDebug<T>(this ILogger logger, T extraKeys, EventId eventId, string message,
-        params object[] args) where T : class
+        params object[] args)
     {
         Log(logger, LogLevel.Debug, extraKeys, eventId, message, args);
     }
@@ -229,7 +230,7 @@ public static class LoggerExtensions
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogDebug(extraKeys, exception, "Error while processing request from {Address}", address)</example>
     public static void LogDebug<T>(this ILogger logger, T extraKeys, Exception exception, string message,
-        params object[] args) where T : class
+        params object[] args)
     {
         Log(logger, LogLevel.Debug, extraKeys, exception, message, args);
     }
@@ -242,7 +243,7 @@ public static class LoggerExtensions
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogDebug(extraKeys, "Processing request from {Address}", address)</example>
-    public static void LogDebug<T>(this ILogger logger, T extraKeys, string message, params object[] args) where T : class
+    public static void LogDebug<T>(this ILogger logger, T extraKeys, string message, params object[] args)
     {
         Log(logger, LogLevel.Debug, extraKeys, message, args);
     }
@@ -262,7 +263,7 @@ public static class LoggerExtensions
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogTrace(extraKeys, 0, exception, "Error while processing request from {Address}", address)</example>
     public static void LogTrace<T>(this ILogger logger, T extraKeys, EventId eventId, Exception exception,
-        string message, params object[] args) where T : class
+        string message, params object[] args)
     {
         Log(logger, LogLevel.Trace, extraKeys, eventId, exception, message, args);
     }
@@ -277,7 +278,7 @@ public static class LoggerExtensions
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogTrace(extraKeys, 0, "Processing request from {Address}", address)</example>
     public static void LogTrace<T>(this ILogger logger, T extraKeys, EventId eventId, string message,
-        params object[] args) where T : class
+        params object[] args)
     {
         Log(logger, LogLevel.Trace, extraKeys, eventId, message, args);
     }
@@ -292,7 +293,7 @@ public static class LoggerExtensions
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogTrace(extraKeys, exception, "Error while processing request from {Address}", address)</example>
     public static void LogTrace<T>(this ILogger logger, T extraKeys, Exception exception, string message,
-        params object[] args) where T : class
+        params object[] args)
     {
         Log(logger, LogLevel.Trace, extraKeys, exception, message, args);
     }
@@ -305,7 +306,7 @@ public static class LoggerExtensions
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogTrace(extraKeys, "Processing request from {Address}", address)</example>
-    public static void LogTrace<T>(this ILogger logger, T extraKeys, string message, params object[] args) where T : class
+    public static void LogTrace<T>(this ILogger logger, T extraKeys, string message, params object[] args)
     {
         Log(logger, LogLevel.Trace, extraKeys, message, args);
     }
@@ -325,7 +326,7 @@ public static class LoggerExtensions
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogInformation(extraKeys, 0, exception, "Error while processing request from {Address}", address)</example>
     public static void LogInformation<T>(this ILogger logger, T extraKeys, EventId eventId, Exception exception,
-        string message, params object[] args) where T : class
+        string message, params object[] args)
     {
         Log(logger, LogLevel.Information, extraKeys, eventId, exception, message, args);
     }
@@ -340,7 +341,7 @@ public static class LoggerExtensions
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogInformation(extraKeys, 0, "Processing request from {Address}", address)</example>
     public static void LogInformation<T>(this ILogger logger, T extraKeys, EventId eventId, string message,
-        params object[] args) where T : class
+        params object[] args)
     {
         Log(logger, LogLevel.Information, extraKeys, eventId, message, args);
     }
@@ -355,7 +356,7 @@ public static class LoggerExtensions
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogInformation(extraKeys, exception, "Error while processing request from {Address}", address)</example>
     public static void LogInformation<T>(this ILogger logger, T extraKeys, Exception exception, string message,
-        params object[] args) where T : class
+        params object[] args)
     {
         Log(logger, LogLevel.Information, extraKeys, exception, message, args);
     }
@@ -368,7 +369,7 @@ public static class LoggerExtensions
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogInformation(extraKeys, "Processing request from {Address}", address)</example>
-    public static void LogInformation<T>(this ILogger logger, T extraKeys, string message, params object[] args) where T : class
+    public static void LogInformation<T>(this ILogger logger, T extraKeys, string message, params object[] args)
     {
         Log(logger, LogLevel.Information, extraKeys, message, args);
     }
@@ -388,7 +389,7 @@ public static class LoggerExtensions
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogWarning(extraKeys, 0, exception, "Error while processing request from {Address}", address)</example>
     public static void LogWarning<T>(this ILogger logger, T extraKeys, EventId eventId, Exception exception,
-        string message, params object[] args) where T : class
+        string message, params object[] args)
     {
         Log(logger, LogLevel.Warning, extraKeys, eventId, exception, message, args);
     }
@@ -403,7 +404,7 @@ public static class LoggerExtensions
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogWarning(extraKeys, 0, "Processing request from {Address}", address)</example>
     public static void LogWarning<T>(this ILogger logger, T extraKeys, EventId eventId, string message,
-        params object[] args) where T : class
+        params object[] args)
     {
         Log(logger, LogLevel.Warning, extraKeys, eventId, message, args);
     }
@@ -418,7 +419,7 @@ public static class LoggerExtensions
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogWarning(extraKeys, exception, "Error while processing request from {Address}", address)</example>
     public static void LogWarning<T>(this ILogger logger, T extraKeys, Exception exception, string message,
-        params object[] args) where T : class
+        params object[] args)
     {
         Log(logger, LogLevel.Warning, extraKeys, exception, message, args);
     }
@@ -431,7 +432,7 @@ public static class LoggerExtensions
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogWarning(extraKeys, "Processing request from {Address}", address)</example>
-    public static void LogWarning<T>(this ILogger logger, T extraKeys, string message, params object[] args) where T : class
+    public static void LogWarning<T>(this ILogger logger, T extraKeys, string message, params object[] args)
     {
         Log(logger, LogLevel.Warning, extraKeys, message, args);
     }
@@ -451,7 +452,7 @@ public static class LoggerExtensions
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogError(extraKeys, 0, exception, "Error while processing request from {Address}", address)</example>
     public static void LogError<T>(this ILogger logger, T extraKeys, EventId eventId, Exception exception,
-        string message, params object[] args) where T : class
+        string message, params object[] args)
     {
         Log(logger, LogLevel.Error, extraKeys, eventId, exception, message, args);
     }
@@ -466,7 +467,7 @@ public static class LoggerExtensions
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogError(extraKeys, 0, "Processing request from {Address}", address)</example>
     public static void LogError<T>(this ILogger logger, T extraKeys, EventId eventId, string message,
-        params object[] args) where T : class
+        params object[] args)
     {
         Log(logger, LogLevel.Error, extraKeys, eventId, message, args);
     }
@@ -481,7 +482,7 @@ public static class LoggerExtensions
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogError(extraKeys, exception, "Error while processing request from {Address}", address)</example>
     public static void LogError<T>(this ILogger logger, T extraKeys, Exception exception, string message,
-        params object[] args) where T : class
+        params object[] args)
     {
         Log(logger, LogLevel.Error, extraKeys, exception, message, args);
     }
@@ -494,7 +495,7 @@ public static class LoggerExtensions
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogError(extraKeys, "Processing request from {Address}", address)</example>
-    public static void LogError<T>(this ILogger logger, T extraKeys, string message, params object[] args) where T : class
+    public static void LogError<T>(this ILogger logger, T extraKeys, string message, params object[] args)
     {
         Log(logger, LogLevel.Error, extraKeys, message, args);
     }
@@ -514,7 +515,7 @@ public static class LoggerExtensions
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogCritical(extraKeys, 0, exception, "Error while processing request from {Address}", address)</example>
     public static void LogCritical<T>(this ILogger logger, T extraKeys, EventId eventId, Exception exception,
-        string message, params object[] args) where T : class
+        string message, params object[] args)
     {
         Log(logger, LogLevel.Critical, extraKeys, eventId, exception, message, args);
     }
@@ -529,7 +530,7 @@ public static class LoggerExtensions
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogCritical(extraKeys, 0, "Processing request from {Address}", address)</example>
     public static void LogCritical<T>(this ILogger logger, T extraKeys, EventId eventId, string message,
-        params object[] args) where T : class
+        params object[] args)
     {
         Log(logger, LogLevel.Critical, extraKeys, eventId, message, args);
     }
@@ -544,7 +545,7 @@ public static class LoggerExtensions
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogCritical(extraKeys, exception, "Error while processing request from {Address}", address)</example>
     public static void LogCritical<T>(this ILogger logger, T extraKeys, Exception exception, string message,
-        params object[] args) where T : class
+        params object[] args)
     {
         Log(logger, LogLevel.Critical, extraKeys, exception, message, args);
     }
@@ -557,7 +558,7 @@ public static class LoggerExtensions
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogCritical(extraKeys, "Processing request from {Address}", address)</example>
-    public static void LogCritical<T>(this ILogger logger, T extraKeys, string message, params object[] args) where T : class
+    public static void LogCritical<T>(this ILogger logger, T extraKeys, string message, params object[] args)
     {
         Log(logger, LogLevel.Critical, extraKeys, message, args);
     }
@@ -565,7 +566,7 @@ public static class LoggerExtensions
     #endregion
 
     #region Log
-    
+
     /// <summary>
     /// Formats and writes a log message at the specified log level.
     /// </summary>
@@ -578,15 +579,17 @@ public static class LoggerExtensions
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.Log(LogLevel.Information, extraKeys, 0, exception, "Error while processing request from {Address}", address)</example>
     public static void Log<T>(this ILogger logger, LogLevel logLevel, T extraKeys, EventId eventId, Exception exception,
-        string message, params object[] args) where T : class
+        string message, params object[] args)
     {
         if (extraKeys is Exception ex && exception is null)
-            logger.Log(logLevel, eventId, ex, message, args);
+            LoggerExt.Log(logger, logLevel, eventId, ex, message, args);
+        else if (extraKeys is EventId evid && evid == 0)
+            LoggerExt.Log(logger, logLevel, evid, exception, message, args);
         else if (extraKeys is not null)
             using (logger.BeginScope(extraKeys))
-                logger.Log(logLevel, eventId, exception, message, args);
+                LoggerExt.Log(logger, logLevel, eventId, exception, message, args);
         else
-            logger.Log(logLevel, eventId, exception, message, args);
+            LoggerExt.Log(logger, logLevel, eventId, exception, message, args);
     }
 
     /// <summary>
@@ -600,7 +603,7 @@ public static class LoggerExtensions
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.Log(LogLevel.Information, extraKeys, 0, "Processing request from {Address}", address)</example>
     public static void Log<T>(this ILogger logger, LogLevel logLevel, T extraKeys, EventId eventId, string message,
-        params object[] args) where T : class
+        params object[] args)
     {
         Log(logger, logLevel, extraKeys, eventId, null, message, args);
     }
@@ -616,7 +619,7 @@ public static class LoggerExtensions
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.Log(LogLevel.Information, extraKeys, exception, "Error while processing request from {Address}", address)</example>
     public static void Log<T>(this ILogger logger, LogLevel logLevel, T extraKeys, Exception exception, string message,
-        params object[] args) where T : class
+        params object[] args)
     {
         Log(logger, logLevel, extraKeys, 0, exception, message, args);
     }
@@ -630,7 +633,7 @@ public static class LoggerExtensions
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.Log(LogLevel.Information, extraKeys, "Processing request from {Address}", address)</example>
-    public static void Log<T>(this ILogger logger, LogLevel logLevel, T extraKeys, string message, params object[] args) where T : class
+    public static void Log<T>(this ILogger logger, LogLevel logLevel, T extraKeys, string message, params object[] args)
     {
         Log(logger, logLevel, extraKeys, 0, null, message, args);
     }

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/PowertoolsLoggerTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/PowertoolsLoggerTest.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using AWS.Lambda.Powertools.Common;
 using AWS.Lambda.Powertools.Logging.Internal;
@@ -652,6 +653,40 @@ namespace AWS.Lambda.Powertools.Logging.Tests
         }
         
         [Fact]
+        public void BeginScope_WhenScopeIsPrimitive_AddExtraKey()
+        {
+            // Arrange
+            var loggerName = Guid.NewGuid().ToString();
+            var service = Guid.NewGuid().ToString();
+            var logLevel = LogLevel.Information;
+
+            var configurations = new Mock<IPowertoolsConfigurations>();
+            configurations.Setup(c => c.Service).Returns(service);
+            configurations.Setup(c => c.LogLevel).Returns(logLevel.ToString);
+            var systemWrapper = new Mock<ISystemWrapper>();
+
+            var logger = new PowertoolsLogger(loggerName,configurations.Object, systemWrapper.Object, () => 
+                new LoggerConfiguration
+                {
+                    Service = service,
+                    MinimumLevel = logLevel               
+                });
+
+            var keyName = LoggingConstants.KeyExtra;
+            var scopeKeys = 20;
+
+            using (var loggerScope = logger.BeginScope(scopeKeys) as PowertoolsLoggerScope)
+            {
+                Assert.NotNull(loggerScope);
+                Assert.NotNull(loggerScope.ExtraKeys);
+                Assert.True(loggerScope.ExtraKeys.Count == 1);
+                Assert.True(loggerScope.ExtraKeys.ContainsKey(keyName));
+                Assert.True((int)loggerScope.ExtraKeys[keyName] == scopeKeys);
+            }
+            Assert.Null(logger.CurrentScope?.ExtraKeys);
+        }
+        
+        [Fact]
         public void BeginScope_WhenScopeIsString_AddExtraKey()
         {
             // Arrange
@@ -685,8 +720,8 @@ namespace AWS.Lambda.Powertools.Logging.Tests
             Assert.Null(logger.CurrentScope?.ExtraKeys);
         }
         
-        [Fact]
-        public void BeginScope_WhenScopeIsObject_AddExtraKey()
+         [Fact]
+        public void BeginScope_WhenScopeIsAnonymousClass_AddExtraKey()
         {
             // Arrange
             var loggerName = Guid.NewGuid().ToString();
@@ -723,6 +758,244 @@ namespace AWS.Lambda.Powertools.Logging.Tests
             Assert.Null(logger.CurrentScope?.ExtraKeys);
         }
         
+        [Fact]
+        public void BeginScope_WhenScopeIsNonKeyValuePairTuple_AddExtraKey()
+        {
+            // Arrange
+            var loggerName = Guid.NewGuid().ToString();
+            var service = Guid.NewGuid().ToString();
+            var logLevel = LogLevel.Information;
+
+            var configurations = new Mock<IPowertoolsConfigurations>();
+            configurations.Setup(c => c.Service).Returns(service);
+            configurations.Setup(c => c.LogLevel).Returns(logLevel.ToString);
+            var systemWrapper = new Mock<ISystemWrapper>();
+
+            var logger = new PowertoolsLogger(loggerName,configurations.Object, systemWrapper.Object, () => 
+                new LoggerConfiguration
+                {
+                    Service = service,
+                    MinimumLevel = logLevel               
+                });
+            
+            var keyName = LoggingConstants.KeyExtra;
+            var scopeKeys = ("Value 1", "Value 2", "Value 2");
+
+            using (var loggerScope = logger.BeginScope(scopeKeys) as PowertoolsLoggerScope)
+            {
+                Assert.NotNull(loggerScope);
+                Assert.NotNull(loggerScope.ExtraKeys);
+                Assert.True(loggerScope.ExtraKeys.Count == 1);
+                Assert.True(loggerScope.ExtraKeys.ContainsKey(keyName));
+                Assert.True(((ITuple)loggerScope.ExtraKeys[keyName]).Length == ((ITuple)scopeKeys).Length);
+            }
+            Assert.Null(logger.CurrentScope?.ExtraKeys);
+        }
+        
+        [Fact]
+        public void BeginScope_WhenScopeIsArray_AddExtraKey()
+        {
+            // Arrange
+            var loggerName = Guid.NewGuid().ToString();
+            var service = Guid.NewGuid().ToString();
+            var logLevel = LogLevel.Information;
+
+            var configurations = new Mock<IPowertoolsConfigurations>();
+            configurations.Setup(c => c.Service).Returns(service);
+            configurations.Setup(c => c.LogLevel).Returns(logLevel.ToString);
+            var systemWrapper = new Mock<ISystemWrapper>();
+
+            var logger = new PowertoolsLogger(loggerName,configurations.Object, systemWrapper.Object, () => 
+                new LoggerConfiguration
+                {
+                    Service = service,
+                    MinimumLevel = logLevel               
+                });
+
+            var keyName = LoggingConstants.KeyExtra;
+            var scopeKeys = new[] { Guid.NewGuid().ToString() };
+
+            using (var loggerScope = logger.BeginScope(scopeKeys) as PowertoolsLoggerScope)
+            {
+                Assert.NotNull(loggerScope);
+                Assert.NotNull(loggerScope.ExtraKeys);
+                Assert.True(loggerScope.ExtraKeys.Count == 1);
+                Assert.True(loggerScope.ExtraKeys.ContainsKey(keyName));
+                Assert.True((string[])loggerScope.ExtraKeys[keyName] == scopeKeys);
+            }
+            Assert.Null(logger.CurrentScope?.ExtraKeys);
+        }
+        
+        [Fact]
+        public void BeginScope_WhenScopeIsDynamic_AddExtraKey()
+        {
+            // Arrange
+            var loggerName = Guid.NewGuid().ToString();
+            var service = Guid.NewGuid().ToString();
+            var logLevel = LogLevel.Information;
+
+            var configurations = new Mock<IPowertoolsConfigurations>();
+            configurations.Setup(c => c.Service).Returns(service);
+            configurations.Setup(c => c.LogLevel).Returns(logLevel.ToString);
+            var systemWrapper = new Mock<ISystemWrapper>();
+
+            var logger = new PowertoolsLogger(loggerName,configurations.Object, systemWrapper.Object, () => 
+                new LoggerConfiguration
+                {
+                    Service = service,
+                    MinimumLevel = logLevel               
+                });
+
+            var keyName = LoggingConstants.KeyExtra;
+            dynamic scopeKeys = 1;
+
+            using (var loggerScope = logger.BeginScope(scopeKeys) as PowertoolsLoggerScope)
+            {
+                Assert.NotNull(loggerScope);
+                Assert.NotNull(loggerScope.ExtraKeys);
+                Assert.True(loggerScope.ExtraKeys.Count == 1);
+                Assert.True(loggerScope.ExtraKeys.ContainsKey(keyName));
+                Assert.True((int)loggerScope.ExtraKeys[keyName] == scopeKeys);
+            }
+            Assert.Null(logger.CurrentScope?.ExtraKeys);
+        }
+        
+        [Fact]
+        public void BeginScope_WhenScopeIsEnum_AddExtraKey()
+        {
+            // Arrange
+            var loggerName = Guid.NewGuid().ToString();
+            var service = Guid.NewGuid().ToString();
+            var logLevel = LogLevel.Information;
+
+            var configurations = new Mock<IPowertoolsConfigurations>();
+            configurations.Setup(c => c.Service).Returns(service);
+            configurations.Setup(c => c.LogLevel).Returns(logLevel.ToString);
+            var systemWrapper = new Mock<ISystemWrapper>();
+
+            var logger = new PowertoolsLogger(loggerName,configurations.Object, systemWrapper.Object, () => 
+                new LoggerConfiguration
+                {
+                    Service = service,
+                    MinimumLevel = logLevel               
+                });
+
+            var keyName = LoggingConstants.KeyExtra;
+            var scopeKeys = LoggerOutputCase.PascalCase;
+
+            using (var loggerScope = logger.BeginScope(scopeKeys) as PowertoolsLoggerScope)
+            {
+                Assert.NotNull(loggerScope);
+                Assert.NotNull(loggerScope.ExtraKeys);
+                Assert.True(loggerScope.ExtraKeys.Count == 1);
+                Assert.True(loggerScope.ExtraKeys.ContainsKey(keyName));
+                Assert.True((LoggerOutputCase)loggerScope.ExtraKeys[keyName] == scopeKeys);
+            }
+            Assert.Null(logger.CurrentScope?.ExtraKeys);
+        }
+        
+        [Fact]
+        public void BeginScope_WhenScopeIsStruct_ExtractExtraKeyName()
+        {
+            // Arrange
+            var loggerName = Guid.NewGuid().ToString();
+            var service = Guid.NewGuid().ToString();
+            var logLevel = LogLevel.Information;
+
+            var configurations = new Mock<IPowertoolsConfigurations>();
+            configurations.Setup(c => c.Service).Returns(service);
+            configurations.Setup(c => c.LogLevel).Returns(logLevel.ToString);
+            var systemWrapper = new Mock<ISystemWrapper>();
+
+            var logger = new PowertoolsLogger(loggerName,configurations.Object, systemWrapper.Object, () => 
+                new LoggerConfiguration
+                {
+                    Service = service,
+                    MinimumLevel = logLevel               
+                });
+
+            var keyName = "Point";
+            var scopeKeys = new System.Drawing.Point { X = 100, Y = 150 };
+
+            using (var loggerScope = logger.BeginScope(scopeKeys) as PowertoolsLoggerScope)
+            {
+                Assert.NotNull(loggerScope);
+                Assert.NotNull(loggerScope.ExtraKeys);
+                Assert.True(loggerScope.ExtraKeys.Count == 1);
+                Assert.True(loggerScope.ExtraKeys.ContainsKey(keyName));
+                Assert.True((System.Drawing.Point)loggerScope.ExtraKeys[keyName] == scopeKeys);
+            }
+            Assert.Null(logger.CurrentScope?.ExtraKeys);
+        }
+
+        [Fact]
+        public void BeginScope_WhenScopeIsTypedClass_ExtractExtraKeyName()
+        {
+            // Arrange
+            var loggerName = Guid.NewGuid().ToString();
+            var service = Guid.NewGuid().ToString();
+            var logLevel = LogLevel.Information;
+
+            var configurations = new Mock<IPowertoolsConfigurations>();
+            configurations.Setup(c => c.Service).Returns(service);
+            configurations.Setup(c => c.LogLevel).Returns(logLevel.ToString);
+            var systemWrapper = new Mock<ISystemWrapper>();
+
+            var logger = new PowertoolsLogger(loggerName,configurations.Object, systemWrapper.Object, () => 
+                new LoggerConfiguration
+                {
+                    Service = service,
+                    MinimumLevel = logLevel               
+                });
+
+            var keyName = "LoggerConfiguration";
+            var scopeKeys = new LoggerConfiguration();
+
+            using (var loggerScope = logger.BeginScope(scopeKeys) as PowertoolsLoggerScope)
+            {
+                Assert.NotNull(loggerScope);
+                Assert.NotNull(loggerScope.ExtraKeys);
+                Assert.True(loggerScope.ExtraKeys.Count == 1);
+                Assert.True(loggerScope.ExtraKeys.ContainsKey(keyName));
+                Assert.True((LoggerConfiguration)loggerScope.ExtraKeys[keyName] == scopeKeys);
+            }
+            Assert.Null(logger.CurrentScope?.ExtraKeys);
+        }
+        
+        [Fact]
+        public void BeginScope_WhenScopeIsGenericTypedClass_ExtractExtraKeyName()
+        {
+            // Arrange
+            var loggerName = Guid.NewGuid().ToString();
+            var service = Guid.NewGuid().ToString();
+            var logLevel = LogLevel.Information;
+
+            var configurations = new Mock<IPowertoolsConfigurations>();
+            configurations.Setup(c => c.Service).Returns(service);
+            configurations.Setup(c => c.LogLevel).Returns(logLevel.ToString);
+            var systemWrapper = new Mock<ISystemWrapper>();
+
+            var logger = new PowertoolsLogger(loggerName,configurations.Object, systemWrapper.Object, () => 
+                new LoggerConfiguration
+                {
+                    Service = service,
+                    MinimumLevel = logLevel               
+                });
+
+            var keyName = "List";
+            var scopeKeys = new List<string> { Guid.NewGuid().ToString() };
+
+            using (var loggerScope = logger.BeginScope(scopeKeys) as PowertoolsLoggerScope)
+            {
+                Assert.NotNull(loggerScope);
+                Assert.NotNull(loggerScope.ExtraKeys);
+                Assert.True(loggerScope.ExtraKeys.Count == 1);
+                Assert.True(loggerScope.ExtraKeys.ContainsKey(keyName));
+                Assert.True((List<string>)loggerScope.ExtraKeys[keyName] == scopeKeys);
+            }
+            Assert.Null(logger.CurrentScope?.ExtraKeys);
+        }
+
         [Fact]
         public void BeginScope_WhenScopeIsTuple_ExtractScopeKeys()
         {


### PR DESCRIPTION
> Please provide the issue number

Issue number: #166 

## Summary

This PR improves extra keys feature of logger.

### Changes

> Please provide a summary of what's being changed

- it accepts any type as provided not only type class
- it adds extra data provided under "Extra" key if user does not provide key name

### User experience

#### 1. Typed Object Type as Extra Key
For typed class key name will be class name/type name for both generic and non-generic types:

```public class LookupInfo``` => ```LookupInfo```
```public class LookupInfo<T>``` => ```LookupInfo```
```public class LookupInfo<T0,T1,T2,...>``` => ```LookupInfo```

Example:
```
var lookupInfo = new LookupInfo { LookupId = requestContextRequestId };
Logger.LogInformation(lookupInfo, "This is a log with typed object additional data");
```
Output:
```
{
    "cold_start": true,
    "lookup_info": {
       "lookup_id": "4c50eace-8b1e-43d3-92ba-0efacf5d1625"
    },
    "message": "This is a log with typed object additional data",
}
```

#### 2. Anonymous Object Type as Extra Key
For anonymous class key name will be "Extra" for example:
```
var lookupInfo = new { LookupId = requestContextRequestId };
Logger.LogInformation(lookupInfo, "This is a log with anonymous type object additional data");
```

Output:
```
{
    "cold_start": true,
    "extra": {
       "lookup_id": "4c50eace-8b1e-43d3-92ba-0efacf5d1625"
    },
    "message": "This is a log with anonymous type object additional data",
}
```

#### 3. Anonymous Object Type as Extra Key With Specified Key
When specify the key name for extra additional data (acceptable are tuple or key/value pair) for example:

```
var lookupInfo = new { LookupId = requestContextRequestId };
Logger.LogInformation(("LookupInfo", lookupInfo), "This is a log specifying the key name for additional data");
```

Output:
```
{
    "cold_start": true,
    "lookup_info": {
       "lookup_id": "4c50eace-8b1e-43d3-92ba-0efacf5d1625"
    },
    "message": "This is a log specifying the key name for additional data",
}
```

#### 4. Multiple Key/Value Pairs
When passing multiple key/value pairs (acceptable are Dictionary or list or key/value pair or array of  key/value pair ) for example:

```
var extraKeys = new Dictionary<string, object>()
{
     { "LookupInfo", new { LookupId = requestContextRequestId } },
     { "CorrelationIds", new { MyCorrelationId = "correlation_id_value" } }
};
Logger.LogInformation(extraKeys, "This is a log with multiple extra key/value pairs");
```

Output:
```
{
    "cold_start": true,
    "lookup_info": {
       "lookup_id": "4c50eace-8b1e-43d3-92ba-0efacf5d1625"
    },
    "correlation_ids": {
       "my_correlation_id": "correlation_id_value"
    },
    "message": "This is a log with multiple extra key/value pairs",
}
```

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://awslabs.github.io/aws-lambda-powertools-dotnet/tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
