### PR TITLE
chore: update urls to new format. remove latest from .net url

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -65,7 +65,7 @@ body:
     id: logs
     attributes:
       label: Debugging logs
-      description: If available, please share [debugging logs](https://docs.powertools.aws.dev/lambda-dotnet/#debug-mode)
+      description: If available, please share [debugging logs](https://docs.powertools.aws.dev/lambda/dotnet/#debug-mode)
       render: csharp
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Acknowledgment
       options:
-        - label: This feature request meets [Powertools for AWS Lambda (.NET) Tenets](https://docs.powertools.aws.dev/lambda-dotnet/tenets)
+        - label: This feature request meets [Powertools for AWS Lambda (.NET) Tenets](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
           required: true
         - label: Should this be considered in other Powertools for AWS Lambda languages? i.e. [Python](https://github.com/aws-powertools/powertools-lambda-python), [Java](https://github.com/aws-powertools/powertools-lambda-java/), and [TypeScript](https://github.com/aws-powertools/powertools-lambda-typescript/)
           required: false

--- a/.github/ISSUE_TEMPLATE/maintenance.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance.yml
@@ -52,7 +52,7 @@ body:
     attributes:
       label: Acknowledgment
       options:
-        - label: This request meets [Powertools for AWS Lambda (.NET) Tenets](https://docs.powertools.aws.dev/lambda-dotnet/latest/#tenets)
+        - label: This request meets [Powertools for AWS Lambda (.NET) Tenets](https://docs.powertools.aws.dev/lambda/dotnet/#tenets)
           required: true
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/rfc.yml
+++ b/.github/ISSUE_TEMPLATE/rfc.yml
@@ -79,7 +79,7 @@ body:
     attributes:
       label: Acknowledgment
       options:
-        - label: This feature request meets [Powertools for AWS Lambda (.NET) Tenets](https://docs.powertools.aws.dev/lambda-dotnet/tenets/)
+        - label: This feature request meets [Powertools for AWS Lambda (.NET) Tenets](https://docs.powertools.aws.dev/lambda/dotnet/tenets/)
           required: true
         - label: Should this be considered in other Powertools for AWS Lambda (.NET) languages? i.e. [Python](https://github.com/aws-powertools/powertools-lambda-python), [Java](https://github.com/aws-powertools/powertools-lambda-java/), and [TypeScript](https://github.com/aws-powertools/powertools-lambda-typescript/)
           required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@ Issue number:
 
 Please leave checklist items unchecked if they do not apply to your change.
 
-* [ ] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda-dotnet/tenets)
+* [ ] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
 * [ ] I have performed a self-review of this change
 * [ ] Changes have been tested
 * [ ] Changes are documented

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -121,7 +121,7 @@ Manage [labels](#labels), review issues regularly, and create new labels as need
 
 > TODO: This is an area we want to automate using the new GitHub GraphQL API.
 
-Make sure issues are assigned to our [board of activities](https://github.com/orgs/awslabs/projects/51/) and have the right [status](https://docs.powertools.aws.dev/lambda-dotnet/latest/roadmap/#roadmap-status-definition).
+Make sure issues are assigned to our [board of activities](https://github.com/orgs/aws-powertools/projects/6/views/4?query=is%3Aopen+sort%3Aupdated-desc) and have the right [status](https://docs.powertools.aws.dev/lambda/dotnet/roadmap/#roadmap-status-definition).
 
 Use our [labels](#labels) to signal good first issues to new community members, and to set expectation that this might need additional feedback from the author, other customers, experienced community members and/or maintainers.
 
@@ -153,7 +153,7 @@ Keep the `develop` branch at production quality at all times. Backport features 
 
 ### Manage Roadmap
 
-See [Roadmap section](https://docs.powertools.aws.dev/lambda-dotnet/roadmap/)
+See [Roadmap section](https://docs.powertools.aws.dev/lambda/dotnet/roadmap/)
 
 Ensure the repo highlights features that should be elevated to the project roadmap. Be clear about the feature’s status, priority, target version, and whether or not it should be elevated to the roadmap.
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 [![Build](https://github.com/aws-powertools/powertools-lambda-dotnet/actions/workflows/build.yml/badge.svg?branch=develop)](https://github.com/aws-powertools/powertools-lambda-dotnet/actions/workflows/build.yml)
 [![Join our Discord](https://dcbadge.vercel.app/api/server/B8zZKbbyET)](https://discord.gg/B8zZKbbyET)
 
-Powertools is a developer toolkit to implement Serverless [best practices and increase developer velocity](https://docs.powertools.aws.dev/lambda-dotnet/#features).
+Powertools is a developer toolkit to implement Serverless [best practices and increase developer velocity](https://docs.powertools.aws.dev/lambda/dotnet/#features).
 
-**[📜 Documentation](https://docs.powertools.aws.dev/lambda-dotnet/)** | **[NuGet](https://www.nuget.org/)** | **[Roadmap](https://github.com/aws-powertools/powertools-lambda-roadmap/projects/1)** | **[Examples](#examples)**
+**[📜 Documentation](https://docs.powertools.aws.dev/lambda/dotnet/)** | **[NuGet](https://www.nuget.org/)** | **[Roadmap](https://github.com/aws-powertools/powertools-lambda-roadmap/projects/1)** | **[Examples](#examples)**
 
 > **Join us on the AWS Developers Slack at `#lambda-powertools`** - **[Invite, if you don't have an account](https://join.slack.com/t/awsdevelopers/shared_invite/zt-gu30gquv-EhwIYq3kHhhysaZ2aIX7ew)**
 
@@ -14,15 +14,15 @@ Powertools is a developer toolkit to implement Serverless [best practices and in
 
 Powertools for AWS Lambda (.NET) provides three core utilities:
 
-* **[Logging](https://docs.powertools.aws.dev/lambda-dotnet/core/logging/)** - provides a custom logger class that outputs structured JSON. It allows you to pass in strings or more complex objects, and will take care of serializing the log output. Common use cases—such as logging the Lambda event payload and capturing cold start information—are handled for you, including appending custom keys to the logger at anytime.
+* **[Logging](https://docs.powertools.aws.dev/lambda/dotnet/core/logging/)** - provides a custom logger class that outputs structured JSON. It allows you to pass in strings or more complex objects, and will take care of serializing the log output. Common use cases—such as logging the Lambda event payload and capturing cold start information—are handled for you, including appending custom keys to the logger at anytime.
 
-* **[Metrics](https://docs.powertools.aws.dev/lambda-dotnet/core/metrics/)** - makes collecting custom metrics from your application simple, without the need to make synchronous requests to external systems. This functionality is powered by [Amazon CloudWatch Embedded Metric Format (EMF)](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format.html), which allows for capturing metrics asynchronously.
+* **[Metrics](https://docs.powertools.aws.dev/lambda/dotnet/core/metrics/)** - makes collecting custom metrics from your application simple, without the need to make synchronous requests to external systems. This functionality is powered by [Amazon CloudWatch Embedded Metric Format (EMF)](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format.html), which allows for capturing metrics asynchronously.
 
-* **[Tracing](https://docs.powertools.aws.dev/lambda-dotnet/core/tracing/)** - provides a simple way to send traces from functions to AWS X-Ray to provide visibility into function calls, interactions with other AWS services, or external HTTP requests. Annotations can easily be added to traces to allow filtering traces based on key information. For example, when using Tracer, a ColdStart annotation is created for you so you can easily group and analyze traces where there was an initialization overhead.
+* **[Tracing](https://docs.powertools.aws.dev/lambda/dotnet/core/tracing/)** - provides a simple way to send traces from functions to AWS X-Ray to provide visibility into function calls, interactions with other AWS services, or external HTTP requests. Annotations can easily be added to traces to allow filtering traces based on key information. For example, when using Tracer, a ColdStart annotation is created for you so you can easily group and analyze traces where there was an initialization overhead.
 
-* **[Parameters (developer preview)](https://docs.powertools.aws.dev/lambda-dotnet/utilities/parameters/)** - provides high-level functionality to retrieve one or multiple parameter values from [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html), [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/), or [Amazon DynamoDB](https://aws.amazon.com/dynamodb/). We also provide extensibility to bring your own providers.
+* **[Parameters (developer preview)](https://docs.powertools.aws.dev/lambda/dotnet/utilities/parameters/)** - provides high-level functionality to retrieve one or multiple parameter values from [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html), [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/), or [Amazon DynamoDB](https://aws.amazon.com/dynamodb/). We also provide extensibility to bring your own providers.
 
-* **[Idempotency (developer preview)](https://docs.powertools.aws.dev/lambda-dotnet/utilities/idempotency/)** - The idempotency utility provides a simple solution to convert your Lambda functions into idempotent operations which are safe to retry.
+* **[Idempotency (developer preview)](https://docs.powertools.aws.dev/lambda/dotnet/utilities/idempotency/)** - The idempotency utility provides a simple solution to convert your Lambda functions into idempotent operations which are safe to retry.
 
 ### Installation
 

--- a/apidocs/index.md
+++ b/apidocs/index.md
@@ -7,7 +7,7 @@ To get started use the `API Documentaion` menu on the navigation bar, or search 
 > [!NOTE]
 > Are you looking for documentation on how to use Powertools for AWS Lambda (.NET) utilities and code samples?
 >  
-> 👉 [Here](https://docs.powertools.aws.dev/lambda-dotnet/) is the perfect place to start.
+> 👉 [Here](https://docs.powertools.aws.dev/lambda/dotnet/) is the perfect place to start.
 
 ## Feedback
 

--- a/apidocs/toc.yml
+++ b/apidocs/toc.yml
@@ -2,4 +2,4 @@
   href: api/
   homepage: api/index.md
 - name: Powertools for AWS Lambda (.NET) Documentation
-  href: "https://docs.powertools.aws.dev/lambda-dotnet/"
+  href: "https://docs.powertools.aws.dev/lambda/dotnet/"

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ description: Powertools for AWS Lambda (.NET)
 Powertools for AWS Lambda (.NET) (which from here will be referred as Powertools) is a suite of utilities for [AWS Lambda](https://aws.amazon.com/lambda/) functions to ease adopting best practices such as tracing, structured logging, custom metrics, and more. Please note, **Powertools for AWS Lambda (.NET) is optimized for .NET 6+**.
 
 ???+ tip
-    Powertools is also available for [Python](https://docs.powertools.aws.dev/lambda-python/){target="_blank"}, [Java](https://docs.powertools.aws.dev/lambda-java/){target="_blank"}, and [TypeScript](https://docs.powertools.aws.dev/lambda-typescript/latest/){target="_blank"}.
+    Powertools is also available for [Python](https://docs.powertools.aws.dev/lambda/python/){target="_blank"}, [Java](https://docs.powertools.aws.dev/lambda/java/){target="_blank"}, and [TypeScript](https://docs.powertools.aws.dev/lambda/typescript/latest/){target="_blank"}.
 
 ??? hint "Support this project by becoming a reference customer or sharing your work :heart:"
 

--- a/docs/javascript/extra.js
+++ b/docs/javascript/extra.js
@@ -10,12 +10,12 @@ const awsconfig = {
 };
 
 const RUNTIME = "dotnet"
-const BASE_ORIGIN = "awslabs.github.io"
+const BASE_ORIGIN = "docs.powertools.aws.dev"
 
 function copyToClipboard(e) {
 	e.preventDefault()
 	navigator.clipboard.writeText(e.target.textContent)
-  	alert$.next("Copied to clipboard")
+	alert$.next("Copied to clipboard")
 }
 
 function enableSearchOnBlurElement() {
@@ -74,7 +74,7 @@ const init = () => {
 	attachListeners()
 }
 
-const recordPageView = ({prevLocation, searchPattern}) => {
+const recordPageView = ({ prevLocation, searchPattern }) => {
 	Analytics.record({
 		data: {
 			// Do not count page view for search

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 
 This is our public roadmap that outlines the high level direction we are working towards, namely [Themes](#themes). We update this document when our priorities change: security and stability is our top priority.
 
-[See our latest list of activities »](https://github.com/orgs/awslabs/projects/105/views/4?query=is%3Aopen+sort%3Aupdated-desc){target="_blank"}
+[See our latest list of activities »](https://github.com/orgs/aws-powertools/projects/6/views/4?query=is%3Aopen+sort%3Aupdated-desc){target="_blank"}
 
 ## Themes
 
@@ -30,7 +30,7 @@ graph LR
 <i>Visual representation</i>
 </center>
 
-Within our [public board](https://github.com/orgs/awslabs/projects/105/views/3?query=is%3Aopen+sort%3Aupdated-desc){target="_blank"}, you'll see the following values in the `Status` column:
+Within our [public board](https://github.com/orgs/aws-powertools/projects/6/views/4?query=is%3Aopen+sort%3Aupdated-desc){target="_blank"}, you'll see the following values in the `Status` column:
 
 * **Ideas**. Incoming and existing feature requests that are not being actively considered yet. These will be reviewed when bandwidth permits and based on demand.
 * **Backlog**. Accepted feature requests or enhancements that we want to work on.

--- a/libraries/src/AWS.Lambda.Powertools.Logging/README.md
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/README.md
@@ -11,7 +11,7 @@ The logging utility provides a [AWS Lambda](https://aws.amazon.com/lambda/) opti
 
 ## Read the docs
 
-For a full list of features go to [docs.powertools.aws.dev/lambda-dotnet/core/logging/](docs.powertools.aws.dev/lambda-dotnet/core/logging/)
+For a full list of features go to [docs.powertools.aws.dev/lambda/dotnet/core/logging/](docs.powertools.aws.dev/lambda/dotnet/core/logging/)
 
 GitHub: https://github.com/aws-powertools/powertools-lambda-dotnet/
 

--- a/libraries/src/AWS.Lambda.Powertools.Metrics/README.md
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/README.md
@@ -13,7 +13,7 @@ These metrics can be visualized through [Amazon CloudWatch Console](https://aws.
 
 ## Read the docs
 
-For a full list of features go to [docs.powertools.aws.dev/lambda-dotnet/core/metrics/](docs.powertools.aws.dev/lambda-dotnet/core/metrics/)
+For a full list of features go to [docs.powertools.aws.dev/lambda/dotnet/core/metrics/](docs.powertools.aws.dev/lambda/dotnet/core/metrics/)
 
 GitHub: https://github.com/aws-powertools/powertools-lambda-dotnet/
 

--- a/libraries/src/AWS.Lambda.Powertools.Parameters/README.md
+++ b/libraries/src/AWS.Lambda.Powertools.Parameters/README.md
@@ -11,7 +11,7 @@ The Parameters utility provides high-level functionality to retrieve one or mult
 
 ## Read the docs
 
-For a full list of features go to [docs.powertools.aws.dev/lambda-dotnet/utilities/parameters/](docs.powertools.aws.dev/lambda-dotnet/utilities/parameters/)
+For a full list of features go to [docs.powertools.aws.dev/lambda/dotnet/utilities/parameters/](docs.powertools.aws.dev/lambda/dotnet/utilities/parameters/)
 
 GitHub: <https://github.com/aws-powertools/powertools-lambda-dotnet/>
 

--- a/libraries/src/AWS.Lambda.Powertools.Tracing/README.md
+++ b/libraries/src/AWS.Lambda.Powertools.Tracing/README.md
@@ -13,7 +13,7 @@ a provides functionality to reduce the overhead of performing common tracing tas
 
 ## Read the docs
 
-For a full list of features go to [docs.powertools.aws.dev/lambda-dotnet/core/tracing/](docs.powertools.aws.dev/lambda-dotnet/core/tracing/)
+For a full list of features go to [docs.powertools.aws.dev/lambda/dotnet/core/tracing/](docs.powertools.aws.dev/lambda/dotnet/core/tracing/)
 
 **GitHub:** https://github.com/aws-powertools/powertools-lambda-dotnet/
 
@@ -129,4 +129,4 @@ public class Function
 
 ## Sample output
 
-![Tracing showcase](http://docs.powertools.aws.dev/lambda-dotnet/media/tracer_utility_showcase.png)
+![Tracing showcase](http://docs.powertools.aws.dev/lambda/dotnet/media/tracer_utility_showcase.png)


### PR DESCRIPTION
> Please provide the issue number

Issue number: #290 

## Summary

Docs urls need to be updated to lambda/<language> so lambda/dotnet instead of lambda-dotnet

### Changes

> Please provide a summary of what's being changed

update urls to new format. remove latest from .net url

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda-dotnet/tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
