### PR TITLE
docs: Clarify why we currently prefer X-Ray over ADOT in Tracing

### DIFF
--- a/docs/core/tracing.md
+++ b/docs/core/tracing.md
@@ -26,6 +26,8 @@ Powertools for AWS Lambda (.NET) are available as NuGet packages. You can instal
 
 ## Getting Started
 
+!!! note "Tracer relies on AWS X-Ray SDK over [OpenTelememetry Distro (ADOT)](https://aws-otel.github.io/docs/getting-started/lambda){target="_blank"} for optimal cold start (lower latency)."
+
 Before you use this utility, your AWS Lambda function [must have permissions](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html#services-xray-permissions) to send traces to AWS X-Ray.
 
 To enable active tracing on an AWS Serverless Application Model (AWS SAM) AWS::Serverless::Function resource, use the `Tracing` property. You can use the Globals section of the AWS SAM template to set this for all  


### PR DESCRIPTION
> Please provide the issue number

Issue number: #344 

## Summary

In the Tracer docs, when introducing the utility, we should clarify why we use X-Ray over ADOT/OTEL - which appears to be the recommended way of tracing functions by other AWS teams. The Python docs for Tracer have a banner that explains the reasoning, and since it's a somewhat common question from customers we should add the same banner.

### Changes

> Please provide a summary of what's being changed

Add note

```markdown
!!! note "Tracer relies on AWS X-Ray SDK over [OpenTelememetry Distro (ADOT)](https://aws-otel.github.io/docs/getting-started/lambda){target="_blank"} for optimal cold start (lower latency)."
```

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
