### PR TITLE
chore: Replace Moq NuGet package with NSubstitute

### DIFF
--- a/examples/Idempotency/test/HelloWorld.Test/FunctionTest.cs
+++ b/examples/Idempotency/test/HelloWorld.Test/FunctionTest.cs
@@ -14,22 +14,11 @@
  */
 
 using System;
-using System.Collections.Generic;
-using System.Net;
-using System.Net.Http;
-using System.Text.Json;
-using System.Threading;
 using System.Threading.Tasks;
 using Amazon.DynamoDBv2;
-using Amazon.DynamoDBv2.DataModel;
-using Amazon.DynamoDBv2.Model;
 using Xunit;
 using Amazon.Lambda.APIGatewayEvents;
 using Amazon.Lambda.TestUtilities;
-using DotNet.Testcontainers.Builders;
-using DotNet.Testcontainers.Containers;
-using Moq;
-using Moq.Protected;
 using Xunit.Abstractions;
 
 namespace HelloWorld.Tests

--- a/examples/Idempotency/test/HelloWorld.Test/HelloWorld.Tests.csproj
+++ b/examples/Idempotency/test/HelloWorld.Test/HelloWorld.Tests.csproj
@@ -6,11 +6,10 @@
 		<PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
 		<PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
 		<PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-		<PackageReference Include="Moq" Version="4.18.4" />
-		<PackageReference Include="xunit" Version="2.4.2" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+		<PackageReference Include="xunit" Version="2.5.0" />
 		<PackageReference Include="Testcontainers" Version="3.3.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/examples/Logging/src/HelloWorld/HelloWorld.csproj
+++ b/examples/Logging/src/HelloWorld/HelloWorld.csproj
@@ -6,9 +6,9 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
-        <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.5.0" />
+        <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.6.0" />
         <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
-        <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.1.0" />
+        <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.1.1" />
         <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.101.14" />
     </ItemGroup>
 </Project>

--- a/examples/Logging/test/HelloWorld.Test/FunctionTest.cs
+++ b/examples/Logging/test/HelloWorld.Test/FunctionTest.cs
@@ -24,8 +24,7 @@ using Amazon.DynamoDBv2.DataModel;
 using Xunit;
 using Amazon.Lambda.APIGatewayEvents;
 using Amazon.Lambda.TestUtilities;
-using Moq;
-using Moq.Protected;
+using NSubstitute;
 using Xunit.Abstractions;
 
 namespace HelloWorld.Tests
@@ -39,6 +38,20 @@ namespace HelloWorld.Tests
             _testOutputHelper = testOutputHelper;
         }
 
+        private class MockHttpMessageHandler : HttpMessageHandler
+        {
+            private readonly HttpResponseMessage _responseMessage;
+            public MockHttpMessageHandler(HttpResponseMessage responseMessage)
+            {
+                _responseMessage = responseMessage;
+            }
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                return await Task.FromResult(_responseMessage);
+            }
+        }
+
         [Fact]
         public async Task TestHelloWorldFunctionHandler()
         {
@@ -47,21 +60,12 @@ namespace HelloWorld.Tests
             var accountId = Guid.NewGuid().ToString("D");
             var location = "192.158. 1.38";
             
-            var dynamoDbContext = new Mock<IDynamoDBContext>();
-            var handlerMock = new Mock<HttpMessageHandler>();
-            handlerMock
-                .Protected()
-                .Setup<Task<HttpResponseMessage>>(
-                    "SendAsync",
-                    ItExpr.IsAny<HttpRequestMessage>(),
-                    ItExpr.IsAny<CancellationToken>()
-                )
-                .ReturnsAsync(new HttpResponseMessage
-                {
-                    StatusCode = HttpStatusCode.OK,
-                    Content = new StringContent(location)
-                })
-                .Verifiable();
+            var dynamoDbContext = Substitute.For<IDynamoDBContext>();
+            var handlerMock = new MockHttpMessageHandler(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(location)
+            });
 
             var request = new APIGatewayProxyRequest
             {
@@ -94,7 +98,7 @@ namespace HelloWorld.Tests
                 Headers = new Dictionary<string, string> { { "Content-Type", "application/json" } }
             };
 
-            var function = new Function(dynamoDbContext.Object, new HttpClient(handlerMock.Object));
+            var function = new Function(dynamoDbContext, new HttpClient(handlerMock));
             var response = await function.FunctionHandler(request, context);
 
             _testOutputHelper.WriteLine("Lambda Response: \n" + response.Body);

--- a/examples/Logging/test/HelloWorld.Test/HelloWorld.Tests.csproj
+++ b/examples/Logging/test/HelloWorld.Test/HelloWorld.Tests.csproj
@@ -7,10 +7,10 @@
 		<PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
 		<PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
 		<PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.101.14" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0-preview-20221221-03" />
-		<PackageReference Include="Moq" Version="4.18.3" />
-		<PackageReference Include="xunit" Version="2.4.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+		<PackageReference Include="NSubstitute" Version="5.0.0" />
+		<PackageReference Include="xunit" Version="2.5.0" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/examples/Metrics/src/HelloWorld/HelloWorld.csproj
+++ b/examples/Metrics/src/HelloWorld/HelloWorld.csproj
@@ -6,10 +6,10 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
-        <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.5.0" />
+        <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.6.0" />
         <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
-        <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.1.0" />
-        <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="1.2.0" />
+        <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.1.1" />
+        <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="1.3.2" />
         <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.101.14" />
     </ItemGroup>
 </Project>

--- a/examples/Metrics/test/HelloWorld.Test/FunctionTest.cs
+++ b/examples/Metrics/test/HelloWorld.Test/FunctionTest.cs
@@ -61,7 +61,6 @@ namespace HelloWorld.Tests
             Environment.SetEnvironmentVariable("POWERTOOLS_METRICS_NAMESPACE","AWSLambdaPowertools");
             
             var dynamoDbContext = Substitute.For<IDynamoDBContext>();
-
             var handlerMock = new MockHttpMessageHandler(new HttpResponseMessage
             {
                 StatusCode = HttpStatusCode.OK,

--- a/examples/Metrics/test/HelloWorld.Test/HelloWorld.Tests.csproj
+++ b/examples/Metrics/test/HelloWorld.Test/HelloWorld.Tests.csproj
@@ -8,7 +8,6 @@
 		<PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
 		<PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.101.14" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
-		<PackageReference Include="Moq" Version="4.18.3" />
 		<PackageReference Include="NSubstitute" Version="5.0.0" />
 		<PackageReference Include="xunit" Version="2.5.0" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">

--- a/examples/Metrics/test/HelloWorld.Test/HelloWorld.Tests.csproj
+++ b/examples/Metrics/test/HelloWorld.Test/HelloWorld.Tests.csproj
@@ -7,10 +7,11 @@
 		<PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
 		<PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
 		<PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.101.14" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0-preview-20221221-03" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
 		<PackageReference Include="Moq" Version="4.18.3" />
-		<PackageReference Include="xunit" Version="2.4.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+		<PackageReference Include="NSubstitute" Version="5.0.0" />
+		<PackageReference Include="xunit" Version="2.5.0" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/examples/Parameters/src/HelloWorld/HelloWorld.csproj
+++ b/examples/Parameters/src/HelloWorld/HelloWorld.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
-        <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.5.0" />
+        <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.6.0" />
         <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
         <PackageReference Include="AWS.Lambda.Powertools.Parameters" Version="0.0.2-preview" />
     </ItemGroup>

--- a/examples/Parameters/test/HelloWorld.Test/FunctionTest.cs
+++ b/examples/Parameters/test/HelloWorld.Test/FunctionTest.cs
@@ -19,7 +19,7 @@ using System.Threading.Tasks;
 using Amazon.Lambda.APIGatewayEvents;
 using Amazon.Lambda.TestUtilities;
 using Xunit;
-using Moq;
+using NSubstitute;
 using System.Text.Json;
 
 namespace HelloWorld.Tests
@@ -32,7 +32,7 @@ namespace HelloWorld.Tests
             // Arrange
             var requestId = Guid.NewGuid().ToString("D");
             var accountId = Guid.NewGuid().ToString("D");
-            
+
             var request = new APIGatewayProxyRequest
             {
                 RequestContext = new APIGatewayProxyRequest.ProxyRequestContext
@@ -41,7 +41,7 @@ namespace HelloWorld.Tests
                     AccountId = accountId
                 }
             };
-            
+
             var context = new TestLambdaContext()
             {
                 FunctionName = Guid.NewGuid().ToString("D"),
@@ -49,9 +49,9 @@ namespace HelloWorld.Tests
                 MemoryLimitInMB = 215,
                 AwsRequestId = requestId
             };
-            
-            var helper = new Mock<IParameterLookupHelper>();
-            
+
+            var helper = Substitute.For<IParameterLookupHelper>();
+
             var singleSsmRecord = new ParameterLookupRecord
             {
                 Provider = ParameterProviderType.SsmProvider,
@@ -59,10 +59,8 @@ namespace HelloWorld.Tests
                 Key = Guid.NewGuid().ToString("D"),
                 Value = Guid.NewGuid().ToString("D")
             };
-            helper.Setup(c =>
-                c.GetSingleParameterWithSsmProvider()
-            ).ReturnsAsync(singleSsmRecord);
-            
+            helper.GetSingleParameterWithSsmProvider().Returns(singleSsmRecord);
+
             var multipleSsmRecord = new ParameterLookupRecord
             {
                 Provider = ParameterProviderType.SsmProvider,
@@ -74,9 +72,7 @@ namespace HelloWorld.Tests
                     { Guid.NewGuid().ToString("D"), Guid.NewGuid().ToString("D") }
                 }
             };
-            helper.Setup(c =>
-                c.GetMultipleParametersWithSsmProvider()
-            ).ReturnsAsync(multipleSsmRecord);
+            helper.GetMultipleParametersWithSsmProvider().Returns(multipleSsmRecord);
 
             var singleSecretRecord = new ParameterLookupRecord
             {
@@ -89,10 +85,8 @@ namespace HelloWorld.Tests
                     Password = Guid.NewGuid().ToString("D")
                 }
             };
-            helper.Setup(c =>
-                c.GetSingleSecretWithSecretsProvider()
-            ).ReturnsAsync(singleSecretRecord);
-            
+            helper.GetSingleSecretWithSecretsProvider().Returns(singleSecretRecord);
+
             var singleDynamoDbRecord = new ParameterLookupRecord
             {
                 Provider = ParameterProviderType.DynamoDBProvider,
@@ -100,10 +94,8 @@ namespace HelloWorld.Tests
                 Key = Guid.NewGuid().ToString("D"),
                 Value = Guid.NewGuid().ToString("D")
             };
-            helper.Setup(c =>
-                c.GetSingleParameterWithDynamoDBProvider()
-            ).ReturnsAsync(singleDynamoDbRecord);
-            
+            helper.GetSingleParameterWithDynamoDBProvider().Returns(singleDynamoDbRecord);
+
             var multipleDynamoDbRecord = new ParameterLookupRecord
             {
                 Provider = ParameterProviderType.DynamoDBProvider,
@@ -115,10 +107,8 @@ namespace HelloWorld.Tests
                     { Guid.NewGuid().ToString("D"), Guid.NewGuid().ToString("D") }
                 }
             };
-            helper.Setup(c =>
-                c.GetMultipleParametersWithDynamoDBProvider()
-            ).ReturnsAsync(multipleDynamoDbRecord);
-            
+            helper.GetMultipleParametersWithDynamoDBProvider().Returns(multipleDynamoDbRecord);
+
             var body = new Dictionary<string, object>
             {
                 { "RequestId", requestId },
@@ -134,7 +124,7 @@ namespace HelloWorld.Tests
                     }
                 }
             };
-            
+
             var expectedResponse = new APIGatewayProxyResponse
             {
                 Body = JsonSerializer.Serialize(body),
@@ -143,15 +133,15 @@ namespace HelloWorld.Tests
             };
 
             // Act
-            var function = new Function(helper.Object);
+            var function = new Function(helper);
             var response = await function.FunctionHandler(request, context).ConfigureAwait(false);
 
             // Assert
-            helper.Verify(v => v.GetSingleParameterWithSsmProvider(), Times.Once);
-            helper.Verify(v => v.GetMultipleParametersWithSsmProvider(), Times.Once);
-            helper.Verify(v => v.GetSingleSecretWithSecretsProvider(), Times.Once);
-            helper.Verify(v => v.GetSingleParameterWithDynamoDBProvider(), Times.Once);
-            helper.Verify(v => v.GetMultipleParametersWithDynamoDBProvider(), Times.Once);
+            await helper.Received(1).GetSingleParameterWithSsmProvider();
+            await helper.Received(1).GetMultipleParametersWithSsmProvider();
+            await helper.Received(1).GetSingleSecretWithSecretsProvider();
+            await helper.Received(1).GetSingleParameterWithDynamoDBProvider();
+            await helper.Received(1).GetMultipleParametersWithDynamoDBProvider();
             Assert.Equal(expectedResponse.Body, response.Body);
             Assert.Equal(expectedResponse.Headers, response.Headers);
             Assert.Equal(expectedResponse.StatusCode, response.StatusCode);

--- a/examples/Parameters/test/HelloWorld.Test/HelloWorld.Tests.csproj
+++ b/examples/Parameters/test/HelloWorld.Test/HelloWorld.Tests.csproj
@@ -6,10 +6,10 @@
 		<PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
 		<PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
 		<PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0-preview.23280.1" />
-		<PackageReference Include="Moq" Version="4.18.4" />
-		<PackageReference Include="xunit" Version="2.4.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+		<PackageReference Include="NSubstitute" Version="5.0.0" />
+		<PackageReference Include="xunit" Version="2.5.0" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/examples/Parameters/test/HelloWorld.Test/ParameterLookupTest.cs
+++ b/examples/Parameters/test/HelloWorld.Test/ParameterLookupTest.cs
@@ -24,7 +24,7 @@ using AWS.Lambda.Powertools.Parameters.SecretsManager;
 using Xunit;
 using AWS.Lambda.Powertools.Parameters.SimpleSystemsManagement;
 using AWS.Lambda.Powertools.Parameters.Transform;
-using Moq;
+using NSubstitute;
 
 namespace HelloWorld.Tests
 {
@@ -40,7 +40,7 @@ namespace HelloWorld.Tests
         private readonly IParameterProvider _parameterProvider;
 
         public MockParameterProviderConfigurationBuilder(IParameterProvider parameterProvider) : base(
-            (new Mock<ParameterProvider>()).Object)
+            Substitute.For<ParameterProvider>())
         {
             _parameterProvider = parameterProvider;
         }
@@ -67,26 +67,25 @@ namespace HelloWorld.Tests
             var parameterName = Guid.NewGuid().ToString("D");
             var parameterValue = Guid.NewGuid().ToString("D");
 
-            Environment.SetEnvironmentVariable(EnvironmentVariableNames.SsmSingleParameterNameVariableName, parameterName);
+            Environment.SetEnvironmentVariable(EnvironmentVariableNames.SsmSingleParameterNameVariableName,
+                parameterName);
 
-            var provider = new Mock<ISsmProvider>();
-            provider.Setup(c =>
-                c.GetAsync(parameterName)
-            ).ReturnsAsync(parameterValue);
+            var provider = Substitute.For<ISsmProvider>();
+            provider.GetAsync(parameterName).Returns(parameterValue);
 
             // Act
-            var helper = new ParameterLookupHelper(provider.Object, parameterProviderType);
+            var helper = new ParameterLookupHelper(provider, parameterProviderType);
             var result = await helper.GetSingleParameterWithSsmProvider().ConfigureAwait(false);
-            
+
             // Assert
-            provider.Verify(v => v.GetAsync(parameterName), Times.Once);
+            await provider.Received(1).GetAsync(parameterName);
             Assert.NotNull(result);
             Assert.Equal(parameterProviderType, result.Provider);
             Assert.Equal(parameterLookupMethod, result.Method);
             Assert.Equal(parameterName, result.Key);
             Assert.Equal(parameterValue, result.Value);
         }
-        
+
         [Fact]
         public async Task TestGetMultipleParametersWithSsmProvider()
         {
@@ -100,24 +99,23 @@ namespace HelloWorld.Tests
                 { Guid.NewGuid().ToString("D"), Guid.NewGuid().ToString("D") }
             };
 
-            Environment.SetEnvironmentVariable(EnvironmentVariableNames.SsmMultipleParametersPathPrefixVariableName, parameterPathPrefix);
+            Environment.SetEnvironmentVariable(EnvironmentVariableNames.SsmMultipleParametersPathPrefixVariableName,
+                parameterPathPrefix);
 
-            var provider = new Mock<ISsmProvider>();
-            provider.Setup(c =>
-                c.GetMultipleAsync(parameterPathPrefix)
-            ).ReturnsAsync(parameterValues);
+            var provider = Substitute.For<ISsmProvider>();
+            provider.GetMultipleAsync(parameterPathPrefix).Returns(parameterValues);
 
             // Act
-            var helper = new ParameterLookupHelper(provider.Object, parameterProviderType);
+            var helper = new ParameterLookupHelper(provider, parameterProviderType);
             var result = await helper.GetMultipleParametersWithSsmProvider().ConfigureAwait(false);
-            
+
             // Assert
-            provider.Verify(v => v.GetMultipleAsync(parameterPathPrefix), Times.Once);
+            await provider.Received(1).GetMultipleAsync(parameterPathPrefix);
             Assert.NotNull(result);
             Assert.Equal(parameterProviderType, result.Provider);
             Assert.Equal(parameterLookupMethod, result.Method);
             Assert.Equal(parameterPathPrefix, result.Key);
-            
+
             var values = result.Value as IDictionary<string, string>;
             Assert.NotNull(values);
             Assert.Equal(parameterValues.Count, values.Count);
@@ -126,7 +124,7 @@ namespace HelloWorld.Tests
             Assert.Equal(parameterValues.Last().Key, values.Last().Key);
             Assert.Equal(parameterValues.Last().Value, values.Last().Value);
         }
-        
+
         [Fact]
         public async Task TestGetSingleSecretWithSecretsProvider()
         {
@@ -142,33 +140,30 @@ namespace HelloWorld.Tests
 
             Environment.SetEnvironmentVariable(EnvironmentVariableNames.SecretsManagerSecretName, secretName);
 
-            var provider = new Mock<ISecretsProvider>();
-            provider.Setup(c =>
-                c.GetAsync<SecretRecord>(secretName)
-            ).ReturnsAsync(secretValue);
-            provider.Setup(c =>
-                c.WithTransformation(Transformation.Json)
-            ).Returns(new MockParameterProviderConfigurationBuilder(provider.Object));
+            var provider = Substitute.For<ISecretsProvider>();
+            var configBuilder = new MockParameterProviderConfigurationBuilder(provider);
+            provider.GetAsync<SecretRecord>(secretName).Returns(secretValue);
+            provider.WithTransformation(Transformation.Json).Returns(configBuilder);
 
             // Act
-            var helper = new ParameterLookupHelper(provider.Object, parameterProviderType);
+            var helper = new ParameterLookupHelper(provider, parameterProviderType);
             var result = await helper.GetSingleSecretWithSecretsProvider().ConfigureAwait(false);
-            
+
             // Assert
-            provider.Verify(v => v.GetAsync<SecretRecord>(secretName), Times.Once);
-            provider.Verify(v => v.WithTransformation(Transformation.Json), Times.Once);
+            await provider.Received(1).GetAsync<SecretRecord>(secretName);
+            provider.Received(1).WithTransformation(Transformation.Json);
             Assert.NotNull(result);
             Assert.Equal(parameterProviderType, result.Provider);
             Assert.Equal(parameterLookupMethod, result.Method);
             Assert.Equal(secretName, result.Key);
             Assert.Equal(secretName, result.Key);
-            
+
             var value = result.Value as SecretRecord;
             Assert.NotNull(value);
             Assert.Equal(secretValue.Username, value.Username);
             Assert.Equal(secretValue.Password, value.Password);
         }
-        
+
         [Fact]
         public async Task TestGetSingleParameterWithDynamoDBProvider()
         {
@@ -179,31 +174,28 @@ namespace HelloWorld.Tests
             var dynamoDbHashKey = Guid.NewGuid().ToString("D");
             var parameterValue = Guid.NewGuid().ToString("D");
 
-            Environment.SetEnvironmentVariable(EnvironmentVariableNames.DynamoDBSingleParameterTableName, dynamoDbTableName);
+            Environment.SetEnvironmentVariable(EnvironmentVariableNames.DynamoDBSingleParameterTableName,
+                dynamoDbTableName);
             Environment.SetEnvironmentVariable(EnvironmentVariableNames.DynamoDBSingleParameterId, dynamoDbHashKey);
 
-            var provider = new Mock<IDynamoDBProvider>();
-            provider.Setup(c =>
-                c.GetAsync(dynamoDbHashKey)
-            ).ReturnsAsync(parameterValue);
-            provider.Setup(c =>
-                c.UseTable(dynamoDbTableName)
-            ).Returns(provider.Object);
-            
+            var provider = Substitute.For<IDynamoDBProvider>();
+            provider.GetAsync(dynamoDbHashKey).Returns(parameterValue);
+            provider.UseTable(dynamoDbTableName).Returns(provider);
+
             // Act
-            var helper = new ParameterLookupHelper(provider.Object, parameterProviderType);
+            var helper = new ParameterLookupHelper(provider, parameterProviderType);
             var result = await helper.GetSingleParameterWithDynamoDBProvider().ConfigureAwait(false);
-            
+
             // Assert
-            provider.Verify(v => v.GetAsync(dynamoDbHashKey), Times.Once);
-            provider.Verify(v => v.UseTable(dynamoDbTableName), Times.Once);
+            await provider.Received(1).GetAsync(dynamoDbHashKey);
+            provider.Received(1).UseTable(dynamoDbTableName);
             Assert.NotNull(result);
             Assert.Equal(parameterProviderType, result.Provider);
             Assert.Equal(parameterLookupMethod, result.Method);
             Assert.Equal(dynamoDbHashKey, result.Key);
             Assert.Equal(parameterValue, result.Value);
         }
-        
+
         [Fact]
         public async Task TestGetMultipleParametersWithDynamoDBProvider()
         {
@@ -218,29 +210,27 @@ namespace HelloWorld.Tests
                 { Guid.NewGuid().ToString("D"), Guid.NewGuid().ToString("D") }
             };
 
-            Environment.SetEnvironmentVariable(EnvironmentVariableNames.DynamoDBMultipleParametersTableName, dynamoDbTableName);
-            Environment.SetEnvironmentVariable(EnvironmentVariableNames.DynamoDBMultipleParametersParameterId, dynamoDbHashKey);
+            Environment.SetEnvironmentVariable(EnvironmentVariableNames.DynamoDBMultipleParametersTableName,
+                dynamoDbTableName);
+            Environment.SetEnvironmentVariable(EnvironmentVariableNames.DynamoDBMultipleParametersParameterId,
+                dynamoDbHashKey);
 
-            var provider = new Mock<IDynamoDBProvider>();
-            provider.Setup(c =>
-                c.GetMultipleAsync(dynamoDbHashKey)
-            ).ReturnsAsync(parameterValues);
-            provider.Setup(c =>
-                c.UseTable(dynamoDbTableName)
-            ).Returns(provider.Object);
-            
+            var provider = Substitute.For<IDynamoDBProvider>();
+            provider.GetMultipleAsync(dynamoDbHashKey).Returns(parameterValues);
+            provider.UseTable(dynamoDbTableName).Returns(provider);
+
             // Act
-            var helper = new ParameterLookupHelper(provider.Object, parameterProviderType);
+            var helper = new ParameterLookupHelper(provider, parameterProviderType);
             var result = await helper.GetMultipleParametersWithDynamoDBProvider().ConfigureAwait(false);
-            
+
             // Assert
-            provider.Verify(v => v.GetMultipleAsync(dynamoDbHashKey), Times.Once);
-            provider.Verify(v => v.UseTable(dynamoDbTableName), Times.Once);
+            await provider.Received(1).GetMultipleAsync(dynamoDbHashKey);
+            provider.Received(1).UseTable(dynamoDbTableName);
             Assert.NotNull(result);
             Assert.Equal(parameterProviderType, result.Provider);
             Assert.Equal(parameterLookupMethod, result.Method);
             Assert.Equal(dynamoDbHashKey, result.Key);
-            
+
             var values = result.Value as IDictionary<string, string>;
             Assert.NotNull(values);
             Assert.Equal(parameterValues.Count, values.Count);

--- a/examples/ServerlessApi/src/LambdaPowertoolsAPI/LambdaPowertoolsAPI.csproj
+++ b/examples/ServerlessApi/src/LambdaPowertoolsAPI/LambdaPowertoolsAPI.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="8.1.0" />
-    <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.1.0" />
-    <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="1.2.0" />
-    <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="1.1.0" />
+    <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.1.1" />
+    <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="1.3.2" />
+    <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="1.1.1" />
   </ItemGroup>
 </Project>

--- a/examples/ServerlessApi/test/LambdaPowertoolsAPI.Tests/LambdaPowertoolsAPI.Tests.csproj
+++ b/examples/ServerlessApi/test/LambdaPowertoolsAPI.Tests/LambdaPowertoolsAPI.Tests.csproj
@@ -19,10 +19,13 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.6.0" />
-    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.7" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\LambdaPowertoolsAPI\LambdaPowertoolsAPI.csproj" />

--- a/examples/Tracing/src/HelloWorld/HelloWorld.csproj
+++ b/examples/Tracing/src/HelloWorld/HelloWorld.csproj
@@ -6,11 +6,11 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
-        <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.5.0" />
+        <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.6.0" />
         <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
-        <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.1.0" />
-        <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="1.1.0" />
+        <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.1.1" />
+        <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="1.1.1" />
         <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.101.14" />
-        <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.11.0" />
+        <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.12.0" />
     </ItemGroup>
 </Project>

--- a/examples/Tracing/test/HelloWorld.Test/HelloWorld.Tests.csproj
+++ b/examples/Tracing/test/HelloWorld.Test/HelloWorld.Tests.csproj
@@ -7,10 +7,10 @@
 		<PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
 		<PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
 		<PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.101.14" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0-preview-20221221-03" />
-		<PackageReference Include="Moq" Version="4.18.3" />
-		<PackageReference Include="xunit" Version="2.4.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+		<PackageReference Include="NSubstitute" Version="5.0.0" />
+		<PackageReference Include="xunit" Version="2.5.0" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/libraries/tests/AWS.Lambda.Powertools.Common.Tests/AWS.Lambda.Powertools.Common.Tests.csproj
+++ b/libraries/tests/AWS.Lambda.Powertools.Common.Tests/AWS.Lambda.Powertools.Common.Tests.csproj
@@ -12,7 +12,7 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0-preview-20221221-03" />
-        <PackageReference Include="Moq" Version="4.18.4" />
+        <PackageReference Include="NSubstitute" Version="5.0.0" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <PrivateAssets>all</PrivateAssets>

--- a/libraries/tests/AWS.Lambda.Powertools.Common.Tests/AWS.Lambda.Powertools.Common.Tests.csproj
+++ b/libraries/tests/AWS.Lambda.Powertools.Common.Tests/AWS.Lambda.Powertools.Common.Tests.csproj
@@ -7,14 +7,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="3.2.0">
+        <PackageReference Include="coverlet.collector" Version="6.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0-preview-20221221-03" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
         <PackageReference Include="NSubstitute" Version="5.0.0" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Include="xunit" Version="2.5.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/libraries/tests/AWS.Lambda.Powertools.Common.Tests/Core/PowertoolsConfigurationsTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Common.Tests/Core/PowertoolsConfigurationsTest.cs
@@ -14,7 +14,7 @@
  */
 
 using System;
-using Moq;
+using NSubstitute;
 using Xunit;
 
 namespace AWS.Lambda.Powertools.Common.Tests
@@ -29,22 +29,17 @@ namespace AWS.Lambda.Powertools.Common.Tests
             // Arrange
             var key = Guid.NewGuid().ToString();
             var defaultValue = Guid.NewGuid().ToString();
-            var systemWrapper = new Mock<ISystemWrapper>();
+            var systemWrapper = Substitute.For<ISystemWrapper>();
 
-            systemWrapper.Setup(c =>
-                c.GetEnvironmentVariable(key)
-            ).Returns(string.Empty);
-            
-            var configurations = new PowertoolsConfigurations(systemWrapper.Object);
+            systemWrapper.GetEnvironmentVariable(key).Returns(string.Empty);
+
+            var configurations = new PowertoolsConfigurations(systemWrapper);
             
             // Act
             var result = configurations.GetEnvironmentVariableOrDefault(key, defaultValue);
 
             // Assert
-            systemWrapper.Verify(v =>
-                v.GetEnvironmentVariable(
-                    It.Is<string>(i => i == key)
-                ), Times.Once);
+            systemWrapper.Received(1).GetEnvironmentVariable(key);
             
             Assert.Equal(result, defaultValue);
         }
@@ -54,51 +49,41 @@ namespace AWS.Lambda.Powertools.Common.Tests
         {
             // Arrange
             var key = Guid.NewGuid().ToString();
-            var systemWrapper = new Mock<ISystemWrapper>();
+            var systemWrapper = Substitute.For<ISystemWrapper>();
 
-            systemWrapper.Setup(c =>
-                c.GetEnvironmentVariable(key)
-            ).Returns(string.Empty);
-            
-            var configurations = new PowertoolsConfigurations(systemWrapper.Object);
+            systemWrapper.GetEnvironmentVariable(key).Returns(string.Empty);
+
+            var configurations = new PowertoolsConfigurations(systemWrapper);
             
             // Act
             var result = configurations.GetEnvironmentVariableOrDefault(key, false);
 
             // Assert
-            systemWrapper.Verify(v =>
-                v.GetEnvironmentVariable(
-                    It.Is<string>(i => i == key)
-                ), Times.Once);
+            systemWrapper.Received(1).GetEnvironmentVariable(key);
             
             Assert.False(result);
         }
-        
+
         [Fact]
         public void GetEnvironmentVariableOrDefault_WhenEnvironmentVariableIsNull_ReturnsDefaultValueTrue()
         {
             // Arrange
             var key = Guid.NewGuid().ToString();
-            var systemWrapper = new Mock<ISystemWrapper>();
+            var systemWrapper = Substitute.For<ISystemWrapper>();
 
-            systemWrapper.Setup(c =>
-                c.GetEnvironmentVariable(key)
-            ).Returns(string.Empty);
-            
-            var configurations = new PowertoolsConfigurations(systemWrapper.Object);
-            
+            systemWrapper.GetEnvironmentVariable(key).Returns(string.Empty);
+
+            var configurations = new PowertoolsConfigurations(systemWrapper);
+
             // Act
             var result = configurations.GetEnvironmentVariableOrDefault(key, true);
 
             // Assert
-            systemWrapper.Verify(v =>
-                v.GetEnvironmentVariable(
-                    It.Is<string>(i => i == key)
-                ), Times.Once);
+            systemWrapper.Received(1).GetEnvironmentVariable(Arg.Is<string>(i => i == key));
             
             Assert.True(result);
         }
-        
+
         [Fact]
         public void GetEnvironmentVariableOrDefault_WhenEnvironmentVariableHasValue_ReturnsValueString()
         {
@@ -106,22 +91,17 @@ namespace AWS.Lambda.Powertools.Common.Tests
             var key = Guid.NewGuid().ToString();
             var defaultValue = Guid.NewGuid().ToString();
             var value = Guid.NewGuid().ToString();
-            var systemWrapper = new Mock<ISystemWrapper>();
-
-            systemWrapper.Setup(c =>
-                c.GetEnvironmentVariable(key)
-            ).Returns(value);
+            var systemWrapper = Substitute.For<ISystemWrapper>();
             
-            var configurations = new PowertoolsConfigurations(systemWrapper.Object);
+            systemWrapper.GetEnvironmentVariable(key).Returns(value);
+
+            var configurations = new PowertoolsConfigurations(systemWrapper);
             
             // Act
             var result = configurations.GetEnvironmentVariableOrDefault(key, defaultValue);
 
             // Assert
-            systemWrapper.Verify(v =>
-                v.GetEnvironmentVariable(
-                    It.Is<string>(i => i == key)
-                ), Times.Once);
+            systemWrapper.Received(1).GetEnvironmentVariable(Arg.Is<string>(i => i == key));
             
             Assert.Equal(result, value);
         }
@@ -131,22 +111,17 @@ namespace AWS.Lambda.Powertools.Common.Tests
         {
             // Arrange
             var key = Guid.NewGuid().ToString();
-            var systemWrapper = new Mock<ISystemWrapper>();
+            var systemWrapper = Substitute.For<ISystemWrapper>();
 
-            systemWrapper.Setup(c =>
-                c.GetEnvironmentVariable(key)
-            ).Returns("true");
-            
-            var configurations = new PowertoolsConfigurations(systemWrapper.Object);
+            systemWrapper.GetEnvironmentVariable(key).Returns("true");
+
+            var configurations = new PowertoolsConfigurations(systemWrapper);
             
             // Act
             var result = configurations.GetEnvironmentVariableOrDefault(key, false);
 
             // Assert
-            systemWrapper.Verify(v =>
-                v.GetEnvironmentVariable(
-                    It.Is<string>(i => i == key)
-                ), Times.Once);
+            systemWrapper.Received(1).GetEnvironmentVariable(Arg.Is<string>(i => i == key));
             
             Assert.True(result);
         }
@@ -156,22 +131,17 @@ namespace AWS.Lambda.Powertools.Common.Tests
         {
             // Arrange
             var key = Guid.NewGuid().ToString();
-            var systemWrapper = new Mock<ISystemWrapper>();
+            var systemWrapper = Substitute.For<ISystemWrapper>();
 
-            systemWrapper.Setup(c =>
-                c.GetEnvironmentVariable(key)
-            ).Returns("false");
+            systemWrapper.GetEnvironmentVariable(key).Returns("false");
             
-            var configurations = new PowertoolsConfigurations(systemWrapper.Object);
+            var configurations = new PowertoolsConfigurations(systemWrapper);
             
             // Act
             var result = configurations.GetEnvironmentVariableOrDefault(key, true);
 
             // Assert
-            systemWrapper.Verify(v =>
-                v.GetEnvironmentVariable(
-                    It.Is<string>(i => i == key)
-                ), Times.Once);
+            systemWrapper.Received(1).GetEnvironmentVariable(Arg.Is<string>(i => i == key));
             
             Assert.False(result);
         }
@@ -185,47 +155,37 @@ namespace AWS.Lambda.Powertools.Common.Tests
         {
             // Arrange
             var defaultService = "service_undefined";
-            var systemWrapper = new Mock<ISystemWrapper>();
+            var systemWrapper = Substitute.For<ISystemWrapper>();
 
-            systemWrapper.Setup(c =>
-                c.GetEnvironmentVariable(Constants.ServiceNameEnv)
-            ).Returns(string.Empty);
-            
-            var configurations = new PowertoolsConfigurations(systemWrapper.Object);
-            
+            systemWrapper.GetEnvironmentVariable(Constants.ServiceNameEnv).Returns(string.Empty);
+
+            var configurations = new PowertoolsConfigurations(systemWrapper);
+
             // Act
             var result = configurations.Service;
 
             // Assert
-            systemWrapper.Verify(v =>
-                v.GetEnvironmentVariable(
-                    It.Is<string>(i => i == Constants.ServiceNameEnv)
-                ), Times.Once);
+            systemWrapper.Received(1).GetEnvironmentVariable(Arg.Is<string>(i => i == Constants.ServiceNameEnv));
             
             Assert.Equal(result, defaultService);
         }
-        
+
         [Fact]
         public void Service_WhenEnvironmentHasValue_ReturnsValue()
         {
             // Arrange
             var service = Guid.NewGuid().ToString();
-            var systemWrapper = new Mock<ISystemWrapper>();
+            var systemWrapper = Substitute.For<ISystemWrapper>();
 
-            systemWrapper.Setup(c =>
-                c.GetEnvironmentVariable(Constants.ServiceNameEnv)
-            ).Returns(service);
-            
-            var configurations = new PowertoolsConfigurations(systemWrapper.Object);
+            systemWrapper.GetEnvironmentVariable(Constants.ServiceNameEnv).Returns(service);
+
+            var configurations = new PowertoolsConfigurations(systemWrapper);
             
             // Act
             var result = configurations.Service;
 
             // Assert
-            systemWrapper.Verify(v =>
-                v.GetEnvironmentVariable(
-                    It.Is<string>(i => i == Constants.ServiceNameEnv)
-                ), Times.Once);
+            systemWrapper.Received(1).GetEnvironmentVariable(Arg.Is<string>(i => i == Constants.ServiceNameEnv));
             
             Assert.Equal(result, service);
         }
@@ -239,22 +199,17 @@ namespace AWS.Lambda.Powertools.Common.Tests
         {
             // Arrange
             var service = Guid.NewGuid().ToString();
-            var systemWrapper = new Mock<ISystemWrapper>();
+            var systemWrapper = Substitute.For<ISystemWrapper>();
 
-            systemWrapper.Setup(c =>
-                c.GetEnvironmentVariable(Constants.ServiceNameEnv)
-            ).Returns(service);
-            
-            var configurations = new PowertoolsConfigurations(systemWrapper.Object);
+            systemWrapper.GetEnvironmentVariable(Constants.ServiceNameEnv).Returns(service);
+           
+            var configurations = new PowertoolsConfigurations(systemWrapper);
             
             // Act
             var result = configurations.IsServiceDefined;
 
             // Assert
-            systemWrapper.Verify(v =>
-                v.GetEnvironmentVariable(
-                    It.Is<string>(i => i == Constants.ServiceNameEnv)
-                ), Times.Once);
+            systemWrapper.Received(1).GetEnvironmentVariable(Arg.Is<string>(i => i == Constants.ServiceNameEnv));
             
             Assert.True(result);
         }
@@ -263,22 +218,17 @@ namespace AWS.Lambda.Powertools.Common.Tests
         public void IsServiceDefined_WhenEnvironmentDoesNotHaveValue_ReturnsFalse()
         {
             // Arrange
-            var systemWrapper = new Mock<ISystemWrapper>();
+            var systemWrapper = Substitute.For<ISystemWrapper>();
 
-            systemWrapper.Setup(c =>
-                c.GetEnvironmentVariable(Constants.ServiceNameEnv)
-            ).Returns(string.Empty);
-            
-            var configurations = new PowertoolsConfigurations(systemWrapper.Object);
+            systemWrapper.GetEnvironmentVariable(Constants.ServiceNameEnv).Returns(string.Empty);
+
+            var configurations = new PowertoolsConfigurations(systemWrapper);
             
             // Act
             var result = configurations.IsServiceDefined;
 
             // Assert
-            systemWrapper.Verify(v =>
-                v.GetEnvironmentVariable(
-                    It.Is<string>(i => i == Constants.ServiceNameEnv)
-                ), Times.Once);
+            systemWrapper.Received(1).GetEnvironmentVariable(Arg.Is<string>(i => i == Constants.ServiceNameEnv));
             
             Assert.False(result);
         }
@@ -291,70 +241,58 @@ namespace AWS.Lambda.Powertools.Common.Tests
         public void TracerCaptureResponse_WhenEnvironmentIsNull_ReturnsDefaultValue()
         {
             // Arrange
-            var systemWrapper = new Mock<ISystemWrapper>();
+            var systemWrapper = Substitute.For<ISystemWrapper>();
 
-            systemWrapper.Setup(c =>
-                c.GetEnvironmentVariable(Constants.TracerCaptureResponseEnv)
-            ).Returns(string.Empty);
-            
-            var configurations = new PowertoolsConfigurations(systemWrapper.Object);
-            
+            systemWrapper.GetEnvironmentVariable(Constants.TracerCaptureResponseEnv).Returns(string.Empty);
+
+            var configurations = new PowertoolsConfigurations(systemWrapper);
+
             // Act
             var result = configurations.TracerCaptureResponse;
 
             // Assert
-            systemWrapper.Verify(v =>
-                v.GetEnvironmentVariable(
-                    It.Is<string>(i => i == Constants.TracerCaptureResponseEnv)
-                ), Times.Once);
-            
+            systemWrapper.Received(1)
+                .GetEnvironmentVariable(Arg.Is<string>(i => i == Constants.TracerCaptureResponseEnv));
+
             Assert.True(result);
         }
-        
+
         [Fact]
         public void TracerCaptureResponse_WhenEnvironmentHasValue_ReturnsValueFalse()
         {
             // Arrange
-            var systemWrapper = new Mock<ISystemWrapper>();
+            var systemWrapper = Substitute.For<ISystemWrapper>();
 
-            systemWrapper.Setup(c =>
-                c.GetEnvironmentVariable(Constants.TracerCaptureResponseEnv)
-            ).Returns("false");
-            
-            var configurations = new PowertoolsConfigurations(systemWrapper.Object);
-            
+            systemWrapper.GetEnvironmentVariable(Constants.TracerCaptureResponseEnv).Returns("false");
+
+            var configurations = new PowertoolsConfigurations(systemWrapper);
+
             // Act
             var result = configurations.TracerCaptureResponse;
 
             // Assert
-            systemWrapper.Verify(v =>
-                v.GetEnvironmentVariable(
-                    It.Is<string>(i => i == Constants.TracerCaptureResponseEnv)
-                ), Times.Once);
+            systemWrapper.Received(1)
+                .GetEnvironmentVariable(Arg.Is<string>(i => i == Constants.TracerCaptureResponseEnv));
             
             Assert.False(result);
         }
-        
+
         [Fact]
         public void TracerCaptureResponse_WhenEnvironmentHasValue_ReturnsValueTrue()
         {
             // Arrange
-            var systemWrapper = new Mock<ISystemWrapper>();
+            var systemWrapper = Substitute.For<ISystemWrapper>();
 
-            systemWrapper.Setup(c =>
-                c.GetEnvironmentVariable(Constants.TracerCaptureResponseEnv)
-            ).Returns("true");
-            
-            var configurations = new PowertoolsConfigurations(systemWrapper.Object);
+            systemWrapper.GetEnvironmentVariable(Constants.TracerCaptureResponseEnv).Returns("true");
+
+            var configurations = new PowertoolsConfigurations(systemWrapper);
             
             // Act
             var result = configurations.TracerCaptureResponse;
 
             // Assert
-            systemWrapper.Verify(v =>
-                v.GetEnvironmentVariable(
-                    It.Is<string>(i => i == Constants.TracerCaptureResponseEnv)
-                ), Times.Once);
+            systemWrapper.Received(1)
+                .GetEnvironmentVariable(Arg.Is<string>(i => i == Constants.TracerCaptureResponseEnv));
             
             Assert.True(result);
         }
@@ -367,22 +305,18 @@ namespace AWS.Lambda.Powertools.Common.Tests
         public void TracerCaptureError_WhenEnvironmentIsNull_ReturnsDefaultValue()
         {
             // Arrange
-            var systemWrapper = new Mock<ISystemWrapper>();
+            var systemWrapper = Substitute.For<ISystemWrapper>();
 
-            systemWrapper.Setup(c =>
-                c.GetEnvironmentVariable(Constants.TracerCaptureErrorEnv)
-            ).Returns(string.Empty);
-            
-            var configurations = new PowertoolsConfigurations(systemWrapper.Object);
+            systemWrapper.GetEnvironmentVariable(Constants.TracerCaptureErrorEnv).Returns(string.Empty);
+          
+            var configurations = new PowertoolsConfigurations(systemWrapper);
             
             // Act
             var result = configurations.TracerCaptureError;
 
             // Assert
-            systemWrapper.Verify(v =>
-                v.GetEnvironmentVariable(
-                    It.Is<string>(i => i == Constants.TracerCaptureErrorEnv)
-                ), Times.Once);
+            systemWrapper.Received(1)
+                .GetEnvironmentVariable(Arg.Is<string>(i => i == Constants.TracerCaptureErrorEnv));
             
             Assert.True(result);
         }
@@ -391,22 +325,18 @@ namespace AWS.Lambda.Powertools.Common.Tests
         public void TracerCaptureError_WhenEnvironmentHasValue_ReturnsValueFalse()
         {
             // Arrange
-            var systemWrapper = new Mock<ISystemWrapper>();
+            var systemWrapper = Substitute.For<ISystemWrapper>();
 
-            systemWrapper.Setup(c =>
-                c.GetEnvironmentVariable(Constants.TracerCaptureErrorEnv)
-            ).Returns("false");
-            
-            var configurations = new PowertoolsConfigurations(systemWrapper.Object);
+            systemWrapper.GetEnvironmentVariable(Constants.TracerCaptureErrorEnv).Returns("false");
+
+            var configurations = new PowertoolsConfigurations(systemWrapper);
             
             // Act
             var result = configurations.TracerCaptureError;
 
             // Assert
-            systemWrapper.Verify(v =>
-                v.GetEnvironmentVariable(
-                    It.Is<string>(i => i == Constants.TracerCaptureErrorEnv)
-                ), Times.Once);
+            systemWrapper.Received(1)
+                .GetEnvironmentVariable(Arg.Is<string>(i => i == Constants.TracerCaptureErrorEnv));
             
             Assert.False(result);
         }
@@ -415,22 +345,18 @@ namespace AWS.Lambda.Powertools.Common.Tests
         public void TracerCaptureError_WhenEnvironmentHasValue_ReturnsValueTrue()
         {
             // Arrange
-            var systemWrapper = new Mock<ISystemWrapper>();
-
-            systemWrapper.Setup(c =>
-                c.GetEnvironmentVariable(Constants.TracerCaptureErrorEnv)
-            ).Returns("true");
+            var systemWrapper = Substitute.For<ISystemWrapper>();
             
-            var configurations = new PowertoolsConfigurations(systemWrapper.Object);
+            systemWrapper.GetEnvironmentVariable(Constants.TracerCaptureErrorEnv).Returns("true");
+
+            var configurations = new PowertoolsConfigurations(systemWrapper);
             
             // Act
             var result = configurations.TracerCaptureError;
 
             // Assert
-            systemWrapper.Verify(v =>
-                v.GetEnvironmentVariable(
-                    It.Is<string>(i => i == Constants.TracerCaptureErrorEnv)
-                ), Times.Once);
+            systemWrapper.Received(1)
+                .GetEnvironmentVariable(Arg.Is<string>(i => i == Constants.TracerCaptureErrorEnv));
             
             Assert.True(result);
         }
@@ -443,22 +369,18 @@ namespace AWS.Lambda.Powertools.Common.Tests
         public void IsSamLocal_WhenEnvironmentIsNull_ReturnsDefaultValue()
         {
             // Arrange
-            var systemWrapper = new Mock<ISystemWrapper>();
+            var systemWrapper = Substitute.For<ISystemWrapper>();
 
-            systemWrapper.Setup(c =>
-                c.GetEnvironmentVariable(Constants.SamLocalEnv)
-            ).Returns(string.Empty);
-            
-            var configurations = new PowertoolsConfigurations(systemWrapper.Object);
+            systemWrapper.GetEnvironmentVariable(Constants.SamLocalEnv).Returns(string.Empty);
+
+            var configurations = new PowertoolsConfigurations(systemWrapper);
             
             // Act
             var result = configurations.IsSamLocal;
 
             // Assert
-            systemWrapper.Verify(v =>
-                v.GetEnvironmentVariable(
-                    It.Is<string>(i => i == Constants.SamLocalEnv)
-                ), Times.Once);
+            systemWrapper.Received(1)
+                .GetEnvironmentVariable(Arg.Is<string>(i => i == Constants.SamLocalEnv));
             
             Assert.False(result);
         }
@@ -467,22 +389,18 @@ namespace AWS.Lambda.Powertools.Common.Tests
         public void IsSamLocal_WhenEnvironmentHasValue_ReturnsValueFalse()
         {
             // Arrange
-            var systemWrapper = new Mock<ISystemWrapper>();
+            var systemWrapper = Substitute.For<ISystemWrapper>();
 
-            systemWrapper.Setup(c =>
-                c.GetEnvironmentVariable(Constants.SamLocalEnv)
-            ).Returns("false");
-            
-            var configurations = new PowertoolsConfigurations(systemWrapper.Object);
+            systemWrapper.GetEnvironmentVariable(Constants.SamLocalEnv).Returns("false");
+
+            var configurations = new PowertoolsConfigurations(systemWrapper);
             
             // Act
             var result = configurations.IsSamLocal;
 
             // Assert
-            systemWrapper.Verify(v =>
-                v.GetEnvironmentVariable(
-                    It.Is<string>(i => i == Constants.SamLocalEnv)
-                ), Times.Once);
+            systemWrapper.Received(1)
+                .GetEnvironmentVariable(Arg.Is<string>(i => i == Constants.SamLocalEnv));
             
             Assert.False(result);
         }
@@ -491,22 +409,18 @@ namespace AWS.Lambda.Powertools.Common.Tests
         public void IsSamLocal_WhenEnvironmentHasValue_ReturnsValueTrue()
         {
             // Arrange
-            var systemWrapper = new Mock<ISystemWrapper>();
+            var systemWrapper = Substitute.For<ISystemWrapper>();
 
-            systemWrapper.Setup(c =>
-                c.GetEnvironmentVariable(Constants.SamLocalEnv)
-            ).Returns("true");
-            
-            var configurations = new PowertoolsConfigurations(systemWrapper.Object);
+            systemWrapper.GetEnvironmentVariable(Constants.SamLocalEnv).Returns("true");
+
+            var configurations = new PowertoolsConfigurations(systemWrapper);
             
             // Act
             var result = configurations.IsSamLocal;
 
             // Assert
-            systemWrapper.Verify(v =>
-                v.GetEnvironmentVariable(
-                    It.Is<string>(i => i == Constants.SamLocalEnv)
-                ), Times.Once);
+            systemWrapper.Received(1)
+                .GetEnvironmentVariable(Arg.Is<string>(i => i == Constants.SamLocalEnv));
             
             Assert.True(result);
         }
@@ -519,22 +433,18 @@ namespace AWS.Lambda.Powertools.Common.Tests
         public void TracingDisabled_WhenEnvironmentIsNull_ReturnsDefaultValue()
         {
             // Arrange
-            var systemWrapper = new Mock<ISystemWrapper>();
+            var systemWrapper = Substitute.For<ISystemWrapper>();
 
-            systemWrapper.Setup(c =>
-                c.GetEnvironmentVariable(Constants.TracingDisabledEnv)
-            ).Returns(string.Empty);
-            
-            var configurations = new PowertoolsConfigurations(systemWrapper.Object);
+            systemWrapper.GetEnvironmentVariable(Constants.TracingDisabledEnv).Returns(string.Empty);
+
+            var configurations = new PowertoolsConfigurations(systemWrapper);
             
             // Act
             var result = configurations.TracingDisabled;
 
             // Assert
-            systemWrapper.Verify(v =>
-                v.GetEnvironmentVariable(
-                    It.Is<string>(i => i == Constants.TracingDisabledEnv)
-                ), Times.Once);
+            systemWrapper.Received(1)
+                .GetEnvironmentVariable(Arg.Is<string>(i => i == Constants.TracingDisabledEnv));
             
             Assert.False(result);
         }
@@ -543,23 +453,19 @@ namespace AWS.Lambda.Powertools.Common.Tests
         public void TracingDisabled_WhenEnvironmentHasValue_ReturnsValueFalse()
         {
             // Arrange
-            var systemWrapper = new Mock<ISystemWrapper>();
-
-            systemWrapper.Setup(c =>
-                c.GetEnvironmentVariable(Constants.TracingDisabledEnv)
-            ).Returns("false");
+            var systemWrapper = Substitute.For<ISystemWrapper>();
             
-            var configurations = new PowertoolsConfigurations(systemWrapper.Object);
+            systemWrapper.GetEnvironmentVariable(Constants.TracingDisabledEnv).Returns("false");
+            
+            var configurations = new PowertoolsConfigurations(systemWrapper);
             
             // Act
             var result = configurations.TracingDisabled;
 
             // Assert
-            systemWrapper.Verify(v =>
-                v.GetEnvironmentVariable(
-                    It.Is<string>(i => i == Constants.TracingDisabledEnv)
-                ), Times.Once);
-            
+            systemWrapper.Received(1)
+                .GetEnvironmentVariable(Arg.Is<string>(i => i == Constants.TracingDisabledEnv));
+
             Assert.False(result);
         }
         
@@ -567,23 +473,19 @@ namespace AWS.Lambda.Powertools.Common.Tests
         public void TracingDisabled_WhenEnvironmentHasValue_ReturnsValueTrue()
         {
             // Arrange
-            var systemWrapper = new Mock<ISystemWrapper>();
-
-            systemWrapper.Setup(c =>
-                c.GetEnvironmentVariable(Constants.TracingDisabledEnv)
-            ).Returns("true");
+            var systemWrapper = Substitute.For<ISystemWrapper>();
             
-            var configurations = new PowertoolsConfigurations(systemWrapper.Object);
+            systemWrapper.GetEnvironmentVariable(Constants.TracingDisabledEnv).Returns("true");
+            
+            var configurations = new PowertoolsConfigurations(systemWrapper);
             
             // Act
             var result = configurations.TracingDisabled;
 
             // Assert
-            systemWrapper.Verify(v =>
-                v.GetEnvironmentVariable(
-                    It.Is<string>(i => i == Constants.TracingDisabledEnv)
-                ), Times.Once);
-            
+            systemWrapper.Received(1)
+                .GetEnvironmentVariable(Arg.Is<string>(i => i == Constants.TracingDisabledEnv));
+
             Assert.True(result);
         }
         
@@ -595,23 +497,19 @@ namespace AWS.Lambda.Powertools.Common.Tests
         public void IsLambdaEnvironment_WhenEnvironmentIsNull_ReturnsFalse()
         {
             // Arrange
-            var systemWrapper = new Mock<ISystemWrapper>();
+            var systemWrapper = Substitute.For<ISystemWrapper>();
 
-            systemWrapper.Setup(c =>
-                c.GetEnvironmentVariable(Constants.LambdaTaskRoot)
-            ).Returns((string)null);
-            
-            var configurations = new PowertoolsConfigurations(systemWrapper.Object);
+            systemWrapper.GetEnvironmentVariable(Constants.LambdaTaskRoot).Returns((string)null);
+
+            var configurations = new PowertoolsConfigurations(systemWrapper);
             
             // Act
             var result = configurations.IsLambdaEnvironment;
 
             // Assert
-            systemWrapper.Verify(v =>
-                v.GetEnvironmentVariable(
-                    It.Is<string>(i => i == Constants.LambdaTaskRoot)
-                ), Times.Once);
-            
+            systemWrapper.Received(1)
+                .GetEnvironmentVariable(Arg.Is<string>(i => i == Constants.LambdaTaskRoot));
+           
             Assert.False(result);
         }
         
@@ -619,22 +517,18 @@ namespace AWS.Lambda.Powertools.Common.Tests
         public void IsLambdaEnvironment_WhenEnvironmentHasValue_ReturnsTrue()
         {
             // Arrange
-            var systemWrapper = new Mock<ISystemWrapper>();
+            var systemWrapper = Substitute.For<ISystemWrapper>();
 
-            systemWrapper.Setup(c =>
-                c.GetEnvironmentVariable(Constants.LambdaTaskRoot)
-            ).Returns(Guid.NewGuid().ToString);
+            systemWrapper.GetEnvironmentVariable(Constants.TracingDisabledEnv).Returns(Guid.NewGuid().ToString());
             
-            var configurations = new PowertoolsConfigurations(systemWrapper.Object);
+            var configurations = new PowertoolsConfigurations(systemWrapper);
             
             // Act
             var result = configurations.IsLambdaEnvironment;
 
             // Assert
-            systemWrapper.Verify(v =>
-                v.GetEnvironmentVariable(
-                    It.Is<string>(i => i == Constants.LambdaTaskRoot)
-                ), Times.Once);
+            systemWrapper.Received(1)
+                .GetEnvironmentVariable(Arg.Is<string>(i => i == Constants.LambdaTaskRoot));
             
             Assert.True(result);
         }
@@ -643,24 +537,21 @@ namespace AWS.Lambda.Powertools.Common.Tests
         public void Set_Lambda_Execution_Context()
         {
             // Arrange
-            var systemWrapper = new Mock<ISystemWrapper>();
+            var systemWrapper = Substitute.For<ISystemWrapper>();
 
             // systemWrapper.Setup(c =>
             //     c.SetExecutionEnvironment(GetType())
             // );
             
-            var configurations = new PowertoolsConfigurations(systemWrapper.Object);
+            var configurations = new PowertoolsConfigurations(systemWrapper);
             
             // Act
             configurations.SetExecutionEnvironment(typeof(PowertoolsConfigurations));
 
             // Assert
             // method with correct type was called
-            systemWrapper.Verify(v =>
-                v.SetExecutionEnvironment(
-                    It.Is<Type>(i => i == typeof(PowertoolsConfigurations))
-                ), Times.Once);
-            
+            systemWrapper.Received(1)
+                .SetExecutionEnvironment(Arg.Is<Type>(i => i == typeof(PowertoolsConfigurations)));
         }
         
         #endregion

--- a/libraries/tests/AWS.Lambda.Powertools.Common.Tests/Core/PowertoolsEnvironmentTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Common.Tests/Core/PowertoolsEnvironmentTest.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Reflection;
-using Moq;
 using Xunit;
 
 namespace AWS.Lambda.Powertools.Common.Tests;

--- a/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/AWS.Lambda.Powertools.Idempotency.Tests.csproj
+++ b/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/AWS.Lambda.Powertools.Idempotency.Tests.csproj
@@ -9,18 +9,18 @@
 
     <ItemGroup>
         <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.6.0" />
-        <PackageReference Include="FluentAssertions" Version="6.7.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+        <PackageReference Include="FluentAssertions" Version="6.11.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
         <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
         <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
-        <PackageReference Include="Moq" Version="4.18.4" />
+        <PackageReference Include="NSubstitute" Version="5.0.0" />
         <PackageReference Include="Testcontainers" Version="3.3.0" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Include="xunit" Version="2.5.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.2.0">
+        <PackageReference Include="coverlet.collector" Version="6.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Internal/IdempotentAspectTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Internal/IdempotentAspectTests.cs
@@ -14,6 +14,7 @@
  */
 
 using System;
+using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Amazon.Lambda.TestUtilities;
@@ -23,7 +24,8 @@ using AWS.Lambda.Powertools.Idempotency.Persistence;
 using AWS.Lambda.Powertools.Idempotency.Tests.Handlers;
 using AWS.Lambda.Powertools.Idempotency.Tests.Model;
 using FluentAssertions;
-using Moq;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 [assembly: CollectionBehavior(DisableTestParallelization = true)]
@@ -39,10 +41,10 @@ public class IdempotentAspectTests : IDisposable
     public async Task Handle_WhenFirstCall_ShouldPutInStore(Type type)
     {
         //Arrange
-        var store = new Mock<BasePersistenceStore>();
+        var store = Substitute.For<BasePersistenceStore>();
         Idempotency.Configure(builder =>
             builder
-                .WithPersistenceStore(store.Object)
+                .WithPersistenceStore(store)
                 .WithOptions(optionsBuilder => optionsBuilder.WithEventKeyJmesPath("Id"))
             );
         
@@ -55,12 +57,18 @@ public class IdempotentAspectTests : IDisposable
         //Assert
         basket.Products.Count.Should().Be(1);
         function.HandlerExecuted.Should().BeTrue();
+        
+        await store.Received().SaveInProgress(
+            Arg.Is<JsonDocument>(t =>
+                t.ToString() == JsonSerializer.SerializeToDocument(product, new JsonSerializerOptions()).ToString()),
+            Arg.Any<DateTimeOffset>()
+        );
 
-        store
-            .Verify(x=>x.SaveInProgress(It.Is<JsonDocument>(t=> t.ToString() == JsonSerializer.SerializeToDocument(product, It.IsAny<JsonSerializerOptions>()).ToString()), It.IsAny<DateTimeOffset>()));
-
-        store
-            .Verify(x=>x.SaveSuccess(It.IsAny<JsonDocument>(), It.Is<Basket>(y => y.Equals(basket)), It.IsAny<DateTimeOffset>()));
+        await store.Received().SaveSuccess(
+            Arg.Any<JsonDocument>(),
+            Arg.Is<Basket>(y => y.Equals(basket)),
+            Arg.Any<DateTimeOffset>()
+        );
     }
 
     [Theory]
@@ -69,14 +77,14 @@ public class IdempotentAspectTests : IDisposable
     public async Task Handle_WhenSecondCall_AndNotExpired_ShouldGetFromStore(Type type)
     {
         //Arrange
-        var store = new Mock<BasePersistenceStore>();
-        store.Setup(x=>x.SaveInProgress(It.IsAny<JsonDocument>(), It.IsAny<DateTimeOffset>()))
-            .Throws<IdempotencyItemAlreadyExistsException>();
+        var store = Substitute.For<BasePersistenceStore>();
+        store.SaveInProgress(Arg.Any<JsonDocument>(), Arg.Any<DateTimeOffset>())
+            .Returns(_ => throw new IdempotencyItemAlreadyExistsException());
     
         // GIVEN
         Idempotency.Configure(builder =>
             builder
-                .WithPersistenceStore(store.Object)
+                .WithPersistenceStore(store)
                 .WithOptions(optionsBuilder => optionsBuilder.WithEventKeyJmesPath("Id"))
             );
     
@@ -88,9 +96,8 @@ public class IdempotentAspectTests : IDisposable
             DateTimeOffset.UtcNow.AddSeconds(356).ToUnixTimeSeconds(),
             JsonSerializer.SerializeToNode(basket)!.ToString(),
             null);
-        store.Setup(x=>x.GetRecord(It.IsAny<JsonDocument>(), It.IsAny<DateTimeOffset>()))
-            .ReturnsAsync(record);
-    
+        store.GetRecord(Arg.Any<JsonDocument>(), Arg.Any<DateTimeOffset>()).Returns(record);
+
         var function = Activator.CreateInstance(type) as IIdempotencyEnabledFunction;
     
         // Act
@@ -107,15 +114,16 @@ public class IdempotentAspectTests : IDisposable
     public async Task Handle_WhenSecondCall_AndStatusInProgress_ShouldThrowIdempotencyAlreadyInProgressException(Type type)
     {
         // Arrange
-        var store = new Mock<BasePersistenceStore>();
-        
+        var store = Substitute.For<BasePersistenceStore>();
+
         Idempotency.Configure(builder =>
             builder
-                .WithPersistenceStore(store.Object)
+                .WithPersistenceStore(store)
                 .WithOptions(optionsBuilder => optionsBuilder.WithEventKeyJmesPath("Id"))
             );
-        store.Setup(x=>x.SaveInProgress(It.IsAny<JsonDocument>(), It.IsAny<DateTimeOffset>()))
-            .Throws<IdempotencyItemAlreadyExistsException>();
+        
+        store.SaveInProgress(Arg.Any<JsonDocument>(), Arg.Any<DateTimeOffset>())
+            .Returns(_ => throw new IdempotencyItemAlreadyExistsException());
     
         var product = new Product(42, "fake product", 12);
         var basket = new Basket(product);
@@ -125,9 +133,9 @@ public class IdempotentAspectTests : IDisposable
             DateTimeOffset.UtcNow.AddSeconds(356).ToUnixTimeSeconds(),
             JsonSerializer.SerializeToNode(basket)!.ToString(),
             null);
-        store.Setup(x=>x.GetRecord(It.IsAny<JsonDocument>(), It.IsAny<DateTimeOffset>()))
-            .ReturnsAsync(record);
-    
+        store.GetRecord(Arg.Any<JsonDocument>(), Arg.Any<DateTimeOffset>())
+            .Returns(record);
+
         // Act
         var function = Activator.CreateInstance(type) as IIdempotencyEnabledFunction;
         Func<Task> act = async () => await function!.HandleTest(product, new TestLambdaContext());
@@ -142,11 +150,11 @@ public class IdempotentAspectTests : IDisposable
     public async Task Handle_WhenThrowException_ShouldDeleteRecord_AndThrowFunctionException(Type type) 
     {
         // Arrange
-        var store = new Mock<BasePersistenceStore>();
+        var store = Substitute.For<BasePersistenceStore>();
     
         Idempotency.Configure(builder =>
             builder
-                .WithPersistenceStore(store.Object)
+                .WithPersistenceStore(store)
                 .WithOptions(optionsBuilder => optionsBuilder.WithEventKeyJmesPath("Id"))
             );
         
@@ -158,8 +166,7 @@ public class IdempotentAspectTests : IDisposable
     
         // Assert
         await act.Should().ThrowAsync<IndexOutOfRangeException>();
-        store.Verify(
-            x => x.DeleteRecord(It.IsAny<JsonDocument>(), It.IsAny<IndexOutOfRangeException>()));
+        await store.Received().DeleteRecord(Arg.Any<JsonDocument>(), Arg.Any<IndexOutOfRangeException>());
     }
     
     [Theory]
@@ -167,15 +174,14 @@ public class IdempotentAspectTests : IDisposable
     [InlineData(typeof(IdempotencyEnabledSyncFunction))]
     public async Task Handle_WhenIdempotencyDisabled_ShouldJustRunTheFunction(Type type)
     {
-        
         // Arrange
-        var store = new Mock<BasePersistenceStore>();
+        var store = Substitute.For<BasePersistenceStore>();
         
         Environment.SetEnvironmentVariable(Constants.IdempotencyDisabledEnv, "true");
         
         Idempotency.Configure(builder =>
             builder
-                .WithPersistenceStore(store.Object)
+                .WithPersistenceStore(store)
                 .WithOptions(optionsBuilder => optionsBuilder.WithEventKeyJmesPath("Id"))
             );
         
@@ -186,7 +192,7 @@ public class IdempotentAspectTests : IDisposable
         var basket = await function!.HandleTest(product, new TestLambdaContext());
 
         // Assert
-        store.Invocations.Count.Should().Be(0);
+        store.ReceivedCalls().Count().Should().Be(0);
         basket.Products.Count.Should().Be(1);
         function.HandlerExecuted.Should().BeTrue();
     }
@@ -198,72 +204,76 @@ public class IdempotentAspectTests : IDisposable
         var assemblyName = "AWS.Lambda.Powertools.Idempotency";
         var assemblyVersion = "1.0.0";
         
-        var env = new Mock<IPowertoolsEnvironment>();
-        env.Setup(x => x.GetAssemblyName(It.IsAny<Idempotency>())).Returns(assemblyName);
-        env.Setup(x => x.GetAssemblyVersion(It.IsAny<Idempotency>())).Returns(assemblyVersion);
+        var env = Substitute.For<IPowertoolsEnvironment>();
+        env.GetAssemblyName(Arg.Any<Idempotency>()).Returns(assemblyName);
+        env.GetAssemblyVersion(Arg.Any<Idempotency>()).Returns(assemblyVersion);
 
-        var conf = new PowertoolsConfigurations(new SystemWrapper(env.Object));
+        var conf = new PowertoolsConfigurations(new SystemWrapper(env));
         
         // Act
         var xRayRecorder = new Idempotency(conf);
 
         // Assert
-        env.Verify(v =>
-            v.SetEnvironmentVariable(
-                "AWS_EXECUTION_ENV", $"{Constants.FeatureContextIdentifier}/Idempotency/{assemblyVersion}"
-            ), Times.Once);
-            
-        env.Verify(v =>
-            v.GetEnvironmentVariable(
-                "AWS_EXECUTION_ENV"
-            ), Times.Once);
+        env.Received(1).SetEnvironmentVariable(
+            "AWS_EXECUTION_ENV",
+            $"{Constants.FeatureContextIdentifier}/Idempotency/{assemblyVersion}"
+        );
+
+        env.Received(1).GetEnvironmentVariable("AWS_EXECUTION_ENV");
         
         Assert.NotNull(xRayRecorder);
     }
-    
+
     [Fact]
-    public void Handle_WhenIdempotencyOnSubMethodAnnotated_AndFirstCall_ShouldPutInStore() 
+    public async Task Handle_WhenIdempotencyOnSubMethodAnnotated_AndFirstCall_ShouldPutInStore()
     {
         // Arrange
-        var store = new Mock<BasePersistenceStore>();
-        Idempotency.Configure(builder => builder.WithPersistenceStore(store.Object));
+        var store = Substitute.For<BasePersistenceStore>();
+        Idempotency.Configure(builder => builder.WithPersistenceStore(store));
 
         // Act
         IdempotencyInternalFunction function = new IdempotencyInternalFunction();
         Product product = new Product(42, "fake product", 12);
         Basket resultBasket = function.HandleRequest(product, new TestLambdaContext());
-    
+
         // Assert
         resultBasket.Products.Count.Should().Be(2);
         function.IsSubMethodCalled.Should().BeTrue();
-        
-        store
-            .Verify(x=>x.SaveInProgress(It.Is<JsonDocument>(t=> t.ToString() == JsonSerializer.SerializeToDocument("fake", It.IsAny<JsonSerializerOptions>()).ToString()), It.IsAny<DateTimeOffset>()));
 
-        store
-            .Verify(x=>x.SaveSuccess(It.IsAny<JsonDocument>(), It.Is<Basket>(y => y.Equals(resultBasket)), It.IsAny<DateTimeOffset>()));
+        await store
+            .Received(1)
+            .SaveInProgress(
+                Arg.Is<JsonDocument>(t =>
+                    t.ToString() == JsonSerializer.SerializeToDocument("fake", new JsonSerializerOptions())
+                        .ToString()),
+                Arg.Any<DateTimeOffset>());
+
+        await store
+            .Received(1)
+            .SaveSuccess(Arg.Any<JsonDocument>(), Arg.Is<Basket>(y => y.Equals(resultBasket)),
+                Arg.Any<DateTimeOffset>());
     }
 
     [Fact]
     public void Handle_WhenIdempotencyOnSubMethodAnnotated_AndSecondCall_AndNotExpired_ShouldGetFromStore()
     {
         // Arrange
-        var store = new Mock<BasePersistenceStore>();
-        store.Setup(x => x.SaveInProgress(It.IsAny<JsonDocument>(), It.IsAny<DateTimeOffset>()))
-            .Throws<IdempotencyItemAlreadyExistsException>();
+        var store = Substitute.For<BasePersistenceStore>();
+        store.SaveInProgress(Arg.Any<JsonDocument>(), Arg.Any<DateTimeOffset>())
+            .Throws(new IdempotencyItemAlreadyExistsException());
 
-        Idempotency.Configure(builder => builder.WithPersistenceStore(store.Object));
+        Idempotency.Configure(builder => builder.WithPersistenceStore(store));
 
-        Product product = new Product(42, "fake product", 12);
-        Basket basket = new Basket(product);
-        DataRecord record = new DataRecord(
+        var product = new Product(42, "fake product", 12);
+        var basket = new Basket(product);
+        var record = new DataRecord(
             "fake",
             DataRecord.DataRecordStatus.COMPLETED,
             DateTimeOffset.UtcNow.AddSeconds(356).ToUnixTimeSeconds(),
             JsonSerializer.SerializeToNode(basket)!.ToString(),
             null);
-        store.Setup(x => x.GetRecord(It.IsAny<JsonDocument>(), It.IsAny<DateTimeOffset>()))
-            .ReturnsAsync(record);
+        store.GetRecord(Arg.Any<JsonDocument>(), Arg.Any<DateTimeOffset>())
+            .Returns(record);
 
         // Act
         var function = new IdempotencyInternalFunction();
@@ -298,10 +308,10 @@ public class IdempotentAspectTests : IDisposable
     public void Handle_WhenIdempotencyOnSubMethodNotAnnotated_ShouldThrowException() 
     {
         // Arrange
-        var store = new Mock<BasePersistenceStore>();
+        var store = Substitute.For<BasePersistenceStore>();
         Idempotency.Configure(builder =>
             builder
-                .WithPersistenceStore(store.Object)
+                .WithPersistenceStore(store)
         );
 
         // Act
@@ -317,10 +327,10 @@ public class IdempotentAspectTests : IDisposable
     public void Handle_WhenIdempotencyOnSubMethodVoid_ShouldThrowException() 
     {
         // Arrange
-        var store = new Mock<BasePersistenceStore>();
+        var store = Substitute.For<BasePersistenceStore>();
         Idempotency.Configure(builder =>
             builder
-                .WithPersistenceStore(store.Object)
+                .WithPersistenceStore(store)
         );
 
         // Act

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/AWS.Lambda.Powertools.Logging.Tests.csproj
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/AWS.Lambda.Powertools.Logging.Tests.csproj
@@ -9,15 +9,15 @@
 
     <ItemGroup>
         <PackageReference Include="Amazon.Lambda.ApplicationLoadBalancerEvents" Version="2.1.0" />
-        <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.5.0" />
-        <PackageReference Include="coverlet.collector" Version="3.2.0">
+        <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.6.0" />
+        <PackageReference Include="coverlet.collector" Version="6.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0-preview-20221221-03" />
-        <PackageReference Include="Moq" Version="4.18.4" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+        <PackageReference Include="NSubstitute" Version="5.0.0" />
+        <PackageReference Include="xunit" Version="2.5.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/LoggingAttributeTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/LoggingAttributeTest.cs
@@ -21,7 +21,7 @@ using Amazon.Lambda.ApplicationLoadBalancerEvents;
 using AWS.Lambda.Powertools.Common;
 using AWS.Lambda.Powertools.Logging.Internal;
 using Microsoft.Extensions.Logging;
-using Moq;
+using NSubstitute;
 using Xunit;
 
 [assembly: CollectionBehavior(DisableTestParallelization = true)]
@@ -38,42 +38,41 @@ namespace AWS.Lambda.Powertools.Logging.Tests
             var methodName = Guid.NewGuid().ToString();
             var service = Guid.NewGuid().ToString();
             var logLevel = LogLevel.Information;
-            
-            var configurations = new Mock<IPowertoolsConfigurations>();
-            var systemWrapper = new Mock<ISystemWrapper>();
-            
+
+            var configurations = Substitute.For<IPowertoolsConfigurations>();
+            var systemWrapper = Substitute.For<ISystemWrapper>();
+
             var eventArgs = new AspectEventArgs
             {
                 Name = methodName,
-                Args = new object [] { }
+                Args = Array.Empty<object>()
             };
-            
+
             LoggingAspectHandler.ResetForTest();
-            var handler = new LoggingAspectHandler(service, logLevel, null, null, true, null, true, configurations.Object,
-                systemWrapper.Object);
+            var handler = new LoggingAspectHandler(service, logLevel, null, null, true, null, true, configurations,
+                systemWrapper);
 
             // Act
             handler.OnEntry(eventArgs);
 
             var allKeys = Logger.GetAllKeys()
                 .ToDictionary(keyValuePair => keyValuePair.Key, keyValuePair => keyValuePair.Value);
-            
+
             Assert.NotNull(Logger.LoggerProvider);
             Assert.True(allKeys.ContainsKey(LoggingConstants.KeyColdStart));
-            Assert.True((bool) allKeys[LoggingConstants.KeyColdStart]);
+            Assert.True((bool)allKeys[LoggingConstants.KeyColdStart]);
             Assert.False(allKeys.ContainsKey(LoggingConstants.KeyFunctionName));
             Assert.False(allKeys.ContainsKey(LoggingConstants.KeyFunctionVersion));
             Assert.False(allKeys.ContainsKey(LoggingConstants.KeyFunctionMemorySize));
             Assert.False(allKeys.ContainsKey(LoggingConstants.KeyFunctionArn));
             Assert.False(allKeys.ContainsKey(LoggingConstants.KeyFunctionRequestId));
-            
-            systemWrapper.Verify(v =>
-                v.LogLine(
-                    It.IsAny<string>()
-                ), Times.Never);
+
+            systemWrapper.DidNotReceive().LogLine(
+                Arg.Any<string>()
+            );
         }
     }
-    
+
     [Collection("Sequential")]
     public class LoggingAttributeTestWithoutLambdaContextDebug
     {
@@ -84,42 +83,42 @@ namespace AWS.Lambda.Powertools.Logging.Tests
             var methodName = Guid.NewGuid().ToString();
             var service = Guid.NewGuid().ToString();
             var logLevel = LogLevel.Trace;
-            
-            var configurations = new Mock<IPowertoolsConfigurations>();
-            var systemWrapper = new Mock<ISystemWrapper>();
-            
+
+            var configurations = Substitute.For<IPowertoolsConfigurations>();
+            var systemWrapper = Substitute.For<ISystemWrapper>();
+
             var eventArgs = new AspectEventArgs
             {
                 Name = methodName,
-                Args = new object [] { }
+                Args = Array.Empty<object>()
             };
-            
+
             LoggingAspectHandler.ResetForTest();
-            var handler = new LoggingAspectHandler(service, logLevel, null, null, true, null, true, configurations.Object,
-                systemWrapper.Object);
+            var handler = new LoggingAspectHandler(service, logLevel, null, null, true, null, true, configurations,
+                systemWrapper);
 
             // Act
             handler.OnEntry(eventArgs);
 
             var allKeys = Logger.GetAllKeys()
                 .ToDictionary(keyValuePair => keyValuePair.Key, keyValuePair => keyValuePair.Value);
-            
+
             Assert.NotNull(Logger.LoggerProvider);
             Assert.True(allKeys.ContainsKey(LoggingConstants.KeyColdStart));
-            Assert.True((bool) allKeys[LoggingConstants.KeyColdStart]);
+            Assert.True((bool)allKeys[LoggingConstants.KeyColdStart]);
             Assert.False(allKeys.ContainsKey(LoggingConstants.KeyFunctionName));
             Assert.False(allKeys.ContainsKey(LoggingConstants.KeyFunctionVersion));
             Assert.False(allKeys.ContainsKey(LoggingConstants.KeyFunctionMemorySize));
             Assert.False(allKeys.ContainsKey(LoggingConstants.KeyFunctionArn));
             Assert.False(allKeys.ContainsKey(LoggingConstants.KeyFunctionRequestId));
-            
-            systemWrapper.Verify(v =>
-                v.LogLine(
-                    It.Is<string>(i => i == $"Skipping Lambda Context injection because ILambdaContext context parameter not found.")
-                ), Times.Once);
+
+            systemWrapper.Received(1).LogLine(
+                Arg.Is<string>(i =>
+                    i == $"Skipping Lambda Context injection because ILambdaContext context parameter not found.")
+            );
         }
     }
-    
+
     [Collection("Sequential")]
     public class LoggingAttributeTestWithoutEventArg
     {
@@ -130,30 +129,29 @@ namespace AWS.Lambda.Powertools.Logging.Tests
             var methodName = Guid.NewGuid().ToString();
             var service = Guid.NewGuid().ToString();
             var logLevel = LogLevel.Information;
-            
-            var configurations = new Mock<IPowertoolsConfigurations>();
-            var systemWrapper = new Mock<ISystemWrapper>();
-            
+
+            var configurations = Substitute.For<IPowertoolsConfigurations>();
+            var systemWrapper = Substitute.For<ISystemWrapper>();
+
             var eventArgs = new AspectEventArgs
             {
                 Name = methodName,
-                Args = new object [] { }
+                Args = Array.Empty<object>()
             };
-            
+
             LoggingAspectHandler.ResetForTest();
-            var handler = new LoggingAspectHandler(service, logLevel, null, null, true, null, true, configurations.Object,
-                systemWrapper.Object);
+            var handler = new LoggingAspectHandler(service, logLevel, null, null, true, null, true, configurations,
+                systemWrapper);
 
             // Act
             handler.OnEntry(eventArgs);
-            
-            systemWrapper.Verify(v =>
-                v.LogLine(
-                    It.IsAny<string>()
-                ), Times.Never);
+
+            systemWrapper.DidNotReceive().LogLine(
+                Arg.Any<string>()
+            );
         }
     }
-    
+
     [Collection("Sequential")]
     public class LoggingAttributeTestWithoutEventArgDebug
     {
@@ -164,30 +162,29 @@ namespace AWS.Lambda.Powertools.Logging.Tests
             var methodName = Guid.NewGuid().ToString();
             var service = Guid.NewGuid().ToString();
             var logLevel = LogLevel.Trace;
-            
-            var configurations = new Mock<IPowertoolsConfigurations>();
-            var systemWrapper = new Mock<ISystemWrapper>();
-            
+
+            var configurations = Substitute.For<IPowertoolsConfigurations>();
+            var systemWrapper = Substitute.For<ISystemWrapper>();
+
             var eventArgs = new AspectEventArgs
             {
                 Name = methodName,
-                Args = new object [] { }
+                Args = Array.Empty<object>()
             };
-            
+
             LoggingAspectHandler.ResetForTest();
-            var handler = new LoggingAspectHandler(service, logLevel, null, null, true, null, true, configurations.Object,
-                systemWrapper.Object);
+            var handler = new LoggingAspectHandler(service, logLevel, null, null, true, null, true, configurations,
+                systemWrapper);
 
             // Act
             handler.OnEntry(eventArgs);
 
-            systemWrapper.Verify(v =>
-                v.LogLine(
-                    It.Is<string>(i => i ==  $"Skipping Event Log because event parameter not found.")
-                ), Times.Once);
+            systemWrapper.Received(1).LogLine(
+                Arg.Is<string>(i => i == "Skipping Event Log because event parameter not found.")
+            );
         }
     }
-    
+
     [Collection("Sequential")]
     public class LoggingAttributeTestForClearContext
     {
@@ -198,32 +195,32 @@ namespace AWS.Lambda.Powertools.Logging.Tests
             var methodName = Guid.NewGuid().ToString();
             var service = Guid.NewGuid().ToString();
             var logLevel = LogLevel.Trace;
-            
-            var configurations = new Mock<IPowertoolsConfigurations>();
-            var systemWrapper = new Mock<ISystemWrapper>();
-            
+
+            var configurations = Substitute.For<IPowertoolsConfigurations>();
+            var systemWrapper = Substitute.For<ISystemWrapper>();
+
             var eventArgs = new AspectEventArgs
             {
                 Name = methodName,
-                Args = new object [] { }
+                Args = Array.Empty<object>()
             };
 
             LoggingAspectHandler.ResetForTest();
-            var handler = new LoggingAspectHandler(service, logLevel, null, null, true, null, true, configurations.Object,
-                systemWrapper.Object);
+            var handler = new LoggingAspectHandler(service, logLevel, null, null, true, null, true, configurations,
+                systemWrapper);
 
             // Act
             handler.OnEntry(eventArgs);
-            
+
             var allKeys = Logger.GetAllKeys()
                 .ToDictionary(keyValuePair => keyValuePair.Key, keyValuePair => keyValuePair.Value);
-            
+
             Assert.NotNull(Logger.LoggerProvider);
             Assert.True(allKeys.ContainsKey(LoggingConstants.KeyColdStart));
-            Assert.True((bool) allKeys[LoggingConstants.KeyColdStart]);
-            
+            Assert.True((bool)allKeys[LoggingConstants.KeyColdStart]);
+
             handler.OnExit(eventArgs);
-            
+
             Assert.NotNull(Logger.LoggerProvider);
             Assert.False(Logger.GetAllKeys().Any());
         }
@@ -231,15 +228,16 @@ namespace AWS.Lambda.Powertools.Logging.Tests
 
     public abstract class LoggingAttributeTestWithEventArgCorrelationId
     {
-        protected void OnEntry_WhenEventArgExists_CapturesCorrelationIdBase(string correlationId, string correlationIdPath, object eventArg)
+        protected void OnEntry_WhenEventArgExists_CapturesCorrelationIdBase(string correlationId,
+            string correlationIdPath, object eventArg)
         {
             // Arrange
             var methodName = Guid.NewGuid().ToString();
             var service = Guid.NewGuid().ToString();
             var logLevel = LogLevel.Information;
 
-            var configurations = new Mock<IPowertoolsConfigurations>();
-            var systemWrapper = new Mock<ISystemWrapper>();
+            var configurations = Substitute.For<IPowertoolsConfigurations>();
+            var systemWrapper = Substitute.For<ISystemWrapper>();
 
             var eventArgs = new AspectEventArgs
             {
@@ -249,8 +247,7 @@ namespace AWS.Lambda.Powertools.Logging.Tests
 
             LoggingAspectHandler.ResetForTest();
             var handler = new LoggingAspectHandler(service, logLevel, null, null, false, correlationIdPath,
-                true, configurations.Object,
-                systemWrapper.Object);
+                true, configurations, systemWrapper);
 
             // Act
             handler.OnEntry(eventArgs);
@@ -260,12 +257,12 @@ namespace AWS.Lambda.Powertools.Logging.Tests
 
             // Assert
             Assert.True(allKeys.ContainsKey(LoggingConstants.KeyCorrelationId));
-            Assert.Equal((string) allKeys[LoggingConstants.KeyCorrelationId], correlationId);
+            Assert.Equal((string)allKeys[LoggingConstants.KeyCorrelationId], correlationId);
         }
     }
 
     [Collection("Sequential")]
-    public class LoggingAttributeTestWithEventArgCorrelationIdAPIGateway : LoggingAttributeTestWithEventArgCorrelationId
+    public class LoggingAttributeTestWithEventArgCorrelationIdApiGateway : LoggingAttributeTestWithEventArgCorrelationId
     {
         [Fact]
         public void OnEntry_WhenEventArgExists_CapturesCorrelationId()
@@ -285,7 +282,7 @@ namespace AWS.Lambda.Powertools.Logging.Tests
             );
         }
     }
-    
+
     [Collection("Sequential")]
     public class LoggingAttributeTestWithEventArgCorrelationIdApplicationLoadBalancer : LoggingAttributeTestWithEventArgCorrelationId
     {
@@ -301,7 +298,7 @@ namespace AWS.Lambda.Powertools.Logging.Tests
                 {
                     Headers = new Dictionary<string, string>
                     {
-                        {"x-amzn-trace-id", correlationId}
+                        { "x-amzn-trace-id", correlationId }
                     }
                 }
             );

--- a/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/AWS.Lambda.Powertools.Metrics.Tests.csproj
+++ b/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/AWS.Lambda.Powertools.Metrics.Tests.csproj
@@ -13,17 +13,17 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0-preview-20221221-03" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+        <PackageReference Include="NSubstitute" Version="5.0.0" />
+        <PackageReference Include="xunit" Version="2.5.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.2.0">
+        <PackageReference Include="coverlet.collector" Version="6.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Moq" Version="4.18.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/ClearDimensionsTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/ClearDimensionsTests.cs
@@ -1,7 +1,7 @@
 using System;
 using System.IO;
 using AWS.Lambda.Powertools.Common;
-using Moq;
+using NSubstitute;
 using Xunit;
 
 namespace AWS.Lambda.Powertools.Metrics.Tests;
@@ -16,11 +16,11 @@ public class ClearDimensionsTests
         var methodName = Guid.NewGuid().ToString();
         var consoleOut = new StringWriter();
         Console.SetOut(consoleOut);
-
-        var configurations = new Mock<IPowertoolsConfigurations>();
+        
+        var configurations = Substitute.For<IPowertoolsConfigurations>();
 
         var metrics = new Metrics(
-            configurations.Object,
+            configurations,
             nameSpace: "dotnet-powertools-test",
             service: "testService"
         );

--- a/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/EMFValidationTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/EMFValidationTests.cs
@@ -18,7 +18,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using AWS.Lambda.Powertools.Common;
-using Moq;
+//using Moq;
+using NSubstitute;
 using Xunit;
 
 [assembly: CollectionBehavior(DisableTestParallelization = true)]
@@ -37,11 +38,11 @@ namespace AWS.Lambda.Powertools.Metrics.Tests
             var consoleOut = new StringWriter();
             const bool captureColdStartEnabled = true;
             Console.SetOut(consoleOut);
-
-            var configurations = new Mock<IPowertoolsConfigurations>();
+            
+            var configurations = Substitute.For<IPowertoolsConfigurations>();
 
             var metrics = new Metrics(
-                configurations.Object,
+                configurations,
                 nameSpace: "dotnet-powertools-test",
                 service: "testService",
                 captureColdStartEnabled: captureColdStartEnabled
@@ -80,10 +81,10 @@ namespace AWS.Lambda.Powertools.Metrics.Tests
             const bool captureColdStartEnabled = true;
             Console.SetOut(consoleOut);
 
-            var configurations = new Mock<IPowertoolsConfigurations>();
+            var configurations = Substitute.For<IPowertoolsConfigurations>();
 
             var logger = new Metrics(
-                configurations.Object,
+                configurations,
                 nameSpace: "dotnet-powertools-test",
                 service: "testService",
                 captureColdStartEnabled: captureColdStartEnabled
@@ -119,10 +120,10 @@ namespace AWS.Lambda.Powertools.Metrics.Tests
             var consoleOut = new StringWriter();
             Console.SetOut(consoleOut);
 
-            var configurations = new Mock<IPowertoolsConfigurations>();
+            var configurations = Substitute.For<IPowertoolsConfigurations>();
 
             var metrics = new Metrics(
-                configurations.Object,
+                configurations,
                 nameSpace: "dotnet-powertools-test",
                 service: "testService"
             );
@@ -168,10 +169,10 @@ namespace AWS.Lambda.Powertools.Metrics.Tests
             var consoleOut = new StringWriter();
             Console.SetOut(consoleOut);
 
-            var configurations = new Mock<IPowertoolsConfigurations>();
+            var configurations = Substitute.For<IPowertoolsConfigurations>();
 
             var metrics = new Metrics(
-                configurations.Object,
+                configurations,
                 nameSpace: "dotnet-powertools-test",
                 service: "testService"
             );
@@ -216,10 +217,10 @@ namespace AWS.Lambda.Powertools.Metrics.Tests
         {
             // Arrange
             var methodName = Guid.NewGuid().ToString();
-            var configurations = new Mock<IPowertoolsConfigurations>();
+            var configurations = Substitute.For<IPowertoolsConfigurations>();
 
             var metrics = new Metrics(
-                configurations.Object,
+                configurations,
                 nameSpace: "dotnet-powertools-test",
                 service: "testService"
             );
@@ -257,10 +258,10 @@ namespace AWS.Lambda.Powertools.Metrics.Tests
         {
             // Arrange
             var methodName = Guid.NewGuid().ToString();
-            var configurations = new Mock<IPowertoolsConfigurations>();
+            var configurations = Substitute.For<IPowertoolsConfigurations>();
 
             var metrics = new Metrics(
-                configurations.Object
+                configurations
             );
 
             var handler = new MetricsAspectHandler(
@@ -295,10 +296,10 @@ namespace AWS.Lambda.Powertools.Metrics.Tests
             var consoleOut = new StringWriter();
             Console.SetOut(consoleOut);
 
-            var configurations = new Mock<IPowertoolsConfigurations>();
+            var configurations = Substitute.For<IPowertoolsConfigurations>();
 
             var metrics = new Metrics(
-                configurations.Object,
+                configurations,
                 nameSpace: "dotnet-powertools-test",
                 service: "testService"
             );
@@ -334,8 +335,8 @@ namespace AWS.Lambda.Powertools.Metrics.Tests
         {
             // Arrange
             var methodName = Guid.NewGuid().ToString();
-            var configurations = new Mock<IPowertoolsConfigurations>();
-            var metrics = new Metrics(configurations.Object);
+            var configurations = Substitute.For<IPowertoolsConfigurations>();
+            var metrics = new Metrics(configurations);
 
             var handler = new MetricsAspectHandler(
                 metrics,
@@ -366,9 +367,9 @@ namespace AWS.Lambda.Powertools.Metrics.Tests
             var consoleOut = new StringWriter();
             Console.SetOut(consoleOut);
 
-            var configurations = new Mock<IPowertoolsConfigurations>();
+            var configurations = Substitute.For<IPowertoolsConfigurations>();
             var metrics = new Metrics(
-                configurations.Object,
+                configurations,
                 nameSpace: "dotnet-powertools-test",
                 service: "testService"
             );
@@ -404,10 +405,10 @@ namespace AWS.Lambda.Powertools.Metrics.Tests
             Console.SetOut(consoleOut);
 
             var defaultDimensions = new Dictionary<string, string> { { "CustomDefaultDimension", "CustomDefaultDimensionValue" } };
-            var configurations = new Mock<IPowertoolsConfigurations>();
+            var configurations = Substitute.For<IPowertoolsConfigurations>();
 
             var metrics = new Metrics(
-                configurations.Object,
+                configurations,
                 nameSpace: "dotnet-powertools-test",
                 service: "testService"
             );
@@ -441,10 +442,10 @@ namespace AWS.Lambda.Powertools.Metrics.Tests
         {
             // Arrange
             var methodName = Guid.NewGuid().ToString();
-            var configurations = new Mock<IPowertoolsConfigurations>();
+            var configurations = Substitute.For<IPowertoolsConfigurations>();
 
             var metrics = new Metrics(
-                configurations.Object,
+                configurations,
                 nameSpace: "dotnet-powertools-test",
                 service: "testService"
             );
@@ -481,11 +482,11 @@ namespace AWS.Lambda.Powertools.Metrics.Tests
             var methodName = Guid.NewGuid().ToString();
             var consoleOut = new StringWriter();
             Console.SetOut(consoleOut);
-            var configurations = new Mock<IPowertoolsConfigurations>();
+            var configurations = Substitute.For<IPowertoolsConfigurations>();
             var defaultDimensions = new Dictionary<string, string> { { "CustomDefaultDimension", "CustomDefaultDimensionValue" } };
 
             var metrics = new Metrics(
-                configurations.Object,
+                configurations,
                 nameSpace: "dotnet-powertools-test",
                 service: "testService"
             );
@@ -521,10 +522,10 @@ namespace AWS.Lambda.Powertools.Metrics.Tests
             var methodName = Guid.NewGuid().ToString();
             var consoleOut = new StringWriter();
             Console.SetOut(consoleOut);
-            var configurations = new Mock<IPowertoolsConfigurations>();
+            var configurations = Substitute.For<IPowertoolsConfigurations>();
 
             var metrics = new Metrics(
-                configurations.Object,
+                configurations,
                 nameSpace: "dotnet-powertools-test",
                 service: "testService"
             );
@@ -562,10 +563,10 @@ namespace AWS.Lambda.Powertools.Metrics.Tests
             var consoleOut = new StringWriter();
             Console.SetOut(consoleOut);
 
-            var configurations = new Mock<IPowertoolsConfigurations>();
+            var configurations = Substitute.For<IPowertoolsConfigurations>();
 
             var metrics = new Metrics(
-                configurations.Object,
+                configurations,
                 nameSpace: "dotnet-powertools-test",
                 service: "testService"
             );
@@ -605,10 +606,10 @@ namespace AWS.Lambda.Powertools.Metrics.Tests
             var consoleOut = new StringWriter();
             Console.SetOut(consoleOut);
 
-            var configurations = new Mock<IPowertoolsConfigurations>();
+            var configurations = Substitute.For<IPowertoolsConfigurations>();
 
             var metrics = new Metrics(
-                configurations.Object,
+                configurations,
                 nameSpace: "dotnet-powertools-test",
                 service: "testService"
             );
@@ -647,10 +648,10 @@ namespace AWS.Lambda.Powertools.Metrics.Tests
             var consoleOut = new StringWriter();
             Console.SetOut(consoleOut);
 
-            var configurations = new Mock<IPowertoolsConfigurations>();
+            var configurations = Substitute.For<IPowertoolsConfigurations>();
 
             var metrics = new Metrics(
-                configurations.Object,
+                configurations,
                 nameSpace: "dotnet-powertools-test",
                 service: "testService"
             );
@@ -707,9 +708,9 @@ namespace AWS.Lambda.Powertools.Metrics.Tests
             var consoleOut = new StringWriter();
             Console.SetOut(consoleOut);
 
-            var configurations = new Mock<IPowertoolsConfigurations>();
+            var configurations = Substitute.For<IPowertoolsConfigurations>();
 
-            var metrics = new Metrics(configurations.Object,
+            var metrics = new Metrics(configurations,
                 nameSpace: "dotnet-powertools-test",
                 service: "testService");
 

--- a/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/EMFValidationTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/EMFValidationTests.cs
@@ -18,7 +18,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using AWS.Lambda.Powertools.Common;
-//using Moq;
 using NSubstitute;
 using Xunit;
 

--- a/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/MetricsTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/MetricsTests.cs
@@ -1,5 +1,5 @@
 using AWS.Lambda.Powertools.Common;
-using Moq;
+using NSubstitute;
 using Xunit;
 
 namespace AWS.Lambda.Powertools.Metrics.Tests;
@@ -13,24 +13,20 @@ public class MetricsTests
         // Arrange
         var assemblyName = "AWS.Lambda.Powertools.Metrics";
         var assemblyVersion = "1.0.0";
-            
-        var env = new Mock<IPowertoolsEnvironment>();
-        env.Setup(x => x.GetAssemblyName(It.IsAny<Metrics>())).Returns(assemblyName);
-        env.Setup(x => x.GetAssemblyVersion(It.IsAny<Metrics>())).Returns(assemblyVersion);
+
+        var env = Substitute.For<IPowertoolsEnvironment>();
+        env.GetAssemblyName(Arg.Any<Metrics>()).Returns(assemblyName);
+        env.GetAssemblyVersion(Arg.Any<Metrics>()).Returns(assemblyVersion);
     
-        var conf = new PowertoolsConfigurations(new SystemWrapper(env.Object));
+        var conf = new PowertoolsConfigurations(new SystemWrapper(env));
     
         var metrics = new Metrics(conf);
         
         // Assert
-        env.Verify(v =>
-            v.SetEnvironmentVariable(
-                "AWS_EXECUTION_ENV", $"{Constants.FeatureContextIdentifier}/Metrics/{assemblyVersion}"
-            ), Times.Once);
-            
-        env.Verify(v =>
-            v.GetEnvironmentVariable(
-                "AWS_EXECUTION_ENV"
-            ), Times.Once);
+        env.Received(1).SetEnvironmentVariable(
+            "AWS_EXECUTION_ENV", $"{Constants.FeatureContextIdentifier}/Metrics/{assemblyVersion}"
+        );
+
+        env.Received(1).GetEnvironmentVariable("AWS_EXECUTION_ENV");
     }
 }

--- a/libraries/tests/AWS.Lambda.Powertools.Parameters.Tests/AWS.Lambda.Powertools.Parameters.Tests.csproj
+++ b/libraries/tests/AWS.Lambda.Powertools.Parameters.Tests/AWS.Lambda.Powertools.Parameters.Tests.csproj
@@ -9,14 +9,14 @@
 </PropertyGroup>
 
 <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+    <PackageReference Include="NSubstitute" Version="5.0.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/libraries/tests/AWS.Lambda.Powertools.Parameters.Tests/Cache/CacheManagerTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Parameters.Tests/Cache/CacheManagerTest.cs
@@ -15,7 +15,7 @@
 
 using AWS.Lambda.Powertools.Parameters.Cache;
 using AWS.Lambda.Powertools.Parameters.Internal.Cache;
-using Moq;
+using NSubstitute;
 using Xunit;
 
 namespace AWS.Lambda.Powertools.Parameters.Tests.Cache;
@@ -31,17 +31,17 @@ public class CacheManagerTest
         var currentTime = DateTime.Now.AddHours(1);
         var duration = TimeSpan.FromSeconds(5);
 
-        var dateTimeWrapper = new Mock<IDateTimeWrapper>();
-        dateTimeWrapper.Setup(c => c.UtcNow).Returns(currentTime);
-
-        var cacheManager = new CacheManager(dateTimeWrapper.Object);
+        var dateTimeWrapper = Substitute.For<IDateTimeWrapper>();
+        dateTimeWrapper.UtcNow.Returns(currentTime);
+        
+        var cacheManager = new CacheManager(dateTimeWrapper);
         cacheManager.Set(key, value, duration);
 
         // Act
         var result = cacheManager.Get(key);
 
         // Assert
-        dateTimeWrapper.Verify(v => v.UtcNow, Times.Exactly(2));
+        var utcNow = dateTimeWrapper.Received(2).UtcNow;
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -53,10 +53,10 @@ public class CacheManagerTest
         var key = Guid.NewGuid().ToString();
         var currentTime = DateTime.Now.AddHours(1);
 
-        var dateTimeWrapper = new Mock<IDateTimeWrapper>();
-        dateTimeWrapper.Setup(c => c.UtcNow).Returns(currentTime);
+        var dateTimeWrapper = Substitute.For<IDateTimeWrapper>();
+        dateTimeWrapper.UtcNow.Returns(currentTime);
 
-        var cacheManager = new CacheManager(dateTimeWrapper.Object);
+        var cacheManager = new CacheManager(dateTimeWrapper);
 
         // Act
         var result = cacheManager.Get(key);
@@ -74,14 +74,14 @@ public class CacheManagerTest
         var currentTime = DateTime.Now.AddHours(1);
         var duration = TimeSpan.FromSeconds(5);
 
-        var dateTimeWrapper = new Mock<IDateTimeWrapper>();
-        dateTimeWrapper.Setup(c => c.UtcNow).Returns(currentTime);
+        var dateTimeWrapper = Substitute.For<IDateTimeWrapper>();
+        dateTimeWrapper.UtcNow.Returns(currentTime);
 
-        var cacheManager = new CacheManager(dateTimeWrapper.Object);
+        var cacheManager = new CacheManager(dateTimeWrapper);
         cacheManager.Set(key, value, duration);
 
         currentTime = currentTime.Add(duration).AddSeconds(-1);
-        dateTimeWrapper.Setup(c => c.UtcNow).Returns(currentTime);
+        dateTimeWrapper.UtcNow.Returns(currentTime);
 
         // Act
         var result = cacheManager.Get(key);
@@ -100,14 +100,14 @@ public class CacheManagerTest
         var currentTime = DateTime.Now.AddHours(1);
         var duration = TimeSpan.FromSeconds(5);
 
-        var dateTimeWrapper = new Mock<IDateTimeWrapper>();
-        dateTimeWrapper.Setup(c => c.UtcNow).Returns(currentTime);
+        var dateTimeWrapper = Substitute.For<IDateTimeWrapper>();
+        dateTimeWrapper.UtcNow.Returns(currentTime);
 
-        var cacheManager = new CacheManager(dateTimeWrapper.Object);
+        var cacheManager = new CacheManager(dateTimeWrapper);
         cacheManager.Set(key, value, duration);
 
         currentTime = currentTime.Add(duration).AddSeconds(1);
-        dateTimeWrapper.Setup(c => c.UtcNow).Returns(currentTime);
+        dateTimeWrapper.UtcNow.Returns(currentTime);
 
         // Act
         var result = cacheManager.Get(key);

--- a/libraries/tests/AWS.Lambda.Powertools.Parameters.Tests/Configuration/ParameterProviderConfigurationTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Parameters.Tests/Configuration/ParameterProviderConfigurationTest.cs
@@ -16,7 +16,7 @@
 using AWS.Lambda.Powertools.Parameters.Configuration;
 using AWS.Lambda.Powertools.Parameters.Internal.Provider;
 using AWS.Lambda.Powertools.Parameters.Transform;
-using Moq;
+using NSubstitute;
 using Xunit;
 
 namespace AWS.Lambda.Powertools.Parameters.Tests.Configuration;
@@ -31,24 +31,27 @@ public class ParameterProviderConfigurationTest
         var value = Guid.NewGuid().ToString();
         var duration = TimeSpan.FromSeconds(5);
 
-        var provider = new Mock<IParameterProviderBaseHandler>();
-        provider.Setup(c =>
-            c.GetAsync<string>(key, It.IsAny<ParameterProviderConfiguration?>(), It.IsAny<Transformation?>(),
-                It.IsAny<string?>())
-        ).ReturnsAsync(value);
+        var provider = Substitute.For<IParameterProviderBaseHandler>();
+        provider.GetAsync<string>(
+            key,
+            Arg.Is<ParameterProviderConfiguration?>(x => x != null && x.MaxAge == duration),
+            Arg.Is<Transformation?>(x => x == null),
+            Arg.Is<string?>(x => string.IsNullOrEmpty(x))
+        ).Returns(value);
 
-        var providerConfigurationBuilder = new ParameterProviderConfigurationBuilder(provider.Object);
+        var providerConfigurationBuilder = new ParameterProviderConfigurationBuilder(provider);
         providerConfigurationBuilder.WithMaxAge(duration);
 
         // Act
         var result = await providerConfigurationBuilder.GetAsync(key);
 
         // Assert
-        provider.Verify(v => v.GetAsync<string>(key,
-                It.Is<ParameterProviderConfiguration?>(x => x != null && x.MaxAge == duration),
-                It.Is<Transformation?>(x => x == null),
-                It.Is<string?>(x => string.IsNullOrEmpty(x))),
-            Times.Once);
+        await provider.Received(1).GetAsync<string>(
+            key,
+            Arg.Is<ParameterProviderConfiguration?>(x => x != null && x.MaxAge == duration),
+            Arg.Is<Transformation?>(x => x == null),
+            Arg.Is<string?>(x => string.IsNullOrEmpty(x))
+        );
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -60,24 +63,27 @@ public class ParameterProviderConfigurationTest
         var key = Guid.NewGuid().ToString();
         var value = Guid.NewGuid().ToString();
 
-        var provider = new Mock<IParameterProviderBaseHandler>();
-        provider.Setup(c =>
-            c.GetAsync<string>(key, It.IsAny<ParameterProviderConfiguration?>(), It.IsAny<Transformation?>(),
-                It.IsAny<string?>())
-        ).ReturnsAsync(value);
+        var provider = Substitute.For<IParameterProviderBaseHandler>();
+        provider.GetAsync<string>(
+            key,
+            Arg.Is<ParameterProviderConfiguration?>(x => x != null && x.ForceFetch),
+            Arg.Is<Transformation?>(x => x == null),
+            Arg.Is<string?>(x => string.IsNullOrEmpty(x))
+        ).Returns(value);
 
-        var providerConfigurationBuilder = new ParameterProviderConfigurationBuilder(provider.Object);
+        var providerConfigurationBuilder = new ParameterProviderConfigurationBuilder(provider);
         providerConfigurationBuilder.ForceFetch();
 
         // Act
         var result = await providerConfigurationBuilder.GetAsync(key);
 
         // Assert
-        provider.Verify(v => v.GetAsync<string>(key,
-                It.Is<ParameterProviderConfiguration?>(x => x != null && x.ForceFetch),
-                It.Is<Transformation?>(x => x == null),
-                It.Is<string?>(x => string.IsNullOrEmpty(x))),
-            Times.Once);
+        await provider.Received(1).GetAsync<string>(
+            key,
+            Arg.Is<ParameterProviderConfiguration?>(x => x != null && x.ForceFetch),
+            Arg.Is<Transformation?>(x => x == null),
+            Arg.Is<string?>(x => string.IsNullOrEmpty(x))
+        );
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -89,25 +95,28 @@ public class ParameterProviderConfigurationTest
         var key = Guid.NewGuid().ToString();
         var value = Guid.NewGuid().ToString();
 
-        var transformer = new Mock<ITransformer>();
-        var provider = new Mock<IParameterProviderBaseHandler>();
-        provider.Setup(c =>
-            c.GetAsync<string>(key, It.IsAny<ParameterProviderConfiguration?>(), It.IsAny<Transformation?>(),
-                It.IsAny<string?>())
-        ).ReturnsAsync(value);
+        var transformer = Substitute.For<ITransformer>();
+        var provider = Substitute.For<IParameterProviderBaseHandler>();
+        provider.GetAsync<string>(
+            key,
+            Arg.Is<ParameterProviderConfiguration?>(x => x != null && x.Transformer == transformer),
+            Arg.Is<Transformation?>(x => x == null),
+            Arg.Is<string?>(x => string.IsNullOrEmpty(x))
+        ).Returns(value);
 
-        var providerConfigurationBuilder = new ParameterProviderConfigurationBuilder(provider.Object);
-        providerConfigurationBuilder.WithTransformation(transformer.Object);
+        var providerConfigurationBuilder = new ParameterProviderConfigurationBuilder(provider);
+        providerConfigurationBuilder.WithTransformation(transformer);
 
         // Act
         var result = await providerConfigurationBuilder.GetAsync(key);
 
         // Assert
-        provider.Verify(v => v.GetAsync<string>(key,
-                It.Is<ParameterProviderConfiguration?>(x => x != null && x.Transformer == transformer.Object),
-                It.Is<Transformation?>(x => x == null),
-                It.Is<string?>(x => string.IsNullOrEmpty(x))),
-            Times.Once);
+        await provider.Received(1).GetAsync<string>(
+            key,
+            Arg.Is<ParameterProviderConfiguration?>(x => x != null && x.Transformer == transformer),
+            Arg.Is<Transformation?>(x => x == null),
+            Arg.Is<string?>(x => string.IsNullOrEmpty(x))
+        );
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -120,24 +129,27 @@ public class ParameterProviderConfigurationTest
         var value = Guid.NewGuid().ToString();
         var transformation = Transformation.Json;
 
-        var provider = new Mock<IParameterProviderBaseHandler>();
-        provider.Setup(c =>
-            c.GetAsync<string>(key, It.IsAny<ParameterProviderConfiguration?>(), It.IsAny<Transformation?>(),
-                It.IsAny<string?>())
-        ).ReturnsAsync(value);
+        var provider = Substitute.For<IParameterProviderBaseHandler>();
+        provider.GetAsync<string>(
+            key,
+            Arg.Is<ParameterProviderConfiguration?>(x => x != null && x.Transformer == null),
+            Arg.Is<Transformation?>(x => x == transformation),
+            Arg.Is<string?>(x => string.IsNullOrEmpty(x))
+        ).Returns(value);
 
-        var providerConfigurationBuilder = new ParameterProviderConfigurationBuilder(provider.Object);
+        var providerConfigurationBuilder = new ParameterProviderConfigurationBuilder(provider);
         providerConfigurationBuilder.WithTransformation(transformation);
 
         // Act
         var result = await providerConfigurationBuilder.GetAsync(key);
 
         // Assert
-        provider.Verify(v => v.GetAsync<string>(key,
-                It.Is<ParameterProviderConfiguration?>(x => x != null && x.Transformer == null),
-                It.Is<Transformation?>(x => x == transformation),
-                It.Is<string?>(x => string.IsNullOrEmpty(x))),
-            Times.Once);
+        await provider.Received(1).GetAsync<string>(
+            key,
+            Arg.Is<ParameterProviderConfiguration?>(x => x != null && x.Transformer == null),
+            Arg.Is<Transformation?>(x => x == transformation),
+            Arg.Is<string?>(x => string.IsNullOrEmpty(x))
+        );
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -150,24 +162,27 @@ public class ParameterProviderConfigurationTest
         var value = Guid.NewGuid().ToString();
         var transformation = Transformation.Base64;
 
-        var provider = new Mock<IParameterProviderBaseHandler>();
-        provider.Setup(c =>
-            c.GetAsync<string>(key, It.IsAny<ParameterProviderConfiguration?>(), It.IsAny<Transformation?>(),
-                It.IsAny<string?>())
-        ).ReturnsAsync(value);
+        var provider = Substitute.For<IParameterProviderBaseHandler>();
+        provider.GetAsync<string>(
+            key,
+            Arg.Is<ParameterProviderConfiguration?>(x => x != null && x.Transformer == null),
+            Arg.Is<Transformation?>(x => x == transformation),
+            Arg.Is<string?>(x => string.IsNullOrEmpty(x))
+        ).Returns(value);
 
-        var providerConfigurationBuilder = new ParameterProviderConfigurationBuilder(provider.Object);
+        var providerConfigurationBuilder = new ParameterProviderConfigurationBuilder(provider);
         providerConfigurationBuilder.WithTransformation(transformation);
 
         // Act
         var result = await providerConfigurationBuilder.GetAsync(key);
 
         // Assert
-        provider.Verify(v => v.GetAsync<string>(key,
-                It.Is<ParameterProviderConfiguration?>(x => x != null && x.Transformer == null),
-                It.Is<Transformation?>(x => x == transformation),
-                It.Is<string?>(x => string.IsNullOrEmpty(x))),
-            Times.Once);
+        await provider.Received(1).GetAsync<string>(
+            key,
+            Arg.Is<ParameterProviderConfiguration?>(x => x != null && x.Transformer == null),
+            Arg.Is<Transformation?>(x => x == transformation),
+            Arg.Is<string?>(x => string.IsNullOrEmpty(x))
+        );
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -180,24 +195,27 @@ public class ParameterProviderConfigurationTest
         var value = Guid.NewGuid().ToString();
         var transformation = Transformation.Auto;
 
-        var provider = new Mock<IParameterProviderBaseHandler>();
-        provider.Setup(c =>
-            c.GetAsync<string>(key, It.IsAny<ParameterProviderConfiguration?>(), It.IsAny<Transformation?>(),
-                It.IsAny<string?>())
-        ).ReturnsAsync(value);
+        var provider = Substitute.For<IParameterProviderBaseHandler>();
+        provider.GetAsync<string>(
+            key,
+            Arg.Is<ParameterProviderConfiguration?>(x => x != null && x.Transformer == null),
+            Arg.Is<Transformation?>(x => x == transformation),
+            Arg.Is<string?>(x => string.IsNullOrEmpty(x))
+        ).Returns(value);
 
-        var providerConfigurationBuilder = new ParameterProviderConfigurationBuilder(provider.Object);
+        var providerConfigurationBuilder = new ParameterProviderConfigurationBuilder(provider);
         providerConfigurationBuilder.WithTransformation(transformation);
 
         // Act
         var result = await providerConfigurationBuilder.GetAsync(key);
 
         // Assert
-        provider.Verify(v => v.GetAsync<string>(key,
-                It.Is<ParameterProviderConfiguration?>(x => x != null && x.Transformer == null),
-                It.Is<Transformation?>(x => x == transformation),
-                It.Is<string?>(x => string.IsNullOrEmpty(x))),
-            Times.Once);
+        await provider.Received(1).GetAsync<string>(
+            key,
+            Arg.Is<ParameterProviderConfiguration?>(x => x != null && x.Transformer == null),
+            Arg.Is<Transformation?>(x => x == transformation),
+            Arg.Is<string?>(x => string.IsNullOrEmpty(x))
+        );
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -210,24 +228,27 @@ public class ParameterProviderConfigurationTest
         var value = Guid.NewGuid().ToString();
         var transformationName = Guid.NewGuid().ToString();
 
-        var provider = new Mock<IParameterProviderBaseHandler>();
-        provider.Setup(c =>
-            c.GetAsync<string>(key, It.IsAny<ParameterProviderConfiguration?>(), It.IsAny<Transformation?>(),
-                It.IsAny<string?>())
-        ).ReturnsAsync(value);
+        var provider = Substitute.For<IParameterProviderBaseHandler>();
+        provider.GetAsync<string>(
+            key,
+            Arg.Is<ParameterProviderConfiguration?>(x => x != null && x.Transformer == null),
+            Arg.Is<Transformation?>(x => x == null),
+            Arg.Is<string?>(x => x == transformationName)
+        ).Returns(value);
 
-        var providerConfigurationBuilder = new ParameterProviderConfigurationBuilder(provider.Object);
+        var providerConfigurationBuilder = new ParameterProviderConfigurationBuilder(provider);
         providerConfigurationBuilder.WithTransformation(transformationName);
 
         // Act
         var result = await providerConfigurationBuilder.GetAsync(key);
 
         // Assert
-        provider.Verify(v => v.GetAsync<string>(key,
-                It.Is<ParameterProviderConfiguration?>(x => x != null && x.Transformer == null),
-                It.Is<Transformation?>(x => x == null),
-                It.Is<string?>(x => x == transformationName)),
-            Times.Once);
+        await provider.Received(1).GetAsync<string>(
+            key,
+            Arg.Is<ParameterProviderConfiguration?>(x => x != null && x.Transformer == null),
+            Arg.Is<Transformation?>(x => x == null),
+            Arg.Is<string?>(x => x == transformationName)
+        );
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }

--- a/libraries/tests/AWS.Lambda.Powertools.Parameters.Tests/DynamoDB/DynamoDBProviderTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Parameters.Tests/DynamoDB/DynamoDBProviderTest.cs
@@ -22,7 +22,7 @@ using AWS.Lambda.Powertools.Parameters.Internal.Cache;
 using AWS.Lambda.Powertools.Parameters.Provider;
 using AWS.Lambda.Powertools.Parameters.Internal.Provider;
 using AWS.Lambda.Powertools.Parameters.Transform;
-using Moq;
+using NSubstitute;
 using Xunit;
 
 namespace AWS.Lambda.Powertools.Parameters.Tests.DynamoDB;
@@ -38,33 +38,41 @@ public class DynamoDBProviderTest
         var transformerName = Guid.NewGuid().ToString();
         var duration = CacheManager.DefaultMaxAge.Add(TimeSpan.FromHours(10));
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonDynamoDB>();
-        var transformerManager = new Mock<ITransformerManager>();
-        var transformer = new Mock<ITransformer>();
-        var providerHandler = new Mock<IParameterProviderBaseHandler>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonDynamoDB>();
+        var transformerManager = Substitute.For<ITransformerManager>();
+        var transformer = Substitute.For<ITransformer>();
+        var providerHandler = Substitute.For<IParameterProviderBaseHandler>();
 
-        providerHandler.Setup(c =>
-            c.GetAsync<string>(key, It.IsAny<ParameterProviderConfiguration?>(), null, null)
-        ).ReturnsAsync(value);
+        providerHandler.GetAsync<string>(
+            key,
+            Arg.Any<ParameterProviderConfiguration>(),
+            null,
+            null
+        ).Returns(value);
 
         var provider = new DynamoDBProvider();
-        provider.SetHandler(providerHandler.Object);
-        provider.UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+        provider.SetHandler(providerHandler);
+        provider.UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
         provider.DefaultMaxAge(duration);
-        provider.AddTransformer(transformerName, transformer.Object);
+        provider.AddTransformer(transformerName, transformer);
 
         // Act
         var result = await provider.GetAsync(key);
 
         // Assert
-        providerHandler.Verify(v => v.GetAsync<string>(key, null, null, null), Times.Once);
-        providerHandler.Verify(v => v.SetCacheManager(cacheManager.Object), Times.Once);
-        providerHandler.Verify(v => v.SetTransformerManager(transformerManager.Object), Times.Once);
-        providerHandler.Verify(v => v.SetDefaultMaxAge(duration), Times.Once);
-        providerHandler.Verify(v => v.AddCustomTransformer(transformerName, transformer.Object), Times.Once);
+        providerHandler.Received(1).SetCacheManager(cacheManager);
+        providerHandler.Received(1).SetTransformerManager(transformerManager);
+        providerHandler.Received(1).SetDefaultMaxAge(duration);
+        providerHandler.Received(1).AddCustomTransformer(transformerName, transformer);
+        await providerHandler.Received(1).GetAsync<string>(
+            key,
+            Arg.Any<ParameterProviderConfiguration>(),
+            null,
+            null
+        );
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -76,20 +84,20 @@ public class DynamoDBProviderTest
         var key = Guid.NewGuid().ToString();
         var value = Guid.NewGuid().ToString();
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonDynamoDB>();
-        var transformerManager = new Mock<ITransformerManager>();
-        var providerHandler = new Mock<IParameterProviderBaseHandler>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonDynamoDB>();
+        var transformerManager = Substitute.For<ITransformerManager>();
+        var providerHandler = Substitute.For<IParameterProviderBaseHandler>();
 
-        providerHandler.Setup(c =>
-            c.GetAsync<string>(key, It.IsAny<ParameterProviderConfiguration?>(), null, null)
-        ).ReturnsAsync(value);
+        providerHandler
+            .GetAsync<string>(key, Arg.Is<ParameterProviderConfiguration>(x => x != null && x.ForceFetch), null, null)
+            .Returns(value);
 
         var provider = new DynamoDBProvider();
-        provider.SetHandler(providerHandler.Object);
-        provider.UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+        provider.SetHandler(providerHandler);
+        provider.UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await provider
@@ -97,12 +105,9 @@ public class DynamoDBProviderTest
             .GetAsync(key);
 
         // Assert
-        providerHandler.Verify(
-            v => v.GetAsync<string>(key,
-                It.Is<ParameterProviderConfiguration?>(x =>
-                    x != null && x.ForceFetch
-                ), null,
-                null), Times.Once);
+        await providerHandler
+            .Received(1)
+            .GetAsync<string>(key, Arg.Is<ParameterProviderConfiguration>(x => x != null && x.ForceFetch), null, null);
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -115,20 +120,21 @@ public class DynamoDBProviderTest
         var value = Guid.NewGuid().ToString();
         var duration = CacheManager.DefaultMaxAge.Add(TimeSpan.FromHours(10));
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonDynamoDB>();
-        var transformerManager = new Mock<ITransformerManager>();
-        var providerHandler = new Mock<IParameterProviderBaseHandler>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonDynamoDB>();
+        var transformerManager = Substitute.For<ITransformerManager>();
+        var providerHandler = Substitute.For<IParameterProviderBaseHandler>();
 
-        providerHandler.Setup(c =>
-            c.GetAsync<string>(key, It.IsAny<ParameterProviderConfiguration?>(), null, null)
-        ).ReturnsAsync(value);
+        providerHandler
+            .GetAsync<string>(key, Arg.Is<ParameterProviderConfiguration>(x => x != null && x.MaxAge == duration), null,
+                null)
+            .Returns(value);
 
         var provider = new DynamoDBProvider();
-        provider.SetHandler(providerHandler.Object);
-        provider.UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+        provider.SetHandler(providerHandler);
+        provider.UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await provider
@@ -136,12 +142,10 @@ public class DynamoDBProviderTest
             .GetAsync(key);
 
         // Assert
-        providerHandler.Verify(
-            v => v.GetAsync<string>(key,
-                It.Is<ParameterProviderConfiguration?>(x =>
-                    x != null && x.MaxAge == duration
-                ), null,
-                null), Times.Once);
+        await providerHandler
+            .Received(1)
+            .GetAsync<string>(key, Arg.Is<ParameterProviderConfiguration>(x => x != null && x.MaxAge == duration), null,
+                null);
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -153,34 +157,33 @@ public class DynamoDBProviderTest
         var key = Guid.NewGuid().ToString();
         var value = Guid.NewGuid().ToString();
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonDynamoDB>();
-        var transformerManager = new Mock<ITransformerManager>();
-        var transformer = new Mock<ITransformer>();
-        var providerHandler = new Mock<IParameterProviderBaseHandler>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonDynamoDB>();
+        var transformerManager = Substitute.For<ITransformerManager>();
+        var transformer = Substitute.For<ITransformer>();
+        var providerHandler = Substitute.For<IParameterProviderBaseHandler>();
 
-        providerHandler.Setup(c =>
-            c.GetAsync<string>(key, It.IsAny<ParameterProviderConfiguration?>(), null, null)
-        ).ReturnsAsync(value);
+        providerHandler
+            .GetAsync<string>(key,
+                Arg.Is<ParameterProviderConfiguration>(x => x != null && x.Transformer == transformer), null, null)
+            .Returns(value);
 
         var provider = new DynamoDBProvider();
-        provider.SetHandler(providerHandler.Object);
-        provider.UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+        provider.SetHandler(providerHandler);
+        provider.UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await provider
-            .WithTransformation(transformer.Object)
+            .WithTransformation(transformer)
             .GetAsync(key);
 
         // Assert
-        providerHandler.Verify(
-            v => v.GetAsync<string>(key,
-                It.Is<ParameterProviderConfiguration?>(x =>
-                    x != null && x.Transformer == transformer.Object
-                ), null,
-                null), Times.Once);
+        await providerHandler
+            .Received(1)
+            .GetAsync<string>(key,
+                Arg.Is<ParameterProviderConfiguration>(x => x != null && x.Transformer == transformer), null, null);
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -192,21 +195,22 @@ public class DynamoDBProviderTest
         var key = Guid.NewGuid().ToString();
         var value = Guid.NewGuid().ToString();
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonDynamoDB>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonDynamoDB>();
+        var transformerManager = Substitute.For<ITransformerManager>();
         var transformation = Transformation.Auto;
-        var providerHandler = new Mock<IParameterProviderBaseHandler>();
+        var providerHandler = Substitute.For<IParameterProviderBaseHandler>();
 
-        providerHandler.Setup(c =>
-            c.GetAsync<string>(key, It.IsAny<ParameterProviderConfiguration?>(), transformation, null)
-        ).ReturnsAsync(value);
+        providerHandler
+            .GetAsync<string>(key, Arg.Is<ParameterProviderConfiguration>(x => x != null && !x.ForceFetch),
+                transformation, null)
+            .Returns(value);
 
         var provider = new DynamoDBProvider();
-        provider.SetHandler(providerHandler.Object);
-        provider.UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+        provider.SetHandler(providerHandler);
+        provider.UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await provider
@@ -214,13 +218,12 @@ public class DynamoDBProviderTest
             .GetAsync(key);
 
         // Assert
-        providerHandler.Verify(
-            v => v.GetAsync<string>(key,
-                It.Is<ParameterProviderConfiguration?>(x =>
-                    x != null && !x.ForceFetch
-                ),
-                It.Is<Transformation?>(x => x == transformation),
-                null), Times.Once);
+        await providerHandler
+            .Received(1)
+            .GetAsync<string>(key,
+                Arg.Is<ParameterProviderConfiguration>(x => x != null && !x.ForceFetch),
+                transformation,
+                null);
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -232,21 +235,22 @@ public class DynamoDBProviderTest
         var key = Guid.NewGuid().ToString();
         var value = Guid.NewGuid().ToString();
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonDynamoDB>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonDynamoDB>();
+        var transformerManager = Substitute.For<ITransformerManager>();
         var transformerName = Guid.NewGuid().ToString();
-        var providerHandler = new Mock<IParameterProviderBaseHandler>();
+        var providerHandler = Substitute.For<IParameterProviderBaseHandler>();
 
-        providerHandler.Setup(c =>
-            c.GetAsync<string>(key, It.IsAny<ParameterProviderConfiguration?>(), null, transformerName)
-        ).ReturnsAsync(value);
+        providerHandler
+            .GetAsync<string>(key, Arg.Is<ParameterProviderConfiguration>(x => x != null && !x.ForceFetch), null,
+                transformerName)
+            .Returns(value);
 
         var provider = new DynamoDBProvider();
-        provider.SetHandler(providerHandler.Object);
-        provider.UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+        provider.SetHandler(providerHandler);
+        provider.UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await provider
@@ -254,14 +258,12 @@ public class DynamoDBProviderTest
             .GetAsync(key);
 
         // Assert
-        providerHandler.Verify(
-            v => v.GetAsync<string>(key,
-                It.Is<ParameterProviderConfiguration?>(x =>
-                    x != null && !x.ForceFetch
-                ),
+        await providerHandler
+            .Received(1)
+            .GetAsync<string>(key,
+                Arg.Is<ParameterProviderConfiguration>(x => x != null && !x.ForceFetch),
                 null,
-                It.Is<string?>(x => x == transformerName))
-            , Times.Once);
+                transformerName);
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -271,52 +273,36 @@ public class DynamoDBProviderTest
     {
         // Arrange
         var key = Guid.NewGuid().ToString();
-        var value = Guid.NewGuid().ToString();
         var valueFromCache = Guid.NewGuid().ToString();
-        var response = new GetItemResponse
-        {
-            Item = new Dictionary<string, AttributeValue>()
-            {
-                { "value", new AttributeValue { S = value } }
-            }
-        };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonDynamoDB>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonDynamoDB>();
+        var transformerManager = Substitute.For<ITransformerManager>();
 
-        client.Setup(c =>
-            c.GetItemAsync(It.IsAny<GetItemRequest>(), It.IsAny<CancellationToken>())
-        ).ReturnsAsync(response);
-
-        cacheManager.Setup(c =>
-            c.Get(key)
-        ).Returns(valueFromCache);
+        cacheManager.Get(key).Returns(valueFromCache);
 
         var provider = new DynamoDBProvider()
-            .UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+            .UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await provider.GetAsync(key);
 
         // Assert
-        client.Verify(v =>
-                v.GetItemAsync(It.IsAny<GetItemRequest>(),
-                    It.IsAny<CancellationToken>()),
-            Times.Never);
+        await client
+            .DidNotReceive()
+            .GetItemAsync(Arg.Any<GetItemRequest>(), Arg.Any<CancellationToken>());
         Assert.NotNull(result);
         Assert.Equal(valueFromCache, result);
     }
-
+    
     [Fact]
     public async Task GetAsync_WhenForceFetch_IgnoresCachedObject()
     {
         // Arrange
         var key = Guid.NewGuid().ToString();
         var value = Guid.NewGuid().ToString();
-        var valueFromCache = Guid.NewGuid().ToString();
         var response = new GetItemResponse
         {
             Item = new Dictionary<string, AttributeValue>()
@@ -325,35 +311,29 @@ public class DynamoDBProviderTest
             }
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonDynamoDB>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonDynamoDB>();
+        var transformerManager = Substitute.For<ITransformerManager>();
 
-        client.Setup(c =>
-            c.GetItemAsync(It.IsAny<GetItemRequest>(), It.IsAny<CancellationToken>())
-        ).ReturnsAsync(response);
-
-        cacheManager.Setup(c =>
-            c.Get(key)
-        ).Returns(valueFromCache);
+        client.GetItemAsync(
+            Arg.Is<GetItemRequest>(x => x.Key["id"].S == key),
+            Arg.Any<CancellationToken>()
+        ).Returns(response);
 
         var provider = new DynamoDBProvider()
-            .UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+            .UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await provider.ForceFetch().GetAsync(key);
 
         // Assert
-        cacheManager.Verify(v => v.Get(key), Times.Never);
-        client.Verify(v =>
-                v.GetItemAsync(
-                    It.Is<GetItemRequest>(x =>
-                        x.Key["id"].S == key
-                    ),
-                    It.IsAny<CancellationToken>()),
-            Times.Once);
+        cacheManager.DidNotReceive().Get(key);
+        await client.Received(1).GetItemAsync(
+            Arg.Is<GetItemRequest>(x => x.Key["id"].S == key),
+            Arg.Any<CancellationToken>()
+        );
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -373,35 +353,31 @@ public class DynamoDBProviderTest
             }
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonDynamoDB>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonDynamoDB>();
+        var transformerManager = Substitute.For<ITransformerManager>();
 
-        client.Setup(c =>
-            c.GetItemAsync(It.IsAny<GetItemRequest>(), It.IsAny<CancellationToken>())
-        ).ReturnsAsync(response);
-        cacheManager.Setup(c =>
-            c.Get(key)
-        ).Returns(null);
+        client.GetItemAsync(
+            Arg.Is<GetItemRequest>(x => x.Key["id"].S == key),
+            Arg.Any<CancellationToken>()
+        ).Returns(response);
+        cacheManager.Get(key).Returns(null);
 
         var provider = new DynamoDBProvider()
-            .UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+            .UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await provider.GetAsync(key);
 
         // Assert
-        cacheManager.Verify(v => v.Get(key), Times.Once);
-        client.Verify(v =>
-                v.GetItemAsync(
-                    It.Is<GetItemRequest>(x =>
-                        x.Key["id"].S == key
-                    ),
-                    It.IsAny<CancellationToken>()),
-            Times.Once);
-        cacheManager.Verify(v => v.Set(key, value, duration), Times.Once);
+        cacheManager.Received(1).Get(key);
+        await client.Received(1).GetItemAsync(
+            Arg.Is<GetItemRequest>(x => x.Key["id"].S == key),
+            Arg.Any<CancellationToken>()
+        );
+        cacheManager.Received(1).Set(key, value, duration);
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -421,37 +397,32 @@ public class DynamoDBProviderTest
             }
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonDynamoDB>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonDynamoDB>();
+        var transformerManager = Substitute.For<ITransformerManager>();
 
-        client.Setup(c =>
-            c.GetItemAsync(It.IsAny<GetItemRequest>(), It.IsAny<CancellationToken>())
-        ).ReturnsAsync(response);
-
-        cacheManager.Setup(c =>
-            c.Get(key)
-        ).Returns(null);
+        client.GetItemAsync(
+            Arg.Is<GetItemRequest>(x => x.Key["id"].S == key),
+            Arg.Any<CancellationToken>()
+        ).Returns(response);
+        cacheManager.Get(key).Returns(null);
 
         var provider = new DynamoDBProvider()
-            .UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object)
+            .UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager)
             .DefaultMaxAge(duration);
 
         // Act
         var result = await provider.GetAsync(key);
 
         // Assert
-        cacheManager.Verify(v => v.Get(key), Times.Once);
-        client.Verify(v =>
-                v.GetItemAsync(
-                    It.Is<GetItemRequest>(x =>
-                        x.Key["id"].S == key
-                    ),
-                    It.IsAny<CancellationToken>()),
-            Times.Once);
-        cacheManager.Verify(v => v.Set(key, value, duration), Times.Once);
+        cacheManager.Received(1).Get(key);
+        await client.Received(1).GetItemAsync(
+            Arg.Is<GetItemRequest>(x => x.Key["id"].S == key),
+            Arg.Any<CancellationToken>()
+        );
+        cacheManager.Received(1).Set(key, value, duration);
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -472,22 +443,20 @@ public class DynamoDBProviderTest
             }
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonDynamoDB>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonDynamoDB>();
+        var transformerManager = Substitute.For<ITransformerManager>();
 
-        client.Setup(c =>
-            c.GetItemAsync(It.IsAny<GetItemRequest>(), It.IsAny<CancellationToken>())
-        ).ReturnsAsync(response);
-
-        cacheManager.Setup(c =>
-            c.Get(key)
-        ).Returns(null);
+        client.GetItemAsync(
+            Arg.Is<GetItemRequest>(x => x.Key["id"].S == key),
+            Arg.Any<CancellationToken>()
+        ).Returns(response);
+        cacheManager.Get(key).Returns(null);
 
         var provider = new DynamoDBProvider()
-            .UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object)
+            .UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager)
             .DefaultMaxAge(defaultMaxAge);
 
         // Act
@@ -496,15 +465,12 @@ public class DynamoDBProviderTest
             .GetAsync(key);
 
         // Assert
-        cacheManager.Verify(v => v.Get(key), Times.Once);
-        client.Verify(v =>
-                v.GetItemAsync(
-                    It.Is<GetItemRequest>(x =>
-                        x.Key["id"].S == key
-                    ),
-                    It.IsAny<CancellationToken>()),
-            Times.Once);
-        cacheManager.Verify(v => v.Set(key, value, duration), Times.Once);
+        cacheManager.Received(1).Get(key);
+        await client.Received(1).GetItemAsync(
+            Arg.Is<GetItemRequest>(x => x.Key["id"].S == key),
+            Arg.Any<CancellationToken>()
+        );
+        cacheManager.Received(1).Set(key, value, duration);
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -526,22 +492,21 @@ public class DynamoDBProviderTest
             }
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonDynamoDB>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonDynamoDB>();
+        var transformerManager = Substitute.For<ITransformerManager>();
 
-        client.Setup(c =>
-            c.GetItemAsync(It.IsAny<GetItemRequest>(), It.IsAny<CancellationToken>())
-        ).ReturnsAsync(response);
+        client.GetItemAsync(
+            Arg.Is<GetItemRequest>(x => x.Key[primaryKeyAttr].S == key && x.TableName == tableName),
+            Arg.Any<CancellationToken>()
+        ).Returns(response);
 
-        cacheManager.Setup(c =>
-            c.Get(key)
-        ).Returns(null);
+        cacheManager.Get(key).Returns(null);
 
         var provider = new DynamoDBProvider()
-            .UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object)
+            .UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager)
             .UseTable(tableName);
 
         // Act
@@ -549,18 +514,15 @@ public class DynamoDBProviderTest
             .GetAsync(key);
 
         // Assert
-        cacheManager.Verify(v => v.Get(key), Times.Once);
-        client.Verify(v =>
-                v.GetItemAsync(
-                    It.Is<GetItemRequest>(x =>
-                        x.Key[primaryKeyAttr].S == key && x.TableName == tableName
-                    ),
-                    It.IsAny<CancellationToken>()),
-            Times.Once);
+        cacheManager.Received(1).Get(key);
+        await client.Received(1).GetItemAsync(
+            Arg.Is<GetItemRequest>(x => x.Key[primaryKeyAttr].S == key && x.TableName == tableName),
+            Arg.Any<CancellationToken>()
+        );
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
-    
+
     [Fact]
     public async Task GetAsync_WhenTableInfoSet_CallsClientWithTableInfo()
     {
@@ -578,22 +540,21 @@ public class DynamoDBProviderTest
             }
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonDynamoDB>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonDynamoDB>();
+        var transformerManager = Substitute.For<ITransformerManager>();
 
-        client.Setup(c =>
-            c.GetItemAsync(It.IsAny<GetItemRequest>(), It.IsAny<CancellationToken>())
-        ).ReturnsAsync(response);
+        client.GetItemAsync(
+            Arg.Is<GetItemRequest>(x => x.Key[primaryKeyAttr].S == key && x.TableName == tableName),
+            Arg.Any<CancellationToken>()
+        ).Returns(response);
 
-        cacheManager.Setup(c =>
-            c.Get(key)
-        ).Returns(null);
+        cacheManager.Get(key).Returns(null);
 
         var provider = new DynamoDBProvider()
-            .UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object)
+            .UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager)
             .UseTable(tableName, primaryKeyAttr, valueAttr);
 
         // Act
@@ -601,14 +562,11 @@ public class DynamoDBProviderTest
             .GetAsync(key);
 
         // Assert
-        cacheManager.Verify(v => v.Get(key), Times.Once);
-        client.Verify(v =>
-                v.GetItemAsync(
-                    It.Is<GetItemRequest>(x =>
-                        x.Key[primaryKeyAttr].S == key && x.TableName == tableName
-                    ),
-                    It.IsAny<CancellationToken>()),
-            Times.Once);
+        cacheManager.Received(1).Get(key);
+        await client.Received(1).GetItemAsync(
+            Arg.Is<GetItemRequest>(x => x.Key[primaryKeyAttr].S == key && x.TableName == tableName),
+            Arg.Any<CancellationToken>()
+        );
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -626,37 +584,36 @@ public class DynamoDBProviderTest
         var transformerName = Guid.NewGuid().ToString();
         var duration = CacheManager.DefaultMaxAge.Add(TimeSpan.FromHours(10));
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonDynamoDB>();
-        var transformerManager = new Mock<ITransformerManager>();
-        var transformer = new Mock<ITransformer>();
-        var providerHandler = new Mock<IParameterProviderBaseHandler>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonDynamoDB>();
+        var transformerManager = Substitute.For<ITransformerManager>();
+        var transformer = Substitute.For<ITransformer>();
+        var providerHandler = Substitute.For<IParameterProviderBaseHandler>();
 
-        providerHandler.Setup(c =>
-            c.GetMultipleAsync<string>(key, It.IsAny<ParameterProviderConfiguration?>(), null, null)
-        ).ReturnsAsync(value);
+        providerHandler.GetMultipleAsync<string>(key, Arg.Any<ParameterProviderConfiguration?>(), null, null)
+            .Returns(value);
 
         var provider = new DynamoDBProvider();
-        provider.SetHandler(providerHandler.Object);
-        provider.UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+        provider.SetHandler(providerHandler);
+        provider.UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
         provider.DefaultMaxAge(duration);
-        provider.AddTransformer(transformerName, transformer.Object);
+        provider.AddTransformer(transformerName, transformer);
 
         // Act
         var result = await provider.GetMultipleAsync(key);
 
         // Assert
-        providerHandler.Verify(v => v.GetMultipleAsync<string>(key, null, null, null), Times.Once);
-        providerHandler.Verify(v => v.SetCacheManager(cacheManager.Object), Times.Once);
-        providerHandler.Verify(v => v.SetTransformerManager(transformerManager.Object), Times.Once);
-        providerHandler.Verify(v => v.SetDefaultMaxAge(duration), Times.Once);
-        providerHandler.Verify(v => v.AddCustomTransformer(transformerName, transformer.Object), Times.Once);
+        await providerHandler.Received(1).GetMultipleAsync<string>(key, null, null, null);
+        providerHandler.Received(1).SetCacheManager(cacheManager);
+        providerHandler.Received(1).SetTransformerManager(transformerManager);
+        providerHandler.Received(1).SetDefaultMaxAge(duration);
+        providerHandler.Received(1).AddCustomTransformer(transformerName, transformer);
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
-
+    
     [Fact]
     public async Task GetMultipleAsync_WhenForceFetch_CallsHandlerWithConfiguredParameters()
     {
@@ -668,20 +625,19 @@ public class DynamoDBProviderTest
             { Guid.NewGuid().ToString(), Guid.NewGuid().ToString() }
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonDynamoDB>();
-        var transformerManager = new Mock<ITransformerManager>();
-        var providerHandler = new Mock<IParameterProviderBaseHandler>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonDynamoDB>();
+        var transformerManager = Substitute.For<ITransformerManager>();
+        var providerHandler = Substitute.For<IParameterProviderBaseHandler>();
 
-        providerHandler.Setup(c =>
-            c.GetMultipleAsync<string>(key, It.IsAny<ParameterProviderConfiguration?>(), null, null)
-        ).ReturnsAsync(value);
+        providerHandler.GetMultipleAsync<string>(key, Arg.Any<ParameterProviderConfiguration?>(), null, null)
+            .Returns(value);
 
         var provider = new DynamoDBProvider();
-        provider.SetHandler(providerHandler.Object);
-        provider.UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+        provider.SetHandler(providerHandler);
+        provider.UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await provider
@@ -689,12 +645,9 @@ public class DynamoDBProviderTest
             .GetMultipleAsync(key);
 
         // Assert
-        providerHandler.Verify(
-            v => v.GetMultipleAsync<string>(key,
-                It.Is<ParameterProviderConfiguration?>(x =>
-                    x != null && x.ForceFetch
-                ), null,
-                null), Times.Once);
+        await providerHandler.Received(1).GetMultipleAsync<string>(key,
+            Arg.Is<ParameterProviderConfiguration?>(x => x != null && x.ForceFetch),
+            null, null);
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -711,37 +664,34 @@ public class DynamoDBProviderTest
         };
         var duration = CacheManager.DefaultMaxAge.Add(TimeSpan.FromHours(10));
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonDynamoDB>();
-        var transformerManager = new Mock<ITransformerManager>();
-        var providerHandler = new Mock<IParameterProviderBaseHandler>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonDynamoDB>();
+        var transformerManager = Substitute.For<ITransformerManager>();
+        var providerHandler = Substitute.For<IParameterProviderBaseHandler>();
 
-        providerHandler.Setup(c =>
-            c.GetMultipleAsync<string>(key, It.IsAny<ParameterProviderConfiguration?>(), null, null)
-        ).ReturnsAsync(value);
+        providerHandler
+            .GetMultipleAsync<string>(key, Arg.Any<ParameterProviderConfiguration?>(), null, null)
+            .Returns(value);
 
         var provider = new DynamoDBProvider();
-        provider.SetHandler(providerHandler.Object);
-        provider.UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+        provider.SetHandler(providerHandler);
+        provider.UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await provider
             .WithMaxAge(duration)
             .GetMultipleAsync(key);
-
+        
         // Assert
-        providerHandler.Verify(
-            v => v.GetMultipleAsync<string>(key,
-                It.Is<ParameterProviderConfiguration?>(x =>
-                    x != null && x.MaxAge == duration
-                ), null,
-                null), Times.Once);
+        await providerHandler.Received(1).GetMultipleAsync<string>(key,
+            Arg.Is<ParameterProviderConfiguration?>(x => x != null && x.MaxAge == duration),
+            null, null);
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
-
+    
     [Fact]
     public async Task GetMultipleAsync_WithTransformer_CallsHandlerWithConfiguredParameters()
     {
@@ -753,34 +703,30 @@ public class DynamoDBProviderTest
             { Guid.NewGuid().ToString(), Guid.NewGuid().ToString() }
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonDynamoDB>();
-        var transformerManager = new Mock<ITransformerManager>();
-        var transformer = new Mock<ITransformer>();
-        var providerHandler = new Mock<IParameterProviderBaseHandler>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonDynamoDB>();
+        var transformerManager = Substitute.For<ITransformerManager>();
+        var transformer = Substitute.For<ITransformer>();
+        var providerHandler = Substitute.For<IParameterProviderBaseHandler>();
 
-        providerHandler.Setup(c =>
-            c.GetMultipleAsync<string>(key, It.IsAny<ParameterProviderConfiguration?>(), null, null)
-        ).ReturnsAsync(value);
+        providerHandler.GetMultipleAsync<string>(key, Arg.Any<ParameterProviderConfiguration?>(), null, null)
+            .Returns(value);
 
         var provider = new DynamoDBProvider();
-        provider.SetHandler(providerHandler.Object);
-        provider.UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+        provider.SetHandler(providerHandler);
+        provider.UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await provider
-            .WithTransformation(transformer.Object)
+            .WithTransformation(transformer)
             .GetMultipleAsync(key);
 
         // Assert
-        providerHandler.Verify(
-            v => v.GetMultipleAsync<string>(key,
-                It.Is<ParameterProviderConfiguration?>(x =>
-                    x != null && x.Transformer == transformer.Object
-                ), null,
-                null), Times.Once);
+        await providerHandler.Received(1).GetMultipleAsync<string>(key,
+            Arg.Is<ParameterProviderConfiguration?>(x => x != null && x.Transformer == transformer),
+            null, null);
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -790,27 +736,26 @@ public class DynamoDBProviderTest
     {
         // Arrange
         var key = Guid.NewGuid().ToString();
-        var value = new Dictionary<string, string?>()
+        var value = new Dictionary<string, string?>
         {
             { Guid.NewGuid().ToString(), Guid.NewGuid().ToString() },
             { Guid.NewGuid().ToString(), Guid.NewGuid().ToString() }
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonDynamoDB>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonDynamoDB>();
+        var transformerManager = Substitute.For<ITransformerManager>();
         var transformation = Transformation.Auto;
-        var providerHandler = new Mock<IParameterProviderBaseHandler>();
+        var providerHandler = Substitute.For<IParameterProviderBaseHandler>();
 
-        providerHandler.Setup(c =>
-            c.GetMultipleAsync<string>(key, It.IsAny<ParameterProviderConfiguration?>(), transformation, null)
-        ).ReturnsAsync(value);
+        providerHandler.GetMultipleAsync<string>(key, Arg.Any<ParameterProviderConfiguration?>(), transformation, null)
+            .Returns(value);
 
         var provider = new DynamoDBProvider();
-        provider.SetHandler(providerHandler.Object);
-        provider.UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+        provider.SetHandler(providerHandler);
+        provider.UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await provider
@@ -818,13 +763,11 @@ public class DynamoDBProviderTest
             .GetMultipleAsync(key);
 
         // Assert
-        providerHandler.Verify(
-            v => v.GetMultipleAsync<string>(key,
-                It.Is<ParameterProviderConfiguration?>(x =>
-                    x != null && !x.ForceFetch
-                ),
-                It.Is<Transformation?>(x => x == transformation),
-                null), Times.Once);
+        await providerHandler.Received(1).GetMultipleAsync<string>(key,
+            Arg.Is<ParameterProviderConfiguration?>(x =>
+                x != null && !x.ForceFetch),
+            Arg.Is<Transformation?>(x => x == transformation),
+            null);
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -834,27 +777,26 @@ public class DynamoDBProviderTest
     {
         // Arrange
         var key = Guid.NewGuid().ToString();
-        var value = new Dictionary<string, string?>()
+        var value = new Dictionary<string, string?>
         {
             { Guid.NewGuid().ToString(), Guid.NewGuid().ToString() },
             { Guid.NewGuid().ToString(), Guid.NewGuid().ToString() }
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonDynamoDB>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonDynamoDB>();
+        var transformerManager = Substitute.For<ITransformerManager>();
         var transformerName = Guid.NewGuid().ToString();
-        var providerHandler = new Mock<IParameterProviderBaseHandler>();
+        var providerHandler = Substitute.For<IParameterProviderBaseHandler>();
 
-        providerHandler.Setup(c =>
-            c.GetMultipleAsync<string>(key, It.IsAny<ParameterProviderConfiguration?>(), null, transformerName)
-        ).ReturnsAsync(value);
+        providerHandler.GetMultipleAsync<string>(key, Arg.Any<ParameterProviderConfiguration?>(), null, transformerName)
+            .Returns(value);
 
         var provider = new DynamoDBProvider();
-        provider.SetHandler(providerHandler.Object);
-        provider.UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+        provider.SetHandler(providerHandler);
+        provider.UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await provider
@@ -862,68 +804,42 @@ public class DynamoDBProviderTest
             .GetMultipleAsync(key);
 
         // Assert
-        providerHandler.Verify(
-            v => v.GetMultipleAsync<string>(key,
-                It.Is<ParameterProviderConfiguration?>(x =>
-                    x != null && !x.ForceFetch
-                ),
-                null,
-                It.Is<string?>(x => x == transformerName))
-            , Times.Once);
+        await providerHandler.Received(1).GetMultipleAsync<string>(key,
+            Arg.Is<ParameterProviderConfiguration?>(x =>
+                x != null && !x.ForceFetch),
+            null,
+            Arg.Is<string?>(x => x == transformerName));
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
-
+    
     [Fact]
     public async Task GetMultipleAsync_WhenCachedObjectExists_ReturnsCachedObject()
     {
         // Arrange
         var key = Guid.NewGuid().ToString();
-        var valueFromCache = new Dictionary<string, string?>()
+        var valueFromCache = new Dictionary<string, string?>
         {
             { Guid.NewGuid().ToString(), Guid.NewGuid().ToString() },
             { Guid.NewGuid().ToString(), Guid.NewGuid().ToString() }
         };
-        var value = new Dictionary<string, string?>()
-        {
-            { Guid.NewGuid().ToString(), Guid.NewGuid().ToString() },
-            { Guid.NewGuid().ToString(), Guid.NewGuid().ToString() }
-        };
-        var response = new QueryResponse
-        {
-            Items = value.Select(kv =>
-                new Dictionary<string, AttributeValue>()
-                {
-                    { "sk", new AttributeValue { S = kv.Key } },
-                    { "value", new AttributeValue { S = kv.Value } }
-                }).ToList()
-        };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonDynamoDB>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonDynamoDB>();
+        var transformerManager = Substitute.For<ITransformerManager>();
 
-        client.Setup(c =>
-            c.QueryAsync(It.IsAny<QueryRequest>(), It.IsAny<CancellationToken>())
-        ).ReturnsAsync(response);
-
-        cacheManager.Setup(c =>
-            c.Get(key)
-        ).Returns(valueFromCache);
+        cacheManager.Get(key).Returns(valueFromCache);
 
         var provider = new DynamoDBProvider()
-            .UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+            .UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await provider.GetMultipleAsync(key);
 
         // Assert
-        client.Verify(v =>
-                v.QueryAsync(It.IsAny<QueryRequest>(),
-                    It.IsAny<CancellationToken>()),
-            Times.Never);
+        await client.DidNotReceiveWithAnyArgs().QueryAsync(default);
         Assert.NotNull(result);
         Assert.Equal(valueFromCache, result);
     }
@@ -933,12 +849,12 @@ public class DynamoDBProviderTest
     {
         // Arrange
         var key = Guid.NewGuid().ToString();
-        var valueFromCache = new Dictionary<string, string>()
+        var valueFromCache = new Dictionary<string, string>
         {
             { Guid.NewGuid().ToString(), Guid.NewGuid().ToString() },
             { Guid.NewGuid().ToString(), Guid.NewGuid().ToString() }
         };
-        var value = new Dictionary<string, string>()
+        var value = new Dictionary<string, string>
         {
             { Guid.NewGuid().ToString(), Guid.NewGuid().ToString() },
             { Guid.NewGuid().ToString(), Guid.NewGuid().ToString() }
@@ -946,44 +862,40 @@ public class DynamoDBProviderTest
         var response = new QueryResponse
         {
             Items = value.Select(kv =>
-                new Dictionary<string, AttributeValue>()
+                new Dictionary<string, AttributeValue>
                 {
                     { "sk", new AttributeValue { S = kv.Key } },
                     { "value", new AttributeValue { S = kv.Value } }
                 }).ToList()
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonDynamoDB>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonDynamoDB>();
+        var transformerManager = Substitute.For<ITransformerManager>();
 
-        client.Setup(c =>
-            c.QueryAsync(It.IsAny<QueryRequest>(), It.IsAny<CancellationToken>())
-        ).ReturnsAsync(response);
+        client.QueryAsync(Arg.Any<QueryRequest>(), Arg.Any<CancellationToken>())
+            .Returns(response);
 
-        cacheManager.Setup(c =>
-            c.Get(key)
-        ).Returns(valueFromCache);
+        cacheManager.Get(key).Returns(valueFromCache);
 
         var provider = new DynamoDBProvider()
-            .UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+            .UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await provider.ForceFetch().GetMultipleAsync(key);
 
         // Assert
-        cacheManager.Verify(v => v.Get(key), Times.Never);
-        client.Verify(v =>
-                v.QueryAsync(
-                    It.Is<QueryRequest>(x =>
-                        x.ExpressionAttributeValues.First().Key == x.KeyConditionExpression
-                            .Split('=', StringSplitOptions.TrimEntries).Last() &&
-                        x.ExpressionAttributeValues.First().Value.S == key
-                    ),
-                    It.IsAny<CancellationToken>()),
-            Times.Once);
+        cacheManager.DidNotReceive().Get(key);
+        await client.Received(1).QueryAsync(
+            Arg.Is<QueryRequest>(x =>
+                x.ExpressionAttributeValues.First().Key == x.KeyConditionExpression
+                    .Split('=', StringSplitOptions.TrimEntries).Last() &&
+                x.ExpressionAttributeValues.First().Value.S == key
+            ),
+            Arg.Any<CancellationToken>()
+        );
         Assert.NotNull(result);
         Assert.Equal(value.First().Key, result.First().Key);
         Assert.Equal(value.First().Value, result.First().Value);
@@ -997,7 +909,7 @@ public class DynamoDBProviderTest
         // Arrange
         var key = Guid.NewGuid().ToString();
         var duration = CacheManager.DefaultMaxAge;
-        var value = new Dictionary<string, string>()
+        var value = new Dictionary<string, string>
         {
             { Guid.NewGuid().ToString(), Guid.NewGuid().ToString() },
             { Guid.NewGuid().ToString(), Guid.NewGuid().ToString() }
@@ -1005,50 +917,46 @@ public class DynamoDBProviderTest
         var response = new QueryResponse
         {
             Items = value.Select(kv =>
-                new Dictionary<string, AttributeValue>()
+                new Dictionary<string, AttributeValue>
                 {
                     { "sk", new AttributeValue { S = kv.Key } },
                     { "value", new AttributeValue { S = kv.Value } }
                 }).ToList()
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonDynamoDB>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonDynamoDB>();
+        var transformerManager = Substitute.For<ITransformerManager>();
 
-        client.Setup(c =>
-            c.QueryAsync(It.IsAny<QueryRequest>(), It.IsAny<CancellationToken>())
-        ).ReturnsAsync(response);
+        client.QueryAsync(Arg.Any<QueryRequest>(), Arg.Any<CancellationToken>())
+            .Returns(response);
 
-        cacheManager.Setup(c =>
-            c.Get(key)
-        ).Returns(null);
+        cacheManager.Get(key).Returns(null);
 
         var provider = new DynamoDBProvider()
-            .UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+            .UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await provider.GetMultipleAsync(key);
 
         // Assert
-        cacheManager.Verify(v => v.Get(key), Times.Once);
-        client.Verify(v =>
-                v.QueryAsync(
-                    It.Is<QueryRequest>(x =>
-                        x.ExpressionAttributeValues.First().Key == x.KeyConditionExpression
-                            .Split('=', StringSplitOptions.TrimEntries).Last() &&
-                        x.ExpressionAttributeValues.First().Value.S == key
-                    ),
-                    It.IsAny<CancellationToken>()),
-            Times.Once);
-        cacheManager.Verify(v => v.Set(key, It.Is<Dictionary<string, string>>(x =>
+        cacheManager.Received(1).Get(key);
+        await client.Received(1).QueryAsync(
+            Arg.Is<QueryRequest>(x =>
+                x.ExpressionAttributeValues.First().Key == x.KeyConditionExpression
+                    .Split('=', StringSplitOptions.TrimEntries).Last() &&
+                x.ExpressionAttributeValues.First().Value.S == key
+            ),
+            Arg.Any<CancellationToken>()
+        );
+        cacheManager.Received(1).Set(key, Arg.Is<Dictionary<string, string>>(x =>
             x.First().Key == result.First().Key &&
             x.First().Value == result.First().Value &&
             x.Last().Key == result.Last().Key &&
             x.Last().Value == result.Last().Value
-        ), duration), Times.Once);
+        ), duration);
 
         Assert.NotNull(result);
         Assert.Equal(value.First().Key, result.First().Key);
@@ -1063,7 +971,7 @@ public class DynamoDBProviderTest
         // Arrange
         var key = Guid.NewGuid().ToString();
         var duration = CacheManager.DefaultMaxAge.Add(TimeSpan.FromHours(10));
-        var value = new Dictionary<string, string>()
+        var value = new Dictionary<string, string>
         {
             { Guid.NewGuid().ToString(), Guid.NewGuid().ToString() },
             { Guid.NewGuid().ToString(), Guid.NewGuid().ToString() }
@@ -1071,51 +979,47 @@ public class DynamoDBProviderTest
         var response = new QueryResponse
         {
             Items = value.Select(kv =>
-                new Dictionary<string, AttributeValue>()
+                new Dictionary<string, AttributeValue>
                 {
                     { "sk", new AttributeValue { S = kv.Key } },
                     { "value", new AttributeValue { S = kv.Value } }
                 }).ToList()
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonDynamoDB>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonDynamoDB>();
+        var transformerManager = Substitute.For<ITransformerManager>();
 
-        client.Setup(c =>
-            c.QueryAsync(It.IsAny<QueryRequest>(), It.IsAny<CancellationToken>())
-        ).ReturnsAsync(response);
+        client.QueryAsync(Arg.Any<QueryRequest>(), Arg.Any<CancellationToken>())
+            .Returns(response);
 
-        cacheManager.Setup(c =>
-            c.Get(key)
-        ).Returns(null);
+        cacheManager.Get(key).Returns(null);
 
         var provider = new DynamoDBProvider()
-            .UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object)
+            .UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager)
             .DefaultMaxAge(duration);
 
         // Act
         var result = await provider.GetMultipleAsync(key);
 
         // Assert
-        cacheManager.Verify(v => v.Get(key), Times.Once);
-        client.Verify(v =>
-                v.QueryAsync(
-                    It.Is<QueryRequest>(x =>
-                        x.ExpressionAttributeValues.First().Key == x.KeyConditionExpression
-                            .Split('=', StringSplitOptions.TrimEntries).Last() &&
-                        x.ExpressionAttributeValues.First().Value.S == key
-                    ),
-                    It.IsAny<CancellationToken>()),
-            Times.Once);
-        cacheManager.Verify(v => v.Set(key, It.Is<Dictionary<string, string>>(x =>
+        cacheManager.Received(1).Get(key);
+        await client.Received(1).QueryAsync(
+            Arg.Is<QueryRequest>(x =>
+                x.ExpressionAttributeValues.First().Key == x.KeyConditionExpression
+                    .Split('=', StringSplitOptions.TrimEntries).Last() &&
+                x.ExpressionAttributeValues.First().Value.S == key
+            ),
+            Arg.Any<CancellationToken>()
+        );
+        cacheManager.Received(1).Set(key, Arg.Is<Dictionary<string, string>>(x =>
             x.First().Key == result.First().Key &&
             x.First().Value == result.First().Value &&
             x.Last().Key == result.Last().Key &&
             x.Last().Value == result.Last().Value
-        ), duration), Times.Once);
+        ), duration);
 
         Assert.NotNull(result);
         Assert.Equal(value.First().Key, result.First().Key);
@@ -1146,22 +1050,19 @@ public class DynamoDBProviderTest
                 }).ToList()
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonDynamoDB>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonDynamoDB>();
+        var transformerManager = Substitute.For<ITransformerManager>();
 
-        client.Setup(c =>
-            c.QueryAsync(It.IsAny<QueryRequest>(), It.IsAny<CancellationToken>())
-        ).ReturnsAsync(response);
+        client.QueryAsync(Arg.Any<QueryRequest>(), Arg.Any<CancellationToken>())
+            .Returns(response);
 
-        cacheManager.Setup(c =>
-            c.Get(key)
-        ).Returns(null);
+        cacheManager.Get(key).Returns(null);
 
         var provider = new DynamoDBProvider()
-            .UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object)
+            .UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager)
             .DefaultMaxAge(defaultMaxAge);
 
         // Act
@@ -1170,22 +1071,21 @@ public class DynamoDBProviderTest
             .GetMultipleAsync(key);
 
         // Assert
-        cacheManager.Verify(v => v.Get(key), Times.Once);
-        client.Verify(v =>
-                v.QueryAsync(
-                    It.Is<QueryRequest>(x =>
-                        x.ExpressionAttributeValues.First().Key == x.KeyConditionExpression
-                            .Split('=', StringSplitOptions.TrimEntries).Last() &&
-                        x.ExpressionAttributeValues.First().Value.S == key
-                    ),
-                    It.IsAny<CancellationToken>()),
-            Times.Once);
-        cacheManager.Verify(v => v.Set(key, It.Is<Dictionary<string, string>>(x =>
+        cacheManager.Received(1).Get(key);
+        await client.Received(1).QueryAsync(
+            Arg.Is<QueryRequest>(x =>
+                x.ExpressionAttributeValues.First().Key == x.KeyConditionExpression
+                    .Split('=', StringSplitOptions.TrimEntries).Last() &&
+                x.ExpressionAttributeValues.First().Value.S == key
+            ),
+            Arg.Any<CancellationToken>()
+        );
+        cacheManager.Received(1).Set(key, Arg.Is<Dictionary<string, string>>(x =>
             x.First().Key == result.First().Key &&
             x.First().Value == result.First().Value &&
             x.Last().Key == result.Last().Key &&
             x.Last().Value == result.Last().Value
-        ), duration), Times.Once);
+        ), duration);
 
         Assert.NotNull(result);
         Assert.Equal(value.First().Key, result.First().Key);
@@ -1218,22 +1118,19 @@ public class DynamoDBProviderTest
                 }).ToList()
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonDynamoDB>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonDynamoDB>();
+        var transformerManager = Substitute.For<ITransformerManager>();
 
-        client.Setup(c =>
-            c.QueryAsync(It.IsAny<QueryRequest>(), It.IsAny<CancellationToken>())
-        ).ReturnsAsync(response);
+        client.QueryAsync(Arg.Any<QueryRequest>(), Arg.Any<CancellationToken>())
+            .Returns(response);
 
-        cacheManager.Setup(c =>
-            c.Get(key)
-        ).Returns(null);
+        cacheManager.Get(key).Returns(null);
 
         var provider = new DynamoDBProvider()
-            .UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object)
+            .UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager)
             .UseTable(tableName);
 
         // Act
@@ -1241,19 +1138,19 @@ public class DynamoDBProviderTest
             .GetMultipleAsync(key);
 
         // Assert
-        cacheManager.Verify(v => v.Get(key), Times.Once);
-        client.Verify(v =>
-                v.QueryAsync(
-                    It.Is<QueryRequest>(x =>
-                        x.TableName == tableName &&
-                        x.KeyConditionExpression.Split('=', StringSplitOptions.TrimEntries).First() ==
-                        primaryKeyAttribute &&
-                        x.ExpressionAttributeValues.First().Key == x.KeyConditionExpression
-                            .Split('=', StringSplitOptions.TrimEntries).Last() &&
-                        x.ExpressionAttributeValues.First().Value.S == key
-                    ),
-                    It.IsAny<CancellationToken>()),
-            Times.Once);
+        cacheManager.Received(1).Get(key);
+        await client.Received(1).QueryAsync(
+            Arg.Is<QueryRequest>(x =>
+                x.TableName == tableName &&
+                x.KeyConditionExpression.Split('=', StringSplitOptions.TrimEntries).First() ==
+                primaryKeyAttribute &&
+                x.ExpressionAttributeValues.First().Key == x.KeyConditionExpression
+                    .Split('=', StringSplitOptions.TrimEntries).Last() &&
+                x.ExpressionAttributeValues.First().Value.S == key
+            ),
+            Arg.Any<CancellationToken>()
+        );
+
 
         Assert.NotNull(result);
         Assert.Equal(value.First().Key, result.First().Key);
@@ -1286,22 +1183,19 @@ public class DynamoDBProviderTest
                 }).ToList()
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonDynamoDB>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonDynamoDB>();
+        var transformerManager = Substitute.For<ITransformerManager>();
 
-        client.Setup(c =>
-            c.QueryAsync(It.IsAny<QueryRequest>(), It.IsAny<CancellationToken>())
-        ).ReturnsAsync(response);
+        client.QueryAsync(Arg.Any<QueryRequest>(), Arg.Any<CancellationToken>())
+            .Returns(response);
 
-        cacheManager.Setup(c =>
-            c.Get(key)
-        ).Returns(null);
+        cacheManager.Get(key).Returns(null);
 
         var provider = new DynamoDBProvider()
-            .UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object)
+            .UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager)
             .UseTable(tableName, primaryKeyAttribute, sortKeyAttribute, valueAttribute);
 
         // Act
@@ -1309,19 +1203,18 @@ public class DynamoDBProviderTest
             .GetMultipleAsync(key);
 
         // Assert
-        cacheManager.Verify(v => v.Get(key), Times.Once);
-        client.Verify(v =>
-                v.QueryAsync(
-                    It.Is<QueryRequest>(x =>
-                        x.TableName == tableName &&
-                        x.KeyConditionExpression.Split('=', StringSplitOptions.TrimEntries).First() ==
-                        primaryKeyAttribute &&
-                        x.ExpressionAttributeValues.First().Key == x.KeyConditionExpression
-                            .Split('=', StringSplitOptions.TrimEntries).Last() &&
-                        x.ExpressionAttributeValues.First().Value.S == key
-                    ),
-                    It.IsAny<CancellationToken>()),
-            Times.Once);
+        cacheManager.Received(1).Get(key);
+        await client.Received(1).QueryAsync(
+            Arg.Is<QueryRequest>(x =>
+                x.TableName == tableName &&
+                x.KeyConditionExpression.Split('=', StringSplitOptions.TrimEntries).First() ==
+                primaryKeyAttribute &&
+                x.ExpressionAttributeValues.First().Key == x.KeyConditionExpression
+                    .Split('=', StringSplitOptions.TrimEntries).Last() &&
+                x.ExpressionAttributeValues.First().Value.S == key
+            ),
+            Arg.Any<CancellationToken>()
+        );
 
         Assert.NotNull(result);
         Assert.Equal(value.First().Key, result.First().Key);

--- a/libraries/tests/AWS.Lambda.Powertools.Parameters.Tests/SecretsManager/SecretsProviderTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Parameters.Tests/SecretsManager/SecretsProviderTest.cs
@@ -23,7 +23,7 @@ using AWS.Lambda.Powertools.Parameters.Provider;
 using AWS.Lambda.Powertools.Parameters.Internal.Provider;
 using AWS.Lambda.Powertools.Parameters.SecretsManager;
 using AWS.Lambda.Powertools.Parameters.Transform;
-using Moq;
+using NSubstitute;
 using Xunit;
 
 namespace AWS.Lambda.Powertools.Parameters.Tests.SecretsManager;
@@ -41,33 +41,32 @@ public class SecretsProviderTest
         var transformerName = Guid.NewGuid().ToString();
         var duration = CacheManager.DefaultMaxAge.Add(TimeSpan.FromHours(10));
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSecretsManager>();
-        var transformerManager = new Mock<ITransformerManager>();
-        var transformer = new Mock<ITransformer>();
-        var providerHandler = new Mock<IParameterProviderBaseHandler>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSecretsManager>();
+        var transformerManager = Substitute.For<ITransformerManager>();
+        var transformer = Substitute.For<ITransformer>();
+        var providerHandler = Substitute.For<IParameterProviderBaseHandler>();
 
-        providerHandler.Setup(c =>
-            c.GetAsync<string>(key, It.IsAny<ParameterProviderConfiguration?>(), null, null)
-        ).ReturnsAsync(value);
+        providerHandler.GetAsync<string>(key, Arg.Any<ParameterProviderConfiguration?>(), null, null)
+            .Returns(value);
 
         var secretsProvider = new SecretsProvider();
-        secretsProvider.SetHandler(providerHandler.Object);
-        secretsProvider.UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+        secretsProvider.SetHandler(providerHandler);
+        secretsProvider.UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
         secretsProvider.DefaultMaxAge(duration);
-        secretsProvider.AddTransformer(transformerName, transformer.Object);
+        secretsProvider.AddTransformer(transformerName, transformer);
 
         // Act
         var result = await secretsProvider.GetAsync(key);
 
         // Assert
-        providerHandler.Verify(v => v.GetAsync<string>(key, null, null, null), Times.Once);
-        providerHandler.Verify(v => v.SetCacheManager(cacheManager.Object), Times.Once);
-        providerHandler.Verify(v => v.SetTransformerManager(transformerManager.Object), Times.Once);
-        providerHandler.Verify(v => v.SetDefaultMaxAge(duration), Times.Once);
-        providerHandler.Verify(v => v.AddCustomTransformer(transformerName, transformer.Object), Times.Once);
+        await providerHandler.Received(1).GetAsync<string>(key, null, null, null);
+        providerHandler.Received(1).SetCacheManager(cacheManager);
+        providerHandler.Received(1).SetTransformerManager(transformerManager);
+        providerHandler.Received(1).SetDefaultMaxAge(duration);
+        providerHandler.Received(1).AddCustomTransformer(transformerName, transformer);
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -79,20 +78,19 @@ public class SecretsProviderTest
         var key = Guid.NewGuid().ToString();
         var value = Guid.NewGuid().ToString();
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSecretsManager>();
-        var transformerManager = new Mock<ITransformerManager>();
-        var providerHandler = new Mock<IParameterProviderBaseHandler>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSecretsManager>();
+        var transformerManager = Substitute.For<ITransformerManager>();
+        var providerHandler = Substitute.For<IParameterProviderBaseHandler>();
 
-        providerHandler.Setup(c =>
-            c.GetAsync<string>(key, It.IsAny<ParameterProviderConfiguration?>(), null, null)
-        ).ReturnsAsync(value);
+        providerHandler.GetAsync<string>(key, Arg.Any<ParameterProviderConfiguration?>(), null, null)
+            .Returns(value);
 
         var secretsProvider = new SecretsProvider();
-        secretsProvider.SetHandler(providerHandler.Object);
-        secretsProvider.UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+        secretsProvider.SetHandler(providerHandler);
+        secretsProvider.UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await secretsProvider
@@ -100,12 +98,10 @@ public class SecretsProviderTest
             .GetAsync(key);
 
         // Assert
-        providerHandler.Verify(
-            v => v.GetAsync<string>(key,
-                It.Is<ParameterProviderConfiguration?>(x =>
-                    x != null && x.ForceFetch
-                ), null,
-                null), Times.Once);
+        await providerHandler.Received(1).GetAsync<string>(key,
+            Arg.Is<ParameterProviderConfiguration?>(x => x != null && x.ForceFetch),
+            null,
+            null);
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -118,20 +114,19 @@ public class SecretsProviderTest
         var value = Guid.NewGuid().ToString();
         var duration = CacheManager.DefaultMaxAge.Add(TimeSpan.FromHours(10));
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSecretsManager>();
-        var transformerManager = new Mock<ITransformerManager>();
-        var providerHandler = new Mock<IParameterProviderBaseHandler>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSecretsManager>();
+        var transformerManager = Substitute.For<ITransformerManager>();
+        var providerHandler = Substitute.For<IParameterProviderBaseHandler>();
 
-        providerHandler.Setup(c =>
-            c.GetAsync<string>(key, It.IsAny<ParameterProviderConfiguration?>(), null, null)
-        ).ReturnsAsync(value);
+        providerHandler.GetAsync<string>(key, Arg.Any<ParameterProviderConfiguration?>(), null, null)
+            .Returns(value);
 
         var secretsProvider = new SecretsProvider();
-        secretsProvider.SetHandler(providerHandler.Object);
-        secretsProvider.UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+        secretsProvider.SetHandler(providerHandler);
+        secretsProvider.UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await secretsProvider
@@ -139,12 +134,10 @@ public class SecretsProviderTest
             .GetAsync(key);
 
         // Assert
-        providerHandler.Verify(
-            v => v.GetAsync<string>(key,
-                It.Is<ParameterProviderConfiguration?>(x =>
-                    x != null && x.MaxAge == duration
-                ), null,
-                null), Times.Once);
+        await providerHandler.Received(1).GetAsync<string>(key,
+            Arg.Is<ParameterProviderConfiguration?>(x => x != null && x.MaxAge == duration),
+            null,
+            null);
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -156,34 +149,31 @@ public class SecretsProviderTest
         var key = Guid.NewGuid().ToString();
         var value = Guid.NewGuid().ToString();
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSecretsManager>();
-        var transformerManager = new Mock<ITransformerManager>();
-        var transformer = new Mock<ITransformer>();
-        var providerHandler = new Mock<IParameterProviderBaseHandler>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSecretsManager>();
+        var transformerManager = Substitute.For<ITransformerManager>();
+        var transformer = Substitute.For<ITransformer>();
+        var providerHandler = Substitute.For<IParameterProviderBaseHandler>();
 
-        providerHandler.Setup(c =>
-            c.GetAsync<string>(key, It.IsAny<ParameterProviderConfiguration?>(), null, null)
-        ).ReturnsAsync(value);
+        providerHandler.GetAsync<string>(key, Arg.Any<ParameterProviderConfiguration?>(), null, null)
+            .Returns(value);
 
         var secretsProvider = new SecretsProvider();
-        secretsProvider.SetHandler(providerHandler.Object);
-        secretsProvider.UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+        secretsProvider.SetHandler(providerHandler);
+        secretsProvider.UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await secretsProvider
-            .WithTransformation(transformer.Object)
+            .WithTransformation(transformer)
             .GetAsync(key);
 
         // Assert
-        providerHandler.Verify(
-            v => v.GetAsync<string>(key,
-                It.Is<ParameterProviderConfiguration?>(x =>
-                    x != null && x.Transformer == transformer.Object
-                ), null,
-                null), Times.Once);
+        await providerHandler.Received(1).GetAsync<string>(key,
+            Arg.Is<ParameterProviderConfiguration?>(x => x != null && x.Transformer == transformer),
+            null,
+            null);
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -195,21 +185,24 @@ public class SecretsProviderTest
         var key = Guid.NewGuid().ToString();
         var value = Guid.NewGuid().ToString();
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSecretsManager>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSecretsManager>();
+        var transformerManager = Substitute.For<ITransformerManager>();
         var transformation = Transformation.Auto;
-        var providerHandler = new Mock<IParameterProviderBaseHandler>();
+        var providerHandler = Substitute.For<IParameterProviderBaseHandler>();
 
-        providerHandler.Setup(c =>
-            c.GetAsync<string>(key, It.IsAny<ParameterProviderConfiguration?>(), transformation, null)
-        ).ReturnsAsync(value);
+        providerHandler.GetAsync<string>(
+            key,
+            Arg.Is<ParameterProviderConfiguration?>(x => x != null && !x.ForceFetch),
+            transformation,
+            null
+        )!.Returns(Task.FromResult(value));
 
         var secretsProvider = new SecretsProvider();
-        secretsProvider.SetHandler(providerHandler.Object);
-        secretsProvider.UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+        secretsProvider.SetHandler(providerHandler);
+        secretsProvider.UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await secretsProvider
@@ -217,13 +210,12 @@ public class SecretsProviderTest
             .GetAsync(key);
 
         // Assert
-        providerHandler.Verify(
-            v => v.GetAsync<string>(key,
-                It.Is<ParameterProviderConfiguration?>(x =>
-                    x != null && !x.ForceFetch
-                ),
-                It.Is<Transformation?>(x => x == transformation),
-                null), Times.Once);
+        await providerHandler.Received(1).GetAsync<string>(
+            key,
+            Arg.Is<ParameterProviderConfiguration?>(x => x != null && !x.ForceFetch),
+            transformation,
+            null
+        );
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -235,21 +227,24 @@ public class SecretsProviderTest
         var key = Guid.NewGuid().ToString();
         var value = Guid.NewGuid().ToString();
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSecretsManager>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSecretsManager>();
+        var transformerManager = Substitute.For<ITransformerManager>();
         var transformerName = Guid.NewGuid().ToString();
-        var providerHandler = new Mock<IParameterProviderBaseHandler>();
+        var providerHandler = Substitute.For<IParameterProviderBaseHandler>();
 
-        providerHandler.Setup(c =>
-            c.GetAsync<string>(key, It.IsAny<ParameterProviderConfiguration?>(), null, transformerName)
-        ).ReturnsAsync(value);
+        providerHandler.GetAsync<string>(
+            key,
+            Arg.Is<ParameterProviderConfiguration?>(x => x != null && !x.ForceFetch),
+            null,
+            transformerName
+        )!.Returns(Task.FromResult(value));
 
         var secretsProvider = new SecretsProvider();
-        secretsProvider.SetHandler(providerHandler.Object);
-        secretsProvider.UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+        secretsProvider.SetHandler(providerHandler);
+        secretsProvider.UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await secretsProvider
@@ -257,14 +252,12 @@ public class SecretsProviderTest
             .GetAsync(key);
 
         // Assert
-        providerHandler.Verify(
-            v => v.GetAsync<string>(key,
-                It.Is<ParameterProviderConfiguration?>(x =>
-                    x != null && !x.ForceFetch
-                ),
-                null,
-                It.Is<string?>(x => x == transformerName))
-            , Times.Once);
+        await providerHandler.Received(1).GetAsync<string>(
+            key,
+            Arg.Is<ParameterProviderConfiguration?>(x => x != null && !x.ForceFetch),
+            null,
+            transformerName
+        );
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -281,31 +274,26 @@ public class SecretsProviderTest
             SecretString = value
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSecretsManager>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSecretsManager>();
+        var transformerManager = Substitute.For<ITransformerManager>();
 
-        client.Setup(c =>
-            c.GetSecretValueAsync(It.IsAny<GetSecretValueRequest>(), It.IsAny<CancellationToken>())
-        ).ReturnsAsync(response);
+        client.GetSecretValueAsync(Arg.Any<GetSecretValueRequest>(), Arg.Any<CancellationToken>())
+            .Returns(response);
 
-        cacheManager.Setup(c =>
-            c.Get(key)
-        ).Returns(valueFromCache);
+        cacheManager.Get(key).Returns(valueFromCache);
 
         var secretsProvider = new SecretsProvider()
-            .UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+            .UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await secretsProvider.GetAsync(key);
 
         // Assert
-        client.Verify(v =>
-                v.GetSecretValueAsync(It.IsAny<GetSecretValueRequest>(),
-                    It.IsAny<CancellationToken>()),
-            Times.Never);
+        await client.DidNotReceive()
+            .GetSecretValueAsync(Arg.Any<GetSecretValueRequest>(), Arg.Any<CancellationToken>());
         Assert.NotNull(result);
         Assert.Equal(valueFromCache, result);
     }
@@ -322,36 +310,28 @@ public class SecretsProviderTest
             SecretString = value
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSecretsManager>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSecretsManager>();
+        var transformerManager = Substitute.For<ITransformerManager>();
 
-        client.Setup(c =>
-            c.GetSecretValueAsync(It.IsAny<GetSecretValueRequest>(), It.IsAny<CancellationToken>())
-        ).ReturnsAsync(response);
+        client.GetSecretValueAsync(Arg.Any<GetSecretValueRequest>(), Arg.Any<CancellationToken>())
+            .Returns(response);
 
-        cacheManager.Setup(c =>
-            c.Get(key)
-        ).Returns(valueFromCache);
+        cacheManager.Get(key).Returns(valueFromCache);
 
         var secretsProvider = new SecretsProvider()
-            .UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+            .UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await secretsProvider.ForceFetch().GetAsync(key);
 
         // Assert
-        cacheManager.Verify(v => v.Get(key), Times.Never);
-        client.Verify(v =>
-                v.GetSecretValueAsync(
-                    It.Is<GetSecretValueRequest>(x =>
-                        x.SecretId == key &&
-                        x.VersionStage == CurrentVersionStage
-                    ),
-                    It.IsAny<CancellationToken>()),
-            Times.Once);
+        cacheManager.DidNotReceive().Get(key);
+        await client.Received(1).GetSecretValueAsync(
+            Arg.Is<GetSecretValueRequest>(x => x.SecretId == key && x.VersionStage == CurrentVersionStage),
+            Arg.Any<CancellationToken>());
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -368,37 +348,29 @@ public class SecretsProviderTest
             SecretString = value
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSecretsManager>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSecretsManager>();
+        var transformerManager = Substitute.For<ITransformerManager>();
 
-        client.Setup(c =>
-            c.GetSecretValueAsync(It.IsAny<GetSecretValueRequest>(), It.IsAny<CancellationToken>())
-        ).ReturnsAsync(response);
+        client.GetSecretValueAsync(Arg.Any<GetSecretValueRequest>(), Arg.Any<CancellationToken>())
+            .Returns(response);
 
-        cacheManager.Setup(c =>
-            c.Get(key)
-        ).Returns(null);
+        cacheManager.Get(key).Returns(null);
 
         var secretsProvider = new SecretsProvider()
-            .UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+            .UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await secretsProvider.GetAsync(key);
 
         // Assert
-        cacheManager.Verify(v => v.Get(key), Times.Once);
-        client.Verify(v =>
-                v.GetSecretValueAsync(
-                    It.Is<GetSecretValueRequest>(x =>
-                        x.SecretId == key &&
-                        x.VersionStage == CurrentVersionStage
-                    ),
-                    It.IsAny<CancellationToken>()),
-            Times.Once);
-        cacheManager.Verify(v => v.Set(key, value, duration), Times.Once);
+        cacheManager.Received(1).Get(key);
+        await client.Received(1).GetSecretValueAsync(
+            Arg.Is<GetSecretValueRequest>(x => x.SecretId == key && x.VersionStage == CurrentVersionStage),
+            Arg.Any<CancellationToken>());
+        cacheManager.Received(1).Set(key, value, duration);
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -415,38 +387,30 @@ public class SecretsProviderTest
             SecretString = value
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSecretsManager>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSecretsManager>();
+        var transformerManager = Substitute.For<ITransformerManager>();
 
-        client.Setup(c =>
-            c.GetSecretValueAsync(It.IsAny<GetSecretValueRequest>(), It.IsAny<CancellationToken>())
-        ).ReturnsAsync(response);
+        client.GetSecretValueAsync(Arg.Any<GetSecretValueRequest>(), Arg.Any<CancellationToken>())
+            .Returns(response);
 
-        cacheManager.Setup(c =>
-            c.Get(key)
-        ).Returns(null);
+        cacheManager.Get(key).Returns(null);
 
         var secretsProvider = new SecretsProvider()
-            .UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object)
+            .UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager)
             .DefaultMaxAge(duration);
 
         // Act
         var result = await secretsProvider.GetAsync(key);
 
         // Assert
-        cacheManager.Verify(v => v.Get(key), Times.Once);
-        client.Verify(v =>
-                v.GetSecretValueAsync(
-                    It.Is<GetSecretValueRequest>(x =>
-                        x.SecretId == key &&
-                        x.VersionStage == CurrentVersionStage
-                    ),
-                    It.IsAny<CancellationToken>()),
-            Times.Once);
-        cacheManager.Verify(v => v.Set(key, value, duration), Times.Once);
+        cacheManager.Received(1).Get(key);
+        await client.Received(1).GetSecretValueAsync(
+            Arg.Is<GetSecretValueRequest>(x => x.SecretId == key && x.VersionStage == CurrentVersionStage),
+            Arg.Any<CancellationToken>());
+        cacheManager.Received(1).Set(key, value, duration);
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -464,22 +428,19 @@ public class SecretsProviderTest
             SecretString = value
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSecretsManager>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSecretsManager>();
+        var transformerManager = Substitute.For<ITransformerManager>();
 
-        client.Setup(c =>
-            c.GetSecretValueAsync(It.IsAny<GetSecretValueRequest>(), It.IsAny<CancellationToken>())
-        ).ReturnsAsync(response);
+        client.GetSecretValueAsync(Arg.Any<GetSecretValueRequest>(), Arg.Any<CancellationToken>())
+            .Returns(response);
 
-        cacheManager.Setup(c =>
-            c.Get(key)
-        ).Returns(null);
+        cacheManager.Get(key).Returns(null);
 
         var secretsProvider = new SecretsProvider()
-            .UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object)
+            .UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager)
             .DefaultMaxAge(defaultMaxAge);
 
         // Act
@@ -488,16 +449,11 @@ public class SecretsProviderTest
             .GetAsync(key);
 
         // Assert
-        cacheManager.Verify(v => v.Get(key), Times.Once);
-        client.Verify(v =>
-                v.GetSecretValueAsync(
-                    It.Is<GetSecretValueRequest>(x =>
-                        x.SecretId == key &&
-                        x.VersionStage == CurrentVersionStage
-                    ),
-                    It.IsAny<CancellationToken>()),
-            Times.Once);
-        cacheManager.Verify(v => v.Set(key, value, duration), Times.Once);
+        cacheManager.Received(1).Get(key);
+        await client.Received(1).GetSecretValueAsync(
+            Arg.Is<GetSecretValueRequest>(x => x.SecretId == key && x.VersionStage == CurrentVersionStage),
+            Arg.Any<CancellationToken>());
+        cacheManager.Received(1).Set(key, value, duration);
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -517,36 +473,28 @@ public class SecretsProviderTest
             SecretBinary = new MemoryStream(convertedByteArray)
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSecretsManager>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSecretsManager>();
+        var transformerManager = Substitute.For<ITransformerManager>();
 
-        client.Setup(c =>
-            c.GetSecretValueAsync(It.IsAny<GetSecretValueRequest>(), It.IsAny<CancellationToken>())
-        ).ReturnsAsync(response);
+        client.GetSecretValueAsync(Arg.Any<GetSecretValueRequest>(), Arg.Any<CancellationToken>())
+            .Returns(response);
 
-        cacheManager.Setup(c =>
-            c.Get(key)
-        ).Returns(null);
+        cacheManager.Get(key).Returns(null);
 
         var secretsProvider = new SecretsProvider()
-            .UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+            .UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await secretsProvider.GetAsync(key);
 
         // Assert
-        cacheManager.Verify(v => v.Get(key), Times.Once);
-        client.Verify(v =>
-                v.GetSecretValueAsync(
-                    It.Is<GetSecretValueRequest>(x =>
-                        x.SecretId == key &&
-                        x.VersionStage == CurrentVersionStage
-                    ),
-                    It.IsAny<CancellationToken>()),
-            Times.Once);
+        cacheManager.Received(1).Get(key);
+        await client.Received(1).GetSecretValueAsync(
+            Arg.Is<GetSecretValueRequest>(x => x.SecretId == key && x.VersionStage == CurrentVersionStage),
+            Arg.Any<CancellationToken>());
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -557,23 +505,21 @@ public class SecretsProviderTest
         // Arrange
         var key = Guid.NewGuid().ToString();
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSecretsManager>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSecretsManager>();
+        var transformerManager = Substitute.For<ITransformerManager>();
 
-        cacheManager.Setup(c =>
-            c.Get(key)
-        ).Returns(null);
+        cacheManager.Get(key).Returns(null);
 
         var secretsProvider = new SecretsProvider()
-            .UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+            .UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
-        Task<IDictionary<string, string?>> Act() => secretsProvider.GetMultipleAsync(key);
+        async Task<IDictionary<string, string?>> Act() => await secretsProvider.GetMultipleAsync(key);
 
+        // Assert
         await Assert.ThrowsAsync<NotSupportedException>(Act);
-
     }
 }

--- a/libraries/tests/AWS.Lambda.Powertools.Parameters.Tests/SimpleSystemsManagement/SsmProviderTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Parameters.Tests/SimpleSystemsManagement/SsmProviderTest.cs
@@ -22,7 +22,7 @@ using AWS.Lambda.Powertools.Parameters.Provider;
 using AWS.Lambda.Powertools.Parameters.Internal.Provider;
 using AWS.Lambda.Powertools.Parameters.SimpleSystemsManagement;
 using AWS.Lambda.Powertools.Parameters.Transform;
-using Moq;
+using NSubstitute;
 using Xunit;
 
 namespace AWS.Lambda.Powertools.Parameters.Tests.SimpleSystemsManagement;
@@ -38,33 +38,33 @@ public class SsmProviderTest
         var transformerName = Guid.NewGuid().ToString();
         var duration = CacheManager.DefaultMaxAge.Add(TimeSpan.FromHours(10));
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSimpleSystemsManagement>();
-        var transformerManager = new Mock<ITransformerManager>();
-        var transformer = new Mock<ITransformer>();
-        var providerHandler = new Mock<IParameterProviderBaseHandler>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSimpleSystemsManagement>();
+        var transformerManager = Substitute.For<ITransformerManager>();
+        var transformer = Substitute.For<ITransformer>();
+        var providerHandler = Substitute.For<IParameterProviderBaseHandler>();
 
-        providerHandler.Setup(c =>
-            c.GetAsync<string>(key, It.IsAny<ParameterProviderConfiguration?>(), null, null)
-        ).ReturnsAsync(value);
+        providerHandler
+            .GetAsync<string>(key, Arg.Any<ParameterProviderConfiguration?>(), null, null)!
+            .Returns(Task.FromResult(value));
 
         var ssmProvider = new SsmProvider();
-        ssmProvider.SetHandler(providerHandler.Object);
-        ssmProvider.UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+        ssmProvider.SetHandler(providerHandler);
+        ssmProvider.UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
         ssmProvider.DefaultMaxAge(duration);
-        ssmProvider.AddTransformer(transformerName, transformer.Object);
+        ssmProvider.AddTransformer(transformerName, transformer);
 
         // Act
         var result = await ssmProvider.GetAsync(key);
 
         // Assert
-        providerHandler.Verify(v => v.GetAsync<string>(key, null, null, null), Times.Once);
-        providerHandler.Verify(v => v.SetCacheManager(cacheManager.Object), Times.Once);
-        providerHandler.Verify(v => v.SetTransformerManager(transformerManager.Object), Times.Once);
-        providerHandler.Verify(v => v.SetDefaultMaxAge(duration), Times.Once);
-        providerHandler.Verify(v => v.AddCustomTransformer(transformerName, transformer.Object), Times.Once);
+        await providerHandler.Received(1).GetAsync<string>(key, null, null, null);
+        providerHandler.Received(1).SetCacheManager(cacheManager);
+        providerHandler.Received(1).SetTransformerManager(transformerManager);
+        providerHandler.Received(1).SetDefaultMaxAge(duration);
+        providerHandler.Received(1).AddCustomTransformer(transformerName, transformer);
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -76,20 +76,20 @@ public class SsmProviderTest
         var key = Guid.NewGuid().ToString();
         var value = Guid.NewGuid().ToString();
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSimpleSystemsManagement>();
-        var transformerManager = new Mock<ITransformerManager>();
-        var providerHandler = new Mock<IParameterProviderBaseHandler>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSimpleSystemsManagement>();
+        var transformerManager = Substitute.For<ITransformerManager>();
+        var providerHandler = Substitute.For<IParameterProviderBaseHandler>();
 
-        providerHandler.Setup(c =>
-            c.GetAsync<string>(key, It.IsAny<ParameterProviderConfiguration?>(), null, null)
-        ).ReturnsAsync(value);
+        providerHandler
+            .GetAsync<string>(key, Arg.Any<ParameterProviderConfiguration?>(), null, null)!
+            .Returns(Task.FromResult(value));
 
         var ssmProvider = new SsmProvider();
-        ssmProvider.SetHandler(providerHandler.Object);
-        ssmProvider.UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+        ssmProvider.SetHandler(providerHandler);
+        ssmProvider.UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await ssmProvider
@@ -97,12 +97,12 @@ public class SsmProviderTest
             .GetAsync(key);
 
         // Assert
-        providerHandler.Verify(
-            v => v.GetAsync<string>(key,
-                It.Is<ParameterProviderConfiguration?>(x =>
+        await providerHandler.Received(1)
+            .GetAsync<string>(key,
+                Arg.Is<ParameterProviderConfiguration?>(x =>
                     x != null && x.ForceFetch
                 ), null,
-                null), Times.Once);
+                null);
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -115,20 +115,20 @@ public class SsmProviderTest
         var value = Guid.NewGuid().ToString();
         var duration = CacheManager.DefaultMaxAge.Add(TimeSpan.FromHours(10));
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSimpleSystemsManagement>();
-        var transformerManager = new Mock<ITransformerManager>();
-        var providerHandler = new Mock<IParameterProviderBaseHandler>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSimpleSystemsManagement>();
+        var transformerManager = Substitute.For<ITransformerManager>();
+        var providerHandler = Substitute.For<IParameterProviderBaseHandler>();
 
-        providerHandler.Setup(c =>
-            c.GetAsync<string>(key, It.IsAny<ParameterProviderConfiguration?>(), null, null)
-        ).ReturnsAsync(value);
+        providerHandler
+            .GetAsync<string>(key, Arg.Any<ParameterProviderConfiguration?>(), null, null)!
+            .Returns(Task.FromResult(value));
 
         var ssmProvider = new SsmProvider();
-        ssmProvider.SetHandler(providerHandler.Object);
-        ssmProvider.UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+        ssmProvider.SetHandler(providerHandler);
+        ssmProvider.UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await ssmProvider
@@ -136,12 +136,11 @@ public class SsmProviderTest
             .GetAsync(key);
 
         // Assert
-        providerHandler.Verify(
-            v => v.GetAsync<string>(key,
-                It.Is<ParameterProviderConfiguration?>(x =>
-                    x != null && x.MaxAge == duration
-                ), null,
-                null), Times.Once);
+        await providerHandler
+            .Received(1)
+            .GetAsync<string>(key, Arg.Is<ParameterProviderConfiguration?>(
+                x => x != null && x.MaxAge == duration
+            ), null, null);
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -153,34 +152,33 @@ public class SsmProviderTest
         var key = Guid.NewGuid().ToString();
         var value = Guid.NewGuid().ToString();
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSimpleSystemsManagement>();
-        var transformerManager = new Mock<ITransformerManager>();
-        var transformer = new Mock<ITransformer>();
-        var providerHandler = new Mock<IParameterProviderBaseHandler>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSimpleSystemsManagement>();
+        var transformerManager = Substitute.For<ITransformerManager>();
+        var transformer = Substitute.For<ITransformer>();
+        var providerHandler = Substitute.For<IParameterProviderBaseHandler>();
 
-        providerHandler.Setup(c =>
-            c.GetAsync<string>(key, It.IsAny<ParameterProviderConfiguration?>(), null, null)
-        ).ReturnsAsync(value);
+        providerHandler
+            .GetAsync<string>(key, Arg.Any<ParameterProviderConfiguration?>(), null, null)!
+            .Returns(Task.FromResult(value));
 
         var ssmProvider = new SsmProvider();
-        ssmProvider.SetHandler(providerHandler.Object);
-        ssmProvider.UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+        ssmProvider.SetHandler(providerHandler);
+        ssmProvider.UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await ssmProvider
-            .WithTransformation(transformer.Object)
+            .WithTransformation(transformer)
             .GetAsync(key);
 
         // Assert
-        providerHandler.Verify(
-            v => v.GetAsync<string>(key,
-                It.Is<ParameterProviderConfiguration?>(x =>
-                    x != null && x.Transformer == transformer.Object
-                ), null,
-                null), Times.Once);
+        await providerHandler
+            .Received(1)
+            .GetAsync<string>(key, Arg.Is<ParameterProviderConfiguration?>(
+                x => x != null && x.Transformer == transformer
+            ), null, null);
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -192,21 +190,21 @@ public class SsmProviderTest
         var key = Guid.NewGuid().ToString();
         var value = Guid.NewGuid().ToString();
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSimpleSystemsManagement>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSimpleSystemsManagement>();
+        var transformerManager = Substitute.For<ITransformerManager>();
         var transformation = Transformation.Auto;
-        var providerHandler = new Mock<IParameterProviderBaseHandler>();
+        var providerHandler = Substitute.For<IParameterProviderBaseHandler>();
 
-        providerHandler.Setup(c =>
-            c.GetAsync<string>(key, It.IsAny<ParameterProviderConfiguration?>(), transformation, null)
-        ).ReturnsAsync(value);
+        providerHandler
+            .GetAsync<string>(key, Arg.Any<ParameterProviderConfiguration?>(), transformation, null)!
+            .Returns(Task.FromResult(value));
 
         var ssmProvider = new SsmProvider();
-        ssmProvider.SetHandler(providerHandler.Object);
-        ssmProvider.UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+        ssmProvider.SetHandler(providerHandler);
+        ssmProvider.UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await ssmProvider
@@ -214,13 +212,14 @@ public class SsmProviderTest
             .GetAsync(key);
 
         // Assert
-        providerHandler.Verify(
-            v => v.GetAsync<string>(key,
-                It.Is<ParameterProviderConfiguration?>(x =>
-                    x != null && !x.ForceFetch
+        await providerHandler
+            .Received(1)
+            .GetAsync<string>(key,
+                Arg.Is<ParameterProviderConfiguration?>(
+                    x => x != null && !x.ForceFetch
                 ),
-                It.Is<Transformation?>(x => x == transformation),
-                null), Times.Once);
+                Arg.Is<Transformation?>(x => x == transformation),
+                null);
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -232,21 +231,21 @@ public class SsmProviderTest
         var key = Guid.NewGuid().ToString();
         var value = Guid.NewGuid().ToString();
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSimpleSystemsManagement>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSimpleSystemsManagement>();
+        var transformerManager = Substitute.For<ITransformerManager>();
         var transformerName = Guid.NewGuid().ToString();
-        var providerHandler = new Mock<IParameterProviderBaseHandler>();
+        var providerHandler = Substitute.For<IParameterProviderBaseHandler>();
 
-        providerHandler.Setup(c =>
-            c.GetAsync<string>(key, It.IsAny<ParameterProviderConfiguration?>(), null, transformerName)
-        ).ReturnsAsync(value);
+        providerHandler
+            .GetAsync<string>(key, Arg.Any<ParameterProviderConfiguration?>(), null, transformerName)!
+            .Returns(Task.FromResult(value));
 
         var ssmProvider = new SsmProvider();
-        ssmProvider.SetHandler(providerHandler.Object);
-        ssmProvider.UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+        ssmProvider.SetHandler(providerHandler);
+        ssmProvider.UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await ssmProvider
@@ -254,14 +253,14 @@ public class SsmProviderTest
             .GetAsync(key);
 
         // Assert
-        providerHandler.Verify(
-            v => v.GetAsync<string>(key,
-                It.Is<ParameterProviderConfiguration?>(x =>
-                    x != null && !x.ForceFetch
+        await providerHandler
+            .Received(1)
+            .GetAsync<string>(key,
+                Arg.Is<ParameterProviderConfiguration?>(
+                    x => x != null && !x.ForceFetch
                 ),
                 null,
-                It.Is<string?>(x => x == transformerName))
-            , Times.Once);
+                Arg.Is<string?>(x => x == transformerName));
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -281,31 +280,30 @@ public class SsmProviderTest
             }
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSimpleSystemsManagement>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSimpleSystemsManagement>();
+        var transformerManager = Substitute.For<ITransformerManager>();
 
-        client.Setup(c =>
-            c.GetParameterAsync(It.IsAny<GetParameterRequest>(), It.IsAny<CancellationToken>())
-        ).ReturnsAsync(response);
+        client
+            .GetParameterAsync(Arg.Any<GetParameterRequest>(), Arg.Any<CancellationToken>())
+            .Returns(response);
 
-        cacheManager.Setup(c =>
-            c.Get(key)
-        ).Returns(valueFromCache);
+        cacheManager
+            .Get(key)
+            .Returns(valueFromCache);
 
         var ssmProvider = new SsmProvider()
-            .UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+            .UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await ssmProvider.GetAsync(key);
 
         // Assert
-        client.Verify(v =>
-                v.GetParameterAsync(It.IsAny<GetParameterRequest>(),
-                    It.IsAny<CancellationToken>()),
-            Times.Never);
+        await client
+            .DidNotReceive()
+            .GetParameterAsync(Arg.Any<GetParameterRequest>(), Arg.Any<CancellationToken>());
         Assert.NotNull(result);
         Assert.Equal(valueFromCache, result);
     }
@@ -325,35 +323,35 @@ public class SsmProviderTest
             }
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSimpleSystemsManagement>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSimpleSystemsManagement>();
+        var transformerManager = Substitute.For<ITransformerManager>();
 
-        client.Setup(c =>
-            c.GetParameterAsync(It.IsAny<GetParameterRequest>(), It.IsAny<CancellationToken>())
-        ).ReturnsAsync(response);
+        client
+            .GetParameterAsync(Arg.Any<GetParameterRequest>(), Arg.Any<CancellationToken>())
+            .Returns(response);
 
-        cacheManager.Setup(c =>
-            c.Get(key)
-        ).Returns(valueFromCache);
+        cacheManager
+            .Get(key)
+            .Returns(valueFromCache);
 
         var ssmProvider = new SsmProvider()
-            .UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+            .UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await ssmProvider.ForceFetch().GetAsync(key);
 
         // Assert
-        cacheManager.Verify(v => v.Get(key), Times.Never);
-        client.Verify(v =>
-                v.GetParameterAsync(
-                    It.Is<GetParameterRequest>(x =>
-                        x.Name == key && !x.WithDecryption
-                    ),
-                    It.IsAny<CancellationToken>()),
-            Times.Once);
+        cacheManager
+            .DidNotReceive()
+            .Get(key);
+        await client
+            .Received(1)
+            .GetParameterAsync(
+                Arg.Is<GetParameterRequest>(x => x.Name == key && !x.WithDecryption),
+                Arg.Any<CancellationToken>());
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -373,36 +371,29 @@ public class SsmProviderTest
             }
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSimpleSystemsManagement>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSimpleSystemsManagement>();
+        var transformerManager = Substitute.For<ITransformerManager>();
 
-        client.Setup(c =>
-            c.GetParameterAsync(It.IsAny<GetParameterRequest>(), It.IsAny<CancellationToken>())
-        ).ReturnsAsync(response);
+        client.GetParameterAsync(Arg.Any<GetParameterRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
 
-        cacheManager.Setup(c =>
-            c.Get(key)
-        ).Returns(null);
+        cacheManager.Get(key).Returns(null);
 
         var ssmProvider = new SsmProvider()
-            .UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+            .UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await ssmProvider.GetAsync(key);
 
         // Assert
-        cacheManager.Verify(v => v.Get(key), Times.Once);
-        client.Verify(v =>
-                v.GetParameterAsync(
-                    It.Is<GetParameterRequest>(x =>
-                        x.Name == key && !x.WithDecryption
-                    ),
-                    It.IsAny<CancellationToken>()),
-            Times.Once);
-        cacheManager.Verify(v => v.Set(key, value, duration), Times.Once);
+        cacheManager.Received(1).Get(key);
+        await client.Received(1)
+            .GetParameterAsync(Arg.Is<GetParameterRequest>(x =>
+                x.Name == key && !x.WithDecryption), Arg.Any<CancellationToken>());
+        cacheManager.Received(1).Set(key, value, duration);
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -422,37 +413,30 @@ public class SsmProviderTest
             }
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSimpleSystemsManagement>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSimpleSystemsManagement>();
+        var transformerManager = Substitute.For<ITransformerManager>();
 
-        client.Setup(c =>
-            c.GetParameterAsync(It.IsAny<GetParameterRequest>(), It.IsAny<CancellationToken>())
-        ).ReturnsAsync(response);
+        client.GetParameterAsync(Arg.Any<GetParameterRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
 
-        cacheManager.Setup(c =>
-            c.Get(key)
-        ).Returns(null);
+        cacheManager.Get(key).Returns(null);
 
         var ssmProvider = new SsmProvider()
-            .UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object)
+            .UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager)
             .DefaultMaxAge(duration);
 
         // Act
         var result = await ssmProvider.GetAsync(key);
 
         // Assert
-        cacheManager.Verify(v => v.Get(key), Times.Once);
-        client.Verify(v =>
-                v.GetParameterAsync(
-                    It.Is<GetParameterRequest>(x =>
-                        x.Name == key && !x.WithDecryption
-                    ),
-                    It.IsAny<CancellationToken>()),
-            Times.Once);
-        cacheManager.Verify(v => v.Set(key, value, duration), Times.Once);
+        cacheManager.Received(1).Get(key);
+        await client.Received(1)
+            .GetParameterAsync(Arg.Is<GetParameterRequest>(x =>
+                x.Name == key && !x.WithDecryption), Arg.Any<CancellationToken>());
+        cacheManager.Received(1).Set(key, value, duration);
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -473,22 +457,19 @@ public class SsmProviderTest
             }
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSimpleSystemsManagement>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSimpleSystemsManagement>();
+        var transformerManager = Substitute.For<ITransformerManager>();
 
-        client.Setup(c =>
-            c.GetParameterAsync(It.IsAny<GetParameterRequest>(), It.IsAny<CancellationToken>())
-        ).ReturnsAsync(response);
+        client.GetParameterAsync(Arg.Any<GetParameterRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
 
-        cacheManager.Setup(c =>
-            c.Get(key)
-        ).Returns(null);
+        cacheManager.Get(key).Returns(null);
 
         var ssmProvider = new SsmProvider()
-            .UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object)
+            .UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager)
             .DefaultMaxAge(defaultMaxAge);
 
         // Act
@@ -497,15 +478,11 @@ public class SsmProviderTest
             .GetAsync(key);
 
         // Assert
-        cacheManager.Verify(v => v.Get(key), Times.Once);
-        client.Verify(v =>
-                v.GetParameterAsync(
-                    It.Is<GetParameterRequest>(x =>
-                        x.Name == key && !x.WithDecryption
-                    ),
-                    It.IsAny<CancellationToken>()),
-            Times.Once);
-        cacheManager.Verify(v => v.Set(key, value, duration), Times.Once);
+        cacheManager.Received(1).Get(key);
+        await client.Received(1)
+            .GetParameterAsync(Arg.Is<GetParameterRequest>(x =>
+                x.Name == key && !x.WithDecryption), Arg.Any<CancellationToken>());
+        cacheManager.Received(1).Set(key, value, duration);
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -524,22 +501,19 @@ public class SsmProviderTest
             }
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSimpleSystemsManagement>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSimpleSystemsManagement>();
+        var transformerManager = Substitute.For<ITransformerManager>();
 
-        client.Setup(c =>
-            c.GetParameterAsync(It.IsAny<GetParameterRequest>(), It.IsAny<CancellationToken>())
-        ).ReturnsAsync(response);
+        client.GetParameterAsync(Arg.Any<GetParameterRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
 
-        cacheManager.Setup(c =>
-            c.Get(key)
-        ).Returns(null);
+        cacheManager.Get(key).Returns(null);
 
         var ssmProvider = new SsmProvider()
-            .UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+            .UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await ssmProvider
@@ -547,14 +521,10 @@ public class SsmProviderTest
             .GetAsync(key);
 
         // Assert
-        cacheManager.Verify(v => v.Get(key), Times.Once);
-        client.Verify(v =>
-                v.GetParameterAsync(
-                    It.Is<GetParameterRequest>(x =>
-                        x.Name == key && x.WithDecryption
-                    ),
-                    It.IsAny<CancellationToken>()),
-            Times.Once);
+        cacheManager.Received(1).Get(key);
+        await client.Received(1)
+            .GetParameterAsync(Arg.Is<GetParameterRequest>(x =>
+                x.Name == key && x.WithDecryption), Arg.Any<CancellationToken>());
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -572,33 +542,32 @@ public class SsmProviderTest
         var transformerName = Guid.NewGuid().ToString();
         var duration = CacheManager.DefaultMaxAge.Add(TimeSpan.FromHours(10));
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSimpleSystemsManagement>();
-        var transformerManager = new Mock<ITransformerManager>();
-        var transformer = new Mock<ITransformer>();
-        var providerHandler = new Mock<IParameterProviderBaseHandler>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSimpleSystemsManagement>();
+        var transformerManager = Substitute.For<ITransformerManager>();
+        var transformer = Substitute.For<ITransformer>();
+        var providerHandler = Substitute.For<IParameterProviderBaseHandler>();
 
-        providerHandler.Setup(c =>
-            c.GetMultipleAsync<string>(key, It.IsAny<ParameterProviderConfiguration?>(), null, null)
-        ).ReturnsAsync(value);
+        providerHandler.GetMultipleAsync<string>(key, Arg.Any<ParameterProviderConfiguration?>(), null, null)
+            .Returns(value);
 
         var ssmProvider = new SsmProvider();
-        ssmProvider.SetHandler(providerHandler.Object);
-        ssmProvider.UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+        ssmProvider.SetHandler(providerHandler);
+        ssmProvider.UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
         ssmProvider.DefaultMaxAge(duration);
-        ssmProvider.AddTransformer(transformerName, transformer.Object);
+        ssmProvider.AddTransformer(transformerName, transformer);
 
         // Act
         var result = await ssmProvider.GetMultipleAsync(key);
 
         // Assert
-        providerHandler.Verify(v => v.GetMultipleAsync<string>(key, null, null, null), Times.Once);
-        providerHandler.Verify(v => v.SetCacheManager(cacheManager.Object), Times.Once);
-        providerHandler.Verify(v => v.SetTransformerManager(transformerManager.Object), Times.Once);
-        providerHandler.Verify(v => v.SetDefaultMaxAge(duration), Times.Once);
-        providerHandler.Verify(v => v.AddCustomTransformer(transformerName, transformer.Object), Times.Once);
+        await providerHandler.Received(1).GetMultipleAsync<string>(key, null, null, null);
+        providerHandler.Received(1).SetCacheManager(cacheManager);
+        providerHandler.Received(1).SetTransformerManager(transformerManager);
+        providerHandler.Received(1).SetDefaultMaxAge(duration);
+        providerHandler.Received(1).AddCustomTransformer(transformerName, transformer);
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -614,20 +583,19 @@ public class SsmProviderTest
             { Guid.NewGuid().ToString(), Guid.NewGuid().ToString() }
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSimpleSystemsManagement>();
-        var transformerManager = new Mock<ITransformerManager>();
-        var providerHandler = new Mock<IParameterProviderBaseHandler>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSimpleSystemsManagement>();
+        var transformerManager = Substitute.For<ITransformerManager>();
+        var providerHandler = Substitute.For<IParameterProviderBaseHandler>();
 
-        providerHandler.Setup(c =>
-            c.GetMultipleAsync<string>(key, It.IsAny<ParameterProviderConfiguration?>(), null, null)
-        ).ReturnsAsync(value);
+        providerHandler.GetMultipleAsync<string>(key, Arg.Any<ParameterProviderConfiguration?>(), null, null)
+            .Returns(value);
 
         var ssmProvider = new SsmProvider();
-        ssmProvider.SetHandler(providerHandler.Object);
-        ssmProvider.UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+        ssmProvider.SetHandler(providerHandler);
+        ssmProvider.UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await ssmProvider
@@ -635,12 +603,10 @@ public class SsmProviderTest
             .GetMultipleAsync(key);
 
         // Assert
-        providerHandler.Verify(
-            v => v.GetMultipleAsync<string>(key,
-                It.Is<ParameterProviderConfiguration?>(x =>
-                    x != null && x.ForceFetch
-                ), null,
-                null), Times.Once);
+        await providerHandler.Received(1).GetMultipleAsync<string>(key,
+            Arg.Is<ParameterProviderConfiguration?>(x => x != null && x.ForceFetch),
+            null,
+            null);
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -657,20 +623,19 @@ public class SsmProviderTest
         };
         var duration = CacheManager.DefaultMaxAge.Add(TimeSpan.FromHours(10));
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSimpleSystemsManagement>();
-        var transformerManager = new Mock<ITransformerManager>();
-        var providerHandler = new Mock<IParameterProviderBaseHandler>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSimpleSystemsManagement>();
+        var transformerManager = Substitute.For<ITransformerManager>();
+        var providerHandler = Substitute.For<IParameterProviderBaseHandler>();
 
-        providerHandler.Setup(c =>
-            c.GetMultipleAsync<string>(key, It.IsAny<ParameterProviderConfiguration?>(), null, null)
-        ).ReturnsAsync(value);
+        providerHandler.GetMultipleAsync<string>(key, Arg.Any<ParameterProviderConfiguration?>(), null, null)
+            .Returns(value);
 
         var ssmProvider = new SsmProvider();
-        ssmProvider.SetHandler(providerHandler.Object);
-        ssmProvider.UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+        ssmProvider.SetHandler(providerHandler);
+        ssmProvider.UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await ssmProvider
@@ -678,12 +643,10 @@ public class SsmProviderTest
             .GetMultipleAsync(key);
 
         // Assert
-        providerHandler.Verify(
-            v => v.GetMultipleAsync<string>(key,
-                It.Is<ParameterProviderConfiguration?>(x =>
-                    x != null && x.MaxAge == duration
-                ), null,
-                null), Times.Once);
+        await providerHandler.Received(1).GetMultipleAsync<string>(key,
+            Arg.Is<ParameterProviderConfiguration?>(x => x != null && x.MaxAge == duration),
+            null,
+            null);
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -699,34 +662,31 @@ public class SsmProviderTest
             { Guid.NewGuid().ToString(), Guid.NewGuid().ToString() }
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSimpleSystemsManagement>();
-        var transformerManager = new Mock<ITransformerManager>();
-        var transformer = new Mock<ITransformer>();
-        var providerHandler = new Mock<IParameterProviderBaseHandler>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSimpleSystemsManagement>();
+        var transformerManager = Substitute.For<ITransformerManager>();
+        var transformer = Substitute.For<ITransformer>();
+        var providerHandler = Substitute.For<IParameterProviderBaseHandler>();
 
-        providerHandler.Setup(c =>
-            c.GetMultipleAsync<string>(key, It.IsAny<ParameterProviderConfiguration?>(), null, null)
-        ).ReturnsAsync(value);
+        providerHandler.GetMultipleAsync<string>(key, Arg.Any<ParameterProviderConfiguration?>(), null, null)
+            .Returns(value);
 
         var ssmProvider = new SsmProvider();
-        ssmProvider.SetHandler(providerHandler.Object);
-        ssmProvider.UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+        ssmProvider.SetHandler(providerHandler);
+        ssmProvider.UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await ssmProvider
-            .WithTransformation(transformer.Object)
+            .WithTransformation(transformer)
             .GetMultipleAsync(key);
 
         // Assert
-        providerHandler.Verify(
-            v => v.GetMultipleAsync<string>(key,
-                It.Is<ParameterProviderConfiguration?>(x =>
-                    x != null && x.Transformer == transformer.Object
-                ), null,
-                null), Times.Once);
+        await providerHandler.Received(1).GetMultipleAsync<string>(key,
+            Arg.Is<ParameterProviderConfiguration?>(x => x != null && x.Transformer == transformer),
+            null,
+            null);
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -742,21 +702,20 @@ public class SsmProviderTest
             { Guid.NewGuid().ToString(), Guid.NewGuid().ToString() }
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSimpleSystemsManagement>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSimpleSystemsManagement>();
+        var transformerManager = Substitute.For<ITransformerManager>();
         var transformation = Transformation.Auto;
-        var providerHandler = new Mock<IParameterProviderBaseHandler>();
+        var providerHandler = Substitute.For<IParameterProviderBaseHandler>();
 
-        providerHandler.Setup(c =>
-            c.GetMultipleAsync<string>(key, It.IsAny<ParameterProviderConfiguration?>(), transformation, null)
-        ).ReturnsAsync(value);
+        providerHandler.GetMultipleAsync<string>(key, Arg.Any<ParameterProviderConfiguration?>(), transformation, null)
+            .Returns(value);
 
         var ssmProvider = new SsmProvider();
-        ssmProvider.SetHandler(providerHandler.Object);
-        ssmProvider.UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+        ssmProvider.SetHandler(providerHandler);
+        ssmProvider.UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await ssmProvider
@@ -764,13 +723,10 @@ public class SsmProviderTest
             .GetMultipleAsync(key);
 
         // Assert
-        providerHandler.Verify(
-            v => v.GetMultipleAsync<string>(key,
-                It.Is<ParameterProviderConfiguration?>(x =>
-                    x != null && !x.ForceFetch
-                ),
-                It.Is<Transformation?>(x => x == transformation),
-                null), Times.Once);
+        await providerHandler.Received(1).GetMultipleAsync<string>(key,
+            Arg.Is<ParameterProviderConfiguration?>(x => x != null && !x.ForceFetch),
+            Arg.Is<Transformation?>(x => x == transformation),
+            null);
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -786,21 +742,20 @@ public class SsmProviderTest
             { Guid.NewGuid().ToString(), Guid.NewGuid().ToString() }
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSimpleSystemsManagement>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSimpleSystemsManagement>();
+        var transformerManager = Substitute.For<ITransformerManager>();
         var transformerName = Guid.NewGuid().ToString();
-        var providerHandler = new Mock<IParameterProviderBaseHandler>();
+        var providerHandler = Substitute.For<IParameterProviderBaseHandler>();
 
-        providerHandler.Setup(c =>
-            c.GetMultipleAsync<string>(key, It.IsAny<ParameterProviderConfiguration?>(), null, transformerName)
-        ).ReturnsAsync(value);
+        providerHandler.GetMultipleAsync<string>(key, Arg.Any<ParameterProviderConfiguration?>(), null, transformerName)
+            .Returns(value);
 
         var ssmProvider = new SsmProvider();
-        ssmProvider.SetHandler(providerHandler.Object);
-        ssmProvider.UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+        ssmProvider.SetHandler(providerHandler);
+        ssmProvider.UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await ssmProvider
@@ -808,14 +763,10 @@ public class SsmProviderTest
             .GetMultipleAsync(key);
 
         // Assert
-        providerHandler.Verify(
-            v => v.GetMultipleAsync<string>(key,
-                It.Is<ParameterProviderConfiguration?>(x =>
-                    x != null && !x.ForceFetch
-                ),
-                null,
-                It.Is<string?>(x => x == transformerName))
-            , Times.Once);
+        await providerHandler.Received(1).GetMultipleAsync<string>(key,
+            Arg.Is<ParameterProviderConfiguration?>(x => x != null && !x.ForceFetch),
+            null,
+            Arg.Is<string?>(x => x == transformerName));
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
@@ -834,12 +785,12 @@ public class SsmProviderTest
         {
             Parameters = new List<Parameter>
             {
-                new()
+                new Parameter
                 {
                     Name = Guid.NewGuid().ToString(),
                     Value = Guid.NewGuid().ToString()
                 },
-                new()
+                new Parameter
                 {
                     Name = Guid.NewGuid().ToString(),
                     Value = Guid.NewGuid().ToString()
@@ -847,31 +798,25 @@ public class SsmProviderTest
             }
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSimpleSystemsManagement>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSimpleSystemsManagement>();
+        var transformerManager = Substitute.For<ITransformerManager>();
 
-        client.Setup(c =>
-            c.GetParametersByPathAsync(It.IsAny<GetParametersByPathRequest>(), It.IsAny<CancellationToken>())
-        ).ReturnsAsync(response);
+        client.GetParametersByPathAsync(Arg.Any<GetParametersByPathRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
 
-        cacheManager.Setup(c =>
-            c.Get(key)
-        ).Returns(valueFromCache);
+        cacheManager.Get(key).Returns(valueFromCache);
 
         var ssmProvider = new SsmProvider()
-            .UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+            .UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await ssmProvider.GetMultipleAsync(key);
 
         // Assert
-        client.Verify(v =>
-                v.GetParametersByPathAsync(It.IsAny<GetParametersByPathRequest>(),
-                    It.IsAny<CancellationToken>()),
-            Times.Never);
+        await client.DidNotReceiveWithAnyArgs().GetParametersByPathAsync(null, CancellationToken.None);
         Assert.NotNull(result);
         Assert.Equal(valueFromCache, result);
     }
@@ -890,47 +835,38 @@ public class SsmProviderTest
         {
             Parameters = new List<Parameter>
             {
-                new()
+                new Parameter
                 {
                     Name = Guid.NewGuid().ToString(),
                     Value = Guid.NewGuid().ToString()
                 },
-                new()
+                new Parameter
                 {
                     Name = Guid.NewGuid().ToString(),
                     Value = Guid.NewGuid().ToString()
                 }
             }
         };
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSimpleSystemsManagement>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSimpleSystemsManagement>();
+        var transformerManager = Substitute.For<ITransformerManager>();
 
-        client.Setup(c =>
-            c.GetParametersByPathAsync(It.IsAny<GetParametersByPathRequest>(), It.IsAny<CancellationToken>())
-        ).ReturnsAsync(response);
+        client.GetParametersByPathAsync(Arg.Any<GetParametersByPathRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
 
-        cacheManager.Setup(c =>
-            c.Get(key)
-        ).Returns(valueFromCache);
+        cacheManager.Get(key).Returns(valueFromCache);
 
         var ssmProvider = new SsmProvider()
-            .UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+            .UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await ssmProvider.ForceFetch().GetMultipleAsync(key);
 
         // Assert
-        cacheManager.Verify(v => v.Get(key), Times.Never);
-        client.Verify(v =>
-                v.GetParametersByPathAsync(
-                    It.Is<GetParametersByPathRequest>(x =>
-                        x.Path == key && !x.WithDecryption
-                    ),
-                    It.IsAny<CancellationToken>()),
-            Times.Once);
+        cacheManager.DidNotReceiveWithAnyArgs().Get(Arg.Any<string>());
+        await client.ReceivedWithAnyArgs(1).GetParametersByPathAsync(null, CancellationToken.None);
         Assert.NotNull(result);
         Assert.Equal(response.Parameters.First().Name, result.First().Key);
         Assert.Equal(response.Parameters.First().Value, result.First().Value);
@@ -948,12 +884,12 @@ public class SsmProviderTest
         {
             Parameters = new List<Parameter>
             {
-                new()
+                new Parameter
                 {
                     Name = Guid.NewGuid().ToString(),
                     Value = Guid.NewGuid().ToString()
                 },
-                new()
+                new Parameter
                 {
                     Name = Guid.NewGuid().ToString(),
                     Value = Guid.NewGuid().ToString()
@@ -961,43 +897,36 @@ public class SsmProviderTest
             }
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSimpleSystemsManagement>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSimpleSystemsManagement>();
+        var transformerManager = Substitute.For<ITransformerManager>();
 
-        client.Setup(c =>
-            c.GetParametersByPathAsync(It.IsAny<GetParametersByPathRequest>(), It.IsAny<CancellationToken>())
-        ).ReturnsAsync(response);
+        client.GetParametersByPathAsync(Arg.Any<GetParametersByPathRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
 
-        cacheManager.Setup(c =>
-            c.Get(key)
-        ).Returns(null);
+        cacheManager.Get(key).Returns(null);
 
         var ssmProvider = new SsmProvider()
-            .UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+            .UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await ssmProvider.GetMultipleAsync(key);
 
         // Assert
-        cacheManager.Verify(v => v.Get(key), Times.Once);
-        client.Verify(v =>
-                v.GetParametersByPathAsync(
-                    It.Is<GetParametersByPathRequest>(x =>
-                        x.Path == key && !x.WithDecryption
-                    ),
-                    It.IsAny<CancellationToken>()),
-            Times.Once);
-        cacheManager.Verify(v => v.Set(result.First().Key, result.First().Value, duration), Times.Once);
-        cacheManager.Verify(v => v.Set(result.Last().Key, result.Last().Value, duration), Times.Once);
-        cacheManager.Verify(v => v.Set(key, It.Is<Dictionary<string, string>>(x =>
-            x.First().Key == result.First().Key &&
-            x.First().Value == result.First().Value &&
-            x.Last().Key == result.Last().Key &&
-            x.Last().Value == result.Last().Value
-        ), duration), Times.Once);
+        cacheManager.Received(1).Get(key);
+        await client.Received(1).GetParametersByPathAsync(
+            Arg.Is<GetParametersByPathRequest>(x =>
+                x.Path == key && !x.WithDecryption
+            ),
+            Arg.Any<CancellationToken>()
+        );
+
+        foreach (var item in result)
+        {
+            cacheManager.Received(1).Set(item.Key, item.Value, duration);
+        }
 
         Assert.NotNull(result);
         Assert.Equal(response.Parameters.First().Name, result.First().Key);
@@ -1016,12 +945,12 @@ public class SsmProviderTest
         {
             Parameters = new List<Parameter>
             {
-                new()
+                new Parameter
                 {
                     Name = Guid.NewGuid().ToString(),
                     Value = Guid.NewGuid().ToString()
                 },
-                new()
+                new Parameter
                 {
                     Name = Guid.NewGuid().ToString(),
                     Value = Guid.NewGuid().ToString()
@@ -1029,44 +958,37 @@ public class SsmProviderTest
             }
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSimpleSystemsManagement>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSimpleSystemsManagement>();
+        var transformerManager = Substitute.For<ITransformerManager>();
 
-        client.Setup(c =>
-            c.GetParametersByPathAsync(It.IsAny<GetParametersByPathRequest>(), It.IsAny<CancellationToken>())
-        ).ReturnsAsync(response);
+        client.GetParametersByPathAsync(Arg.Any<GetParametersByPathRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
 
-        cacheManager.Setup(c =>
-            c.Get(key)
-        ).Returns(null);
+        cacheManager.Get(key).Returns(null);
 
         var ssmProvider = new SsmProvider()
-            .UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object)
+            .UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager)
             .DefaultMaxAge(duration);
 
         // Act
         var result = await ssmProvider.GetMultipleAsync(key);
 
         // Assert
-        cacheManager.Verify(v => v.Get(key), Times.Once);
-        client.Verify(v =>
-                v.GetParametersByPathAsync(
-                    It.Is<GetParametersByPathRequest>(x =>
-                        x.Path == key && !x.WithDecryption
-                    ),
-                    It.IsAny<CancellationToken>()),
-            Times.Once);
-        cacheManager.Verify(v => v.Set(result.First().Key, result.First().Value, duration), Times.Once);
-        cacheManager.Verify(v => v.Set(result.Last().Key, result.Last().Value, duration), Times.Once);
-        cacheManager.Verify(v => v.Set(key, It.Is<Dictionary<string, string>>(x =>
-            x.First().Key == result.First().Key &&
-            x.First().Value == result.First().Value &&
-            x.Last().Key == result.Last().Key &&
-            x.Last().Value == result.Last().Value
-        ), duration), Times.Once);
+        cacheManager.Received(1).Get(key);
+        await client.Received(1).GetParametersByPathAsync(
+            Arg.Is<GetParametersByPathRequest>(x =>
+                x.Path == key && !x.WithDecryption
+            ),
+            Arg.Any<CancellationToken>()
+        );
+
+        foreach (var item in result)
+        {
+            cacheManager.Received(1).Set(item.Key, item.Value, duration);
+        }
 
         Assert.NotNull(result);
         Assert.Equal(response.Parameters.First().Name, result.First().Key);
@@ -1086,12 +1008,12 @@ public class SsmProviderTest
         {
             Parameters = new List<Parameter>
             {
-                new()
+                new Parameter
                 {
                     Name = Guid.NewGuid().ToString(),
                     Value = Guid.NewGuid().ToString()
                 },
-                new()
+                new Parameter
                 {
                     Name = Guid.NewGuid().ToString(),
                     Value = Guid.NewGuid().ToString()
@@ -1099,22 +1021,19 @@ public class SsmProviderTest
             }
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSimpleSystemsManagement>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSimpleSystemsManagement>();
+        var transformerManager = Substitute.For<ITransformerManager>();
 
-        client.Setup(c =>
-            c.GetParametersByPathAsync(It.IsAny<GetParametersByPathRequest>(), It.IsAny<CancellationToken>())
-        ).ReturnsAsync(response);
+        client.GetParametersByPathAsync(Arg.Any<GetParametersByPathRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
 
-        cacheManager.Setup(c =>
-            c.Get(key)
-        ).Returns(null);
+        cacheManager.Get(key).Returns(null);
 
         var ssmProvider = new SsmProvider()
-            .UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object)
+            .UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager)
             .DefaultMaxAge(defaultMaxAge);
 
         // Act
@@ -1123,22 +1042,18 @@ public class SsmProviderTest
             .GetMultipleAsync(key);
 
         // Assert
-        cacheManager.Verify(v => v.Get(key), Times.Once);
-        client.Verify(v =>
-                v.GetParametersByPathAsync(
-                    It.Is<GetParametersByPathRequest>(x =>
-                        x.Path == key && !x.WithDecryption
-                    ),
-                    It.IsAny<CancellationToken>()),
-            Times.Once);
-        cacheManager.Verify(v => v.Set(result.First().Key, result.First().Value, duration), Times.Once);
-        cacheManager.Verify(v => v.Set(result.Last().Key, result.Last().Value, duration), Times.Once);
-        cacheManager.Verify(v => v.Set(key, It.Is<Dictionary<string, string>>(x =>
-            x.First().Key == result.First().Key &&
-            x.First().Value == result.First().Value &&
-            x.Last().Key == result.Last().Key &&
-            x.Last().Value == result.Last().Value
-        ), duration), Times.Once);
+        cacheManager.Received(1).Get(key);
+        await client.Received(1).GetParametersByPathAsync(
+            Arg.Is<GetParametersByPathRequest>(x =>
+                x.Path == key && !x.WithDecryption
+            ),
+            Arg.Any<CancellationToken>()
+        );
+
+        foreach (var item in result)
+        {
+            cacheManager.Received(1).Set(item.Key, item.Value, duration);
+        }
 
         Assert.NotNull(result);
         Assert.Equal(response.Parameters.First().Name, result.First().Key);
@@ -1156,12 +1071,12 @@ public class SsmProviderTest
         {
             Parameters = new List<Parameter>
             {
-                new()
+                new Parameter
                 {
                     Name = Guid.NewGuid().ToString(),
                     Value = Guid.NewGuid().ToString()
                 },
-                new()
+                new Parameter
                 {
                     Name = Guid.NewGuid().ToString(),
                     Value = Guid.NewGuid().ToString()
@@ -1169,22 +1084,20 @@ public class SsmProviderTest
             }
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSimpleSystemsManagement>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSimpleSystemsManagement>();
+        var transformerManager = Substitute.For<ITransformerManager>();
 
-        client.Setup(c =>
-            c.GetParametersByPathAsync(It.IsAny<GetParametersByPathRequest>(), It.IsAny<CancellationToken>())
-        ).ReturnsAsync(response);
+        client.GetParametersByPathAsync(
+            Arg.Any<GetParametersByPathRequest>(), Arg.Any<CancellationToken>()
+        ).Returns(Task.FromResult(response));
 
-        cacheManager.Setup(c =>
-            c.Get(key)
-        ).Returns(null);
+        cacheManager.Get(key).Returns(null);
 
         var ssmProvider = new SsmProvider()
-            .UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+            .UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await ssmProvider
@@ -1192,20 +1105,20 @@ public class SsmProviderTest
             .GetMultipleAsync(key);
 
         // Assert
-        cacheManager.Verify(v => v.Get(key), Times.Once);
-        client.Verify(v =>
-                v.GetParametersByPathAsync(
-                    It.Is<GetParametersByPathRequest>(x =>
-                        x.Path == key && x.WithDecryption
-                    ),
-                    It.IsAny<CancellationToken>()),
-            Times.Once);
+        cacheManager.Received(1).Get(key);
+        await client.Received(1).GetParametersByPathAsync(
+            Arg.Is<GetParametersByPathRequest>(x =>
+                x.Path == key && x.WithDecryption
+            ),
+            Arg.Any<CancellationToken>()
+        );
 
-        Assert.NotNull(result);
-        Assert.Equal(response.Parameters.First().Name, result.First().Key);
-        Assert.Equal(response.Parameters.First().Value, result.First().Value);
-        Assert.Equal(response.Parameters.Last().Name, result.Last().Key);
-        Assert.Equal(response.Parameters.Last().Value, result.Last().Value);
+        foreach (var item in result)
+        {
+            Assert.Contains(response.Parameters, p =>
+                p.Name == item.Key && p.Value == item.Value
+            );
+        }
     }
 
     [Fact]
@@ -1217,12 +1130,12 @@ public class SsmProviderTest
         {
             Parameters = new List<Parameter>
             {
-                new()
+                new Parameter
                 {
                     Name = Guid.NewGuid().ToString(),
                     Value = Guid.NewGuid().ToString()
                 },
-                new()
+                new Parameter
                 {
                     Name = Guid.NewGuid().ToString(),
                     Value = Guid.NewGuid().ToString()
@@ -1230,22 +1143,20 @@ public class SsmProviderTest
             }
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSimpleSystemsManagement>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSimpleSystemsManagement>();
+        var transformerManager = Substitute.For<ITransformerManager>();
 
-        client.Setup(c =>
-            c.GetParametersByPathAsync(It.IsAny<GetParametersByPathRequest>(), It.IsAny<CancellationToken>())
-        ).ReturnsAsync(response);
+        client.GetParametersByPathAsync(
+            Arg.Any<GetParametersByPathRequest>(), Arg.Any<CancellationToken>()
+        ).Returns(Task.FromResult(response));
 
-        cacheManager.Setup(c =>
-            c.Get(key)
-        ).Returns(null);
+        cacheManager.Get(key).Returns(null);
 
         var ssmProvider = new SsmProvider()
-            .UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+            .UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await ssmProvider
@@ -1253,20 +1164,20 @@ public class SsmProviderTest
             .GetMultipleAsync(key);
 
         // Assert
-        cacheManager.Verify(v => v.Get(key), Times.Once);
-        client.Verify(v =>
-                v.GetParametersByPathAsync(
-                    It.Is<GetParametersByPathRequest>(x =>
-                        x.Path == key && x.Recursive
-                    ),
-                    It.IsAny<CancellationToken>()),
-            Times.Once);
+        cacheManager.Received(1).Get(key);
+        await client.Received(1).GetParametersByPathAsync(
+            Arg.Is<GetParametersByPathRequest>(x =>
+                x.Path == key && x.Recursive
+            ),
+            Arg.Any<CancellationToken>()
+        );
 
-        Assert.NotNull(result);
-        Assert.Equal(response.Parameters.First().Name, result.First().Key);
-        Assert.Equal(response.Parameters.First().Value, result.First().Value);
-        Assert.Equal(response.Parameters.Last().Name, result.Last().Key);
-        Assert.Equal(response.Parameters.Last().Value, result.Last().Value);
+        foreach (var item in result)
+        {
+            Assert.Contains(response.Parameters, p =>
+                p.Name == item.Key && p.Value == item.Value
+            );
+        }
     }
 
     [Fact]
@@ -1279,7 +1190,7 @@ public class SsmProviderTest
         {
             Parameters = new List<Parameter>
             {
-                new()
+                new Parameter
                 {
                     Name = Guid.NewGuid().ToString(),
                     Value = Guid.NewGuid().ToString()
@@ -1291,7 +1202,7 @@ public class SsmProviderTest
         {
             Parameters = new List<Parameter>
             {
-                new()
+                new Parameter
                 {
                     Name = Guid.NewGuid().ToString(),
                     Value = Guid.NewGuid().ToString()
@@ -1299,28 +1210,26 @@ public class SsmProviderTest
             }
         };
 
-        var cacheManager = new Mock<ICacheManager>();
-        var client = new Mock<IAmazonSimpleSystemsManagement>();
-        var transformerManager = new Mock<ITransformerManager>();
+        var cacheManager = Substitute.For<ICacheManager>();
+        var client = Substitute.For<IAmazonSimpleSystemsManagement>();
+        var transformerManager = Substitute.For<ITransformerManager>();
 
-        client.Setup(c =>
-            c.GetParametersByPathAsync(It.Is<GetParametersByPathRequest>(x => string.IsNullOrEmpty(x.NextToken)),
-                It.IsAny<CancellationToken>())
-        ).ReturnsAsync(response1);
+        client.GetParametersByPathAsync(
+            Arg.Is<GetParametersByPathRequest>(x => string.IsNullOrEmpty(x.NextToken)),
+            Arg.Any<CancellationToken>()
+        ).Returns(Task.FromResult(response1));
 
-        client.Setup(c =>
-            c.GetParametersByPathAsync(It.Is<GetParametersByPathRequest>(x => x.NextToken == nextToken),
-                It.IsAny<CancellationToken>())
-        ).ReturnsAsync(response2);
+        client.GetParametersByPathAsync(
+            Arg.Is<GetParametersByPathRequest>(x => x.NextToken == nextToken),
+            Arg.Any<CancellationToken>()
+        ).Returns(Task.FromResult(response2));
 
-        cacheManager.Setup(c =>
-            c.Get(key)
-        ).Returns(null);
+        cacheManager.Get(key).Returns(null);
 
         var ssmProvider = new SsmProvider()
-            .UseClient(client.Object)
-            .UseCacheManager(cacheManager.Object)
-            .UseTransformerManager(transformerManager.Object);
+            .UseClient(client)
+            .UseCacheManager(cacheManager)
+            .UseTransformerManager(transformerManager);
 
         // Act
         var result = await ssmProvider
@@ -1329,27 +1238,26 @@ public class SsmProviderTest
             .GetMultipleAsync(key);
 
         // Assert
-        cacheManager.Verify(v => v.Get(key), Times.Once);
-        client.Verify(v =>
-                v.GetParametersByPathAsync(
-                    It.Is<GetParametersByPathRequest>(x =>
-                        x.Path == key && x.Recursive && x.WithDecryption && string.IsNullOrEmpty(x.NextToken)
-                    ),
-                    It.IsAny<CancellationToken>()),
-            Times.Once);
-        client.Verify(v =>
-                v.GetParametersByPathAsync(
-                    It.Is<GetParametersByPathRequest>(x =>
-                        x.Path == key && x.Recursive && x.WithDecryption && x.NextToken == nextToken
-                    ),
-                    It.IsAny<CancellationToken>()),
-            Times.Once);
+        cacheManager.Received(1).Get(key);
+        await client.Received(1).GetParametersByPathAsync(
+            Arg.Is<GetParametersByPathRequest>(x =>
+                x.Path == key && x.Recursive && x.WithDecryption && string.IsNullOrEmpty(x.NextToken)
+            ),
+            Arg.Any<CancellationToken>()
+        );
 
-        Assert.NotNull(result);
+        await client.Received(1).GetParametersByPathAsync(
+            Arg.Is<GetParametersByPathRequest>(x =>
+                x.Path == key && x.Recursive && x.WithDecryption && x.NextToken == nextToken
+            ),
+            Arg.Any<CancellationToken>()
+        );
 
-        Assert.Equal(response1.Parameters.First().Name, result.First().Key);
-        Assert.Equal(response1.Parameters.First().Value, result.First().Value);
-        Assert.Equal(response2.Parameters.First().Name, result.Last().Key);
-        Assert.Equal(response2.Parameters.First().Value, result.Last().Value);
+        foreach (var item in result)
+        {
+            Assert.Contains(response1.Parameters.Concat(response2.Parameters), p =>
+                p.Name == item.Key && p.Value == item.Value
+            );
+        }
     }
 }

--- a/libraries/tests/AWS.Lambda.Powertools.Parameters.Tests/Transform/TransformerManagerTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Parameters.Tests/Transform/TransformerManagerTest.cs
@@ -15,7 +15,7 @@
 
 using AWS.Lambda.Powertools.Parameters.Internal.Transform;
 using AWS.Lambda.Powertools.Parameters.Transform;
-using Moq;
+using NSubstitute;
 using Xunit;
 
 namespace AWS.Lambda.Powertools.Parameters.Tests.Transform;
@@ -150,71 +150,71 @@ public class TransformerManagerTest
     public void AddTransformer_WhenNameIsJson_ReplacesDefaultJsonTransformer()
     {
         // Arrange
-        var transformer = new Mock<ITransformer>();
+        var transformer = Substitute.For<ITransformer>();
         var transformation = Transformation.Json;
         var transformerManager = new TransformerManager();
 
         // Act
         var preResult = transformerManager.GetTransformer(transformation);
-        transformerManager.AddTransformer(transformation.ToString(), transformer.Object);
+        transformerManager.AddTransformer(transformation.ToString(), transformer);
         var result = transformerManager.GetTransformer(transformation);
 
         // Assert
         Assert.NotNull(preResult);
         Assert.IsType<JsonTransformer>(preResult);
         Assert.NotNull(result);
-        Assert.Equal(result, transformer.Object);
+        Assert.Equal(result, transformer);
     }
 
     [Fact]
     public void AddTransformer_WhenNameIsBase64_ReplacesDefaultBase64Transformer()
     {
         // Arrange
-        var transformer = new Mock<ITransformer>();
+        var transformer = Substitute.For<ITransformer>();
         var transformation = Transformation.Base64;
         var transformerManager = new TransformerManager();
 
         // Act
         var preResult = transformerManager.GetTransformer(transformation);
-        transformerManager.AddTransformer(transformation.ToString(), transformer.Object);
+        transformerManager.AddTransformer(transformation.ToString(), transformer);
         var result = transformerManager.GetTransformer(transformation);
 
         // Assert
         Assert.NotNull(preResult);
         Assert.IsType<Base64Transformer>(preResult);
         Assert.NotNull(result);
-        Assert.Equal(result, transformer.Object);
+        Assert.Equal(result, transformer);
     }
 
     [Fact]
     public void AddTransformer_WhenNameIsCustom_RegisterCustomTransformer()
     {
         // Arrange
-        var transformer = new Mock<ITransformer>();
+        var transformer = Substitute.For<ITransformer>();
         var transformation = Guid.NewGuid().ToString();
         var transformerManager = new TransformerManager();
 
         // Act
         var preResult = transformerManager.TryGetTransformer(transformation);
-        transformerManager.AddTransformer(transformation, transformer.Object);
+        transformerManager.AddTransformer(transformation, transformer);
         var result = transformerManager.GetTransformer(transformation);
 
         // Assert
         Assert.Null(preResult);
         Assert.NotNull(result);
-        Assert.Equal(result, transformer.Object);
+        Assert.Equal(result, transformer);
     }
 
     [Fact]
     public void AddTransformer_WhenNameIsEmpty_ThrowsException()
     {
         // Arrange
-        var transformer = new Mock<ITransformer>();
+        var transformer = Substitute.For<ITransformer>();
         var transformation = string.Empty;
         var transformerManager = new TransformerManager();
 
         // Act
-        void Act() => transformerManager.AddTransformer(transformation, transformer.Object);
+        void Act() => transformerManager.AddTransformer(transformation, transformer);
 
         // Assert
         Assert.Throws<ArgumentException>(Act);
@@ -247,8 +247,7 @@ public class TransformerManagerTest
         // Assert
         Assert.Throws<KeyNotFoundException>(Act);
     }
-
-
+    
     [Fact]
     public void TryGetTransformer_WhenNameIsEmpty_ThrowsException()
     {

--- a/libraries/tests/AWS.Lambda.Powertools.Parameters.Tests/Transform/TransformerTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Parameters.Tests/Transform/TransformerTest.cs
@@ -105,12 +105,12 @@ public class TransformerTest
 
         // Assert
         Assert.NotNull(result);
-        Assert.Equal(key1, result?.First().Key);
-        Assert.Equal(key2, result?.Last().Key);
-        Assert.Equal(value1.First(), result?.First().Value.First());
-        Assert.Equal(value1.Last(), result?.First().Value.Last());
-        Assert.Equal(value2.First(), result?.Last().Value.First());
-        Assert.Equal(value2.Last(), result?.Last().Value.Last());
+        Assert.Equal(key1, result.First().Key);
+        Assert.Equal(key2, result.Last().Key);
+        Assert.Equal(value1.First(), result.First().Value.First());
+        Assert.Equal(value1.Last(), result.First().Value.Last());
+        Assert.Equal(value2.First(), result.Last().Value.First());
+        Assert.Equal(value2.Last(), result.Last().Value.Last());
     }
 
     [Fact]

--- a/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/AWS.Lambda.Powertools.Tracing.Tests.csproj
+++ b/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/AWS.Lambda.Powertools.Tracing.Tests.csproj
@@ -13,14 +13,14 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="3.2.0">
+        <PackageReference Include="coverlet.collector" Version="6.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0-preview-20221221-03" />
-        <PackageReference Include="Moq" Version="4.18.4" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+        <PackageReference Include="NSubstitute" Version="5.0.0" />
+        <PackageReference Include="xunit" Version="2.5.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/XRayRecorderTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/XRayRecorderTests.cs
@@ -3,7 +3,7 @@ using Amazon.XRay.Recorder.Core;
 using Amazon.XRay.Recorder.Core.Internal.Entities;
 using AWS.Lambda.Powertools.Common;
 using AWS.Lambda.Powertools.Tracing.Internal;
-using Moq;
+using NSubstitute;
 using Xunit;
 
 namespace AWS.Lambda.Powertools.Tracing.Tests;
@@ -16,291 +16,260 @@ public class XRayRecorderTests
         // Arrange
         var assemblyName = "AWS.Lambda.Powertools.Tracing";
         var assemblyVersion = "1.0.0";
-        
-        var env = new Mock<IPowertoolsEnvironment>();
-        env.Setup(x => x.GetAssemblyName(It.IsAny<XRayRecorder>())).Returns(assemblyName);
-        env.Setup(x => x.GetAssemblyVersion(It.IsAny<XRayRecorder>())).Returns(assemblyVersion);
 
-        var conf = new PowertoolsConfigurations(new SystemWrapper(env.Object));
-        var awsXray = new Mock<IAWSXRayRecorder>();
-        
+        var env = Substitute.For<IPowertoolsEnvironment>();
+        env.GetAssemblyName(Arg.Any<XRayRecorder>()).Returns(assemblyName);
+        env.GetAssemblyVersion(Arg.Any<XRayRecorder>()).Returns(assemblyVersion);
+
+        var conf = new PowertoolsConfigurations(new SystemWrapper(env));
+        var awsXray = Substitute.For<IAWSXRayRecorder>();
+
         // Act
-        var xRayRecorder = new XRayRecorder(awsXray.Object, conf);
+        var xRayRecorder = new XRayRecorder(awsXray, conf);
 
         // Assert
-        env.Verify(v =>
-            v.SetEnvironmentVariable(
-                "AWS_EXECUTION_ENV", $"{Constants.FeatureContextIdentifier}/Tracing/{assemblyVersion}"
-            ), Times.Once);
-            
-        env.Verify(v =>
-            v.GetEnvironmentVariable(
-                "AWS_EXECUTION_ENV"
-            ), Times.Once);
-        
+        env.Received(1).SetEnvironmentVariable(
+            "AWS_EXECUTION_ENV", $"{Constants.FeatureContextIdentifier}/Tracing/{assemblyVersion}"
+        );
+
+        env.Received(1).GetEnvironmentVariable(
+            "AWS_EXECUTION_ENV"
+        );
+
         Assert.NotNull(xRayRecorder);
     }
-    
+
     [Fact]
     public void Tracing_Instance()
     {
         // Arrange
-        var conf = new Mock<IPowertoolsConfigurations>();
-        var awsXray = new Mock<IAWSXRayRecorder>();
-    
+        var conf = Substitute.For<IPowertoolsConfigurations>();
+        var awsXray = Substitute.For<IAWSXRayRecorder>();
+
         // Act
-        
-        var tracing = new XRayRecorder(awsXray.Object, conf.Object);
-        
+        var tracing = new XRayRecorder(awsXray, conf);
+
         // Assert
         Assert.Equal(tracing, XRayRecorder.Instance);
     }
-    
+
     [Fact]
     public void Tracing_Being_Subsegment()
     {
         // Arrange
-        var conf = new Mock<IPowertoolsConfigurations>();
-        conf.Setup(c => c.IsLambdaEnvironment).Returns(true);
-        
-        var awsXray = new Mock<IAWSXRayRecorder>();
-        
+        var conf = Substitute.For<IPowertoolsConfigurations>();
+        conf.IsLambdaEnvironment.Returns(true);
+
+        var awsXray = Substitute.For<IAWSXRayRecorder>();
+
         // Act
-        var tracing = new XRayRecorder(awsXray.Object, conf.Object);
-    
+        var tracing = new XRayRecorder(awsXray, conf);
+
         tracing.BeginSubsegment("test");
-        
+
         // Assert
-        awsXray.Verify(v =>
-            v.BeginSubsegment("test", null
-            ), Times.Once);
+        awsXray.Received(1).BeginSubsegment("test");
     }
-    
+
     [Fact]
     public void Tracing_Set_Namespace()
     {
         // Arrange
-        var conf = new Mock<IPowertoolsConfigurations>();
-        conf.Setup(c => c.IsLambdaEnvironment).Returns(true);
-        
-        var awsXray = new Mock<IAWSXRayRecorder>();
-        
+        var conf = Substitute.For<IPowertoolsConfigurations>();
+        conf.IsLambdaEnvironment.Returns(true);
+
+        var awsXray = Substitute.For<IAWSXRayRecorder>();
+
         // Act
-        var tracing = new XRayRecorder(awsXray.Object, conf.Object);
-    
+        var tracing = new XRayRecorder(awsXray, conf);
+
         tracing.SetNamespace("test");
-        
+
         // Assert
-        awsXray.Verify(v =>
-            v.SetNamespace("test"
-            ), Times.Once);
+        awsXray.Received(1).SetNamespace("test");
     }
-    
+
     [Fact]
     public void Tracing_Add_Annotation()
     {
         // Arrange
-        var conf = new Mock<IPowertoolsConfigurations>();
-        conf.Setup(c => c.IsLambdaEnvironment).Returns(true);
-        
-        var awsXray = new Mock<IAWSXRayRecorder>();
-        
+        var conf = Substitute.For<IPowertoolsConfigurations>();
+        conf.IsLambdaEnvironment.Returns(true);
+
+        var awsXray = Substitute.For<IAWSXRayRecorder>();
+
         // Act
-        var tracing = new XRayRecorder(awsXray.Object, conf.Object);
-    
+        var tracing = new XRayRecorder(awsXray, conf);
+
         tracing.AddAnnotation("key", "value");
-        
+
         // Assert
-        awsXray.Verify(v =>
-            v.AddAnnotation("key", "value"
-            ), Times.Once);
+        awsXray.Received(1).AddAnnotation("key", "value");
     }
-    
+
     [Fact]
     public void Tracing_Add_Metadata()
     {
         // Arrange
-        var conf = new Mock<IPowertoolsConfigurations>();
-        conf.Setup(c => c.IsLambdaEnvironment).Returns(true);
-        
-        var awsXray = new Mock<IAWSXRayRecorder>();
-        
+        var conf = Substitute.For<IPowertoolsConfigurations>();
+        conf.IsLambdaEnvironment.Returns(true);
+
+        var awsXray = Substitute.For<IAWSXRayRecorder>();
+
         // Act
-        var tracing = new XRayRecorder(awsXray.Object, conf.Object);
-    
-        tracing.AddMetadata("nameSpace","key", "value");
-        
+        var tracing = new XRayRecorder(awsXray, conf);
+
+        tracing.AddMetadata("nameSpace", "key", "value");
+
         // Assert
-        awsXray.Verify(v =>
-            v.AddMetadata("nameSpace","key", "value"
-            ), Times.Once);
+        awsXray.Received(1).AddMetadata("nameSpace", "key", "value");
     }
-    
+
     [Fact]
     public void Tracing_End_Subsegment()
     {
         // Arrange
-        var conf = new Mock<IPowertoolsConfigurations>();
-        conf.Setup(c => c.IsLambdaEnvironment).Returns(true);
-        
-        var awsXray = new Mock<IAWSXRayRecorder>();
-        
+        var conf = Substitute.For<IPowertoolsConfigurations>();
+        conf.IsLambdaEnvironment.Returns(true);
+
+        var awsXray = Substitute.For<IAWSXRayRecorder>();
+
         // Act
-        var tracing = new XRayRecorder(awsXray.Object, conf.Object);
-    
+        var tracing = new XRayRecorder(awsXray, conf);
+
         tracing.EndSubsegment();
-        
+
         // Assert
-        awsXray.Verify(v =>
-            v.EndSubsegment(null), Times.Once);
+        awsXray.Received(1).EndSubsegment();
     }
-    
+
     [Fact]
     public void Tracing_Get_Entity_In_Lambda_Environment()
     {
         // Arrange
-        var conf = new Mock<IPowertoolsConfigurations>();
-        conf.Setup(c => c.IsLambdaEnvironment).Returns(true);
-        
-        var awsXray = new Mock<IAWSXRayRecorder>();
-        awsXray.Setup(x => x.TraceContext.GetEntity()).Returns(new Subsegment("root"));
-        
+        var conf = Substitute.For<IPowertoolsConfigurations>();
+        conf.IsLambdaEnvironment.Returns(true);
+
+        var awsXray = Substitute.For<IAWSXRayRecorder>();
+        awsXray.TraceContext.GetEntity().Returns(new Subsegment("root"));
+
         // Act
-        var tracing = new XRayRecorder(awsXray.Object, conf.Object);
-    
+        var tracing = new XRayRecorder(awsXray, conf);
+
         tracing.GetEntity();
-        
+
         // Assert
-        awsXray.Verify(v =>
-            v.TraceContext.GetEntity(), Times.Once);
+        awsXray.TraceContext.Received(1).GetEntity();
     }
-    
+
     [Fact]
     public void Tracing_Get_Entity_Outside_Lambda_Environment()
     {
         // Arrange
-        var conf = new Mock<IPowertoolsConfigurations>();
-        conf.Setup(c => c.IsLambdaEnvironment).Returns(false);
-        
-        var awsXray = new Mock<IAWSXRayRecorder>();
-        
+        var conf = Substitute.For<IPowertoolsConfigurations>();
+        conf.IsLambdaEnvironment.Returns(false);
+
+        var awsXray = Substitute.For<IAWSXRayRecorder>();
+
         // Act
-        var tracing = new XRayRecorder(awsXray.Object, conf.Object);
-    
+        var tracing = new XRayRecorder(awsXray, conf);
+
         var entity = tracing.GetEntity();
-        
+
         // Assert
-        Assert.Equivalent("Root",entity.Name);
+        Assert.Equal("Root", entity.Name);
     }
-    
+
     [Fact]
     public void Tracing_Set_Entity()
     {
         // Arrange
-        var conf = new Mock<IPowertoolsConfigurations>();
-        conf.Setup(c => c.IsLambdaEnvironment).Returns(true);
+        var conf = Substitute.For<IPowertoolsConfigurations>();
+        conf.IsLambdaEnvironment.Returns(true);
 
         var segment = new Segment("test");
-        
-        var awsXray = new Mock<IAWSXRayRecorder>();
-        awsXray.Setup(x => x.TraceContext.SetEntity(segment));
-        
+
+        var awsXray = Substitute.For<IAWSXRayRecorder>();
+
         // Act
-        var tracing = new XRayRecorder(awsXray.Object, conf.Object);
-    
+        var tracing = new XRayRecorder(awsXray, conf);
+
         tracing.SetEntity(segment);
-        
+
         // Assert
-        awsXray.Verify(v =>
-            v.TraceContext.SetEntity(segment), Times.Once);
+        awsXray.TraceContext.Received(1).SetEntity(segment);
     }
-    
+
     [Fact]
     public void Tracing_Add_Exception()
     {
         // Arrange
-        var conf = new Mock<IPowertoolsConfigurations>();
-        conf.Setup(c => c.IsLambdaEnvironment).Returns(true);
+        var conf = Substitute.For<IPowertoolsConfigurations>();
+        conf.IsLambdaEnvironment.Returns(true);
 
         var ex = new ArgumentException("test");
-        
-        var awsXray = new Mock<IAWSXRayRecorder>();
-        awsXray.Setup(x => x.AddException(ex));
-        
+
+        var awsXray = Substitute.For<IAWSXRayRecorder>();
+        awsXray.When(x => x.AddException(ex));
+
         // Act
-        var tracing = new XRayRecorder(awsXray.Object, conf.Object);
-    
+        var tracing = new XRayRecorder(awsXray, conf);
+
         tracing.AddException(ex);
-        
+
         // Assert
-        awsXray.Verify(v =>
-            v.AddException(ex), Times.Once);
+        awsXray.Received(1).AddException(ex);
     }
-    
+
     [Fact]
     public void Tracing_Add_Http_Information()
     {
         // Arrange
-        var conf = new Mock<IPowertoolsConfigurations>();
-        conf.Setup(c => c.IsLambdaEnvironment).Returns(true);
+        var conf = Substitute.For<IPowertoolsConfigurations>();
+        conf.IsLambdaEnvironment.Returns(true);
 
         var key = "key";
         var value = "value";
-        
-        var awsXray = new Mock<IAWSXRayRecorder>();
-        awsXray.Setup(x => x.AddHttpInformation(key,value));
-        
+
+        var awsXray = Substitute.For<IAWSXRayRecorder>();
+
         // Act
-        var tracing = new XRayRecorder(awsXray.Object, conf.Object);
-    
-        tracing.AddHttpInformation(key,value);
-        
+        var tracing = new XRayRecorder(awsXray, conf);
+
+        tracing.AddHttpInformation(key, value);
+
         // Assert
-        awsXray.Verify(v =>
-            v.AddHttpInformation(key,value), Times.Once);
+        awsXray.Received(1).AddHttpInformation(key, value);
     }
-    
+
     [Fact]
     public void Tracing_All_When_Outside_Lambda()
     {
         // Arrange
-        var conf = new Mock<IPowertoolsConfigurations>();
-        conf.Setup(c => c.IsLambdaEnvironment).Returns(false);
+        var conf = Substitute.For<IPowertoolsConfigurations>();
+        conf.IsLambdaEnvironment.Returns(false);
 
-        var awsXray = new Mock<IAWSXRayRecorder>();
-        var tracing = new XRayRecorder(awsXray.Object, conf.Object);
-        
+        var awsXray = Substitute.For<IAWSXRayRecorder>();
+        var tracing = new XRayRecorder(awsXray, conf);
+
         // Act
-
-        tracing.AddHttpInformation(It.IsAny<string>(),It.IsAny<string>());
-        tracing.AddException(It.IsAny<Exception>());
-        tracing.SetEntity(It.IsAny<Entity>());
+        tracing.AddHttpInformation(Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
+        tracing.AddException(new AggregateException("Test"));
+        tracing.SetEntity(new Segment("test"));
         tracing.EndSubsegment();
-        tracing.AddMetadata(It.IsAny<string>(),It.IsAny<string>(), It.IsAny<string>());
-        tracing.AddAnnotation(It.IsAny<string>(),It.IsAny<string>());
-        tracing.SetNamespace(It.IsAny<string>());
-        tracing.BeginSubsegment(It.IsAny<string>());
-        
+        tracing.AddMetadata(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
+        tracing.AddAnnotation(Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
+        tracing.SetNamespace(Guid.NewGuid().ToString());
+        tracing.BeginSubsegment(Guid.NewGuid().ToString());
+
         // Assert
-        awsXray.Verify(v =>
-            v.AddHttpInformation(It.IsAny<string>(),It.IsAny<string>()), Times.Never);
-        awsXray.Verify(v =>
-            v.AddException(It.IsAny<Exception>()), Times.Never);
-        awsXray.Verify(v =>
-            v.TraceContext.SetEntity(It.IsAny<Entity>()), Times.Never);
-        awsXray.Verify(v =>
-            v.EndSubsegment(null), Times.Never);
-        awsXray.Verify(v =>
-            v.AddMetadata(It.IsAny<string>(),It.IsAny<string>(), It.IsAny<string>()
-            ), Times.Never);
-        awsXray.Verify(v =>
-            v.AddAnnotation(It.IsAny<string>(),It.IsAny<string>()
-            ), Times.Never);
-        awsXray.Verify(v =>
-            v.SetNamespace(It.IsAny<string>()
-            ), Times.Never);
-        awsXray.Verify(v =>
-            v.BeginSubsegment(It.IsAny<string>(), null
-            ), Times.Never);
+        awsXray.DidNotReceive().AddHttpInformation(Arg.Any<string>(), Arg.Any<string>());
+        awsXray.DidNotReceive().AddException(Arg.Any<Exception>());
+        awsXray.DidNotReceive().TraceContext.SetEntity(Arg.Any<Entity>());
+        awsXray.DidNotReceive().EndSubsegment();
+        awsXray.DidNotReceive().AddMetadata(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>());
+        awsXray.DidNotReceive().AddAnnotation(Arg.Any<string>(), Arg.Any<string>());
+        awsXray.DidNotReceive().SetNamespace(Arg.Any<string>());
+        awsXray.DidNotReceive().BeginSubsegment(Arg.Any<string>());
     }
 }


### PR DESCRIPTION
Issue number: #369

## Summary

Removing the dependency to [Moq](https://www.nuget.org/packages/Moq) library and replace it with [NSubstitute](https://www.nuget.org/packages/NSubstitute) Version="5.0.0"

### Changes

All dependencies to Moq package are removed across all test projects Including all utilities as well as example test projects. 

### User experience

This won't change any use experience as only test projects are updated.

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
