### PR TITLE
chore: Bump logging version to fix idempotency example

### DIFF
--- a/examples/Idempotency/src/HelloWorld/HelloWorld.csproj
+++ b/examples/Idempotency/src/HelloWorld/HelloWorld.csproj
@@ -9,7 +9,7 @@
         <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.5.0" />
         <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
         <PackageReference Include="AWS.Lambda.Powertools.Idempotency" Version="0.0.1-preview" />
-        <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.1.0" />
+        <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.1.1" />
         <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.103.7" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
> Please provide the issue number

Issue number: #300 

## Summary

Idempotency example failing due to old Logging version

### Changes

Update Logging version

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
