### PR TITLE
fix: Metrics Race condition if using Async calls

### DIFF
--- a/libraries/src/AWS.Lambda.Powertools.Metrics/Model/MetricDirective.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/Model/MetricDirective.cs
@@ -126,6 +126,11 @@ public class MetricDirective
             return defaultKeys;
         }
     }
+    
+    /// <summary>
+    /// Shared synchronization object
+    /// </summary>
+    private readonly object _lockObj = new();
 
     /// <summary>
     ///     Adds metric to memory
@@ -139,11 +144,14 @@ public class MetricDirective
     {
         if (Metrics.Count < PowertoolsConfigurations.MaxMetrics)
         {
-            var metric = Metrics.FirstOrDefault(m => m.Name == name);
-            if (metric != null)
-                metric.AddValue(value);
-            else
-                Metrics.Add(new MetricDefinition(name, unit, value, metricResolution));
+            lock (_lockObj)
+            {
+                var metric = Metrics.FirstOrDefault(m => m.Name == name);
+                if (metric != null)
+                    metric.AddValue(value);
+                else
+                    Metrics.Add(new MetricDefinition(name, unit, value, metricResolution));
+            }
         }
         else
         {

--- a/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/EMFValidationTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/EMFValidationTests.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 using AWS.Lambda.Powertools.Common;
 using Moq;
 using Xunit;
@@ -642,5 +643,51 @@ namespace AWS.Lambda.Powertools.Metrics.Tests
         }
 
         #endregion
+        
+        [Fact]
+        public async Task WhenMetricsAsyncRaceConditionItemSameKeyExists_ValidateLock()
+        {
+            // Arrange
+            var methodName = Guid.NewGuid().ToString();
+            var consoleOut = new StringWriter();
+            Console.SetOut(consoleOut);
+
+            var configurations = new Mock<IPowertoolsConfigurations>();
+
+            var metrics = new Metrics(configurations.Object,
+                nameSpace: "dotnet-powertools-test",
+                service: "testService");
+
+            var handler = new MetricsAspectHandler(metrics,
+                false);
+
+            var eventArgs = new AspectEventArgs { Name = methodName };
+
+            // Act
+            handler.OnEntry(eventArgs);
+
+            var tasks = new List<Task>();
+            for (var i = 0; i < 100; i++)
+            {
+                tasks.Add(Task.Run(() =>
+                {
+                    Metrics.AddMetric($"Metric Name", 0, MetricUnit.Count);
+                }));
+            }
+
+            await Task.WhenAll(tasks);
+
+
+            handler.OnExit(eventArgs);
+
+            var metricsOutput = consoleOut.ToString();
+
+            // Assert
+            Assert.Contains("{\"Namespace\":\"dotnet-powertools-test\",\"Metrics\":[{\"Name\":\"Metric Name\",\"Unit\":\"Count\"}],\"Dimensions\":[[\"Service\"]]",
+                metricsOutput);
+
+            // Reset
+            handler.ResetForTest();
+        }
     }
 }


### PR DESCRIPTION
> Please provide the issue number

Issue number: #310 

## Summary

Currently it is possible for the async code to hit a race condition that returns a System.ArgumentException: An item with the same key has already been added.

### Changes

Add lock to avoid race condition when adding metrics. 
Hold a lock for as short time as possible to reduce lock contention. 
Add tests to test race condition.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda-dotnet/tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
