### PR TITLE
chore: Replace Testcontainers generic container with DynamoDB module

### DIFF
--- a/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/AWS.Lambda.Powertools.Idempotency.Tests.csproj
+++ b/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/AWS.Lambda.Powertools.Idempotency.Tests.csproj
@@ -14,7 +14,7 @@
         <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
         <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
         <PackageReference Include="Moq" Version="4.18.4" />
-        <PackageReference Include="Testcontainers" Version="3.2.0" />
+        <PackageReference Include="Testcontainers.DynamoDb" Version="3.2.0" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Issue number: \-

## Summary

### Changes

The pull request replaces the Testcontainers' generic container with the official DynamoDB module configuration. This change contains a couple of best practices and leverages the async operations with xUnit.net's `IAsyncLifetime` interface for starting and stopping the container. Instead of using the synchronously blocking member `Wait()`, the pull request uses the `await` keyword, following the Task-based Asynchronous Pattern (TAP).

### User experience

The tests work the same, but the code is much cleaner now. It follows the best practices and recommendations.

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://awslabs.github.io/aws-lambda-powertools-dotnet/tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
