### PR TITLE
feat: Add bring your own log formatter to logger

### DIFF
--- a/libraries/src/AWS.Lambda.Powertools.Logging/ILogFormatter.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/ILogFormatter.cs
@@ -1,0 +1,29 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+namespace AWS.Lambda.Powertools.Logging;
+
+/// <summary>
+/// Represents a type used to format Powertools log entries.
+/// </summary>
+public interface ILogFormatter
+{
+    /// <summary>
+    /// Formats a log entry
+    /// </summary>
+    /// <param name="logEntry">The log entry.</param>
+    /// <returns>Formatted log entry as object.</returns>
+    object FormatLogEntry(LogEntry logEntry);
+}

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Internal/PowertoolsLogger.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Internal/PowertoolsLogger.cs
@@ -345,25 +345,14 @@ internal sealed class PowertoolsLogger : ILogger
         try
         {
             var logObject = logFormatter.FormatLogEntry(logEntry);
-            if (logObject is not null)
-                return logObject;
-
-            return new
-            {
-                logEntry.Timestamp,
-                Level = LogLevel.Error.ToString(),
-                Message = $"{logFormatter.GetType().FullName} returned null value"
-            };
+            if (logObject is null)
+                throw new LogFormatException($"{logFormatter.GetType().FullName} returned Null value.");
+            return logObject;
         }
         catch (Exception e)
         {
-            return new
-            {
-                logEntry.Timestamp,
-                Level = LogLevel.Error.ToString(),
-                Message = $"{logFormatter.GetType().FullName} raised error: {e.Message}.",
-                Exception = e
-            };
+            throw new LogFormatException(
+                $"{logFormatter.GetType().FullName} raised an exception: {e.Message}.", e);
         }
     }
 

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Internal/PowertoolsLogger.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Internal/PowertoolsLogger.cs
@@ -206,20 +206,43 @@ internal sealed class PowertoolsLogger : ILogger
         if (!IsEnabled(logLevel))
             return;
 
-        var message = new Dictionary<string, object>(StringComparer.Ordinal);
+        var timestamp = DateTime.UtcNow;
+        var message = CustomFormatter(state, exception, out var customMessage) && customMessage is not null
+            ? customMessage
+            : formatter(state, exception);
+
+        var logFormatter = Logger.GetFormatter();
+        var logEntry = logFormatter is null? 
+            GetLogEntry(logLevel, timestamp, message, exception) : 
+            GetFormattedLogEntry(logLevel, timestamp, message, exception, logFormatter);
+
+        _systemWrapper.LogLine(JsonSerializer.Serialize(logEntry, JsonSerializerOptions));
+    }
+
+    /// <summary>
+    ///     Gets a log entry.
+    /// </summary>
+    /// <param name="logLevel">Entry will be written on this level.</param>
+    /// <param name="timestamp">Entry timestamp.</param>
+    /// <param name="message">The message to be written. Can be also an object.</param>
+    /// <param name="exception">The exception related to this entry.</param>
+    private Dictionary<string, object> GetLogEntry(LogLevel logLevel, DateTime timestamp, object message,
+        Exception exception)
+    {
+        var logEntry = new Dictionary<string, object>(StringComparer.Ordinal);
 
         // Add Custom Keys
         foreach (var (key, value) in Logger.GetAllKeys())
-            message.TryAdd(key, value);
+            logEntry.TryAdd(key, value);
 
         // Add Lambda Context Keys
         if (PowertoolsLambdaContext.Instance is not null)
         {
-            message.TryAdd(LoggingConstants.KeyFunctionName, PowertoolsLambdaContext.Instance.FunctionName);
-            message.TryAdd(LoggingConstants.KeyFunctionVersion, PowertoolsLambdaContext.Instance.FunctionVersion);
-            message.TryAdd(LoggingConstants.KeyFunctionMemorySize, PowertoolsLambdaContext.Instance.MemoryLimitInMB);
-            message.TryAdd(LoggingConstants.KeyFunctionArn, PowertoolsLambdaContext.Instance.InvokedFunctionArn);
-            message.TryAdd(LoggingConstants.KeyFunctionRequestId, PowertoolsLambdaContext.Instance.AwsRequestId);
+            logEntry.TryAdd(LoggingConstants.KeyFunctionName, PowertoolsLambdaContext.Instance.FunctionName);
+            logEntry.TryAdd(LoggingConstants.KeyFunctionVersion, PowertoolsLambdaContext.Instance.FunctionVersion);
+            logEntry.TryAdd(LoggingConstants.KeyFunctionMemorySize, PowertoolsLambdaContext.Instance.MemoryLimitInMB);
+            logEntry.TryAdd(LoggingConstants.KeyFunctionArn, PowertoolsLambdaContext.Instance.InvokedFunctionArn);
+            logEntry.TryAdd(LoggingConstants.KeyFunctionRequestId, PowertoolsLambdaContext.Instance.AwsRequestId);
         }
 
         // Add Extra Fields
@@ -228,24 +251,120 @@ internal sealed class PowertoolsLogger : ILogger
             foreach (var (key, value) in CurrentScope.ExtraKeys)
             {
                 if (!string.IsNullOrWhiteSpace(key))
-                    message.TryAdd(key, value);
+                    logEntry.TryAdd(key, value);
             }
         }
 
-        message.TryAdd(LoggingConstants.KeyTimestamp, DateTime.UtcNow.ToString("o"));
-        message.TryAdd(LoggingConstants.KeyLogLevel, logLevel.ToString());
-        message.TryAdd(LoggingConstants.KeyService, Service);
-        message.TryAdd(LoggingConstants.KeyLoggerName, _name);
-        message.TryAdd(LoggingConstants.KeyMessage,
-            CustomFormatter(state, exception, out var customMessage) && customMessage is not null
-                ? customMessage
-                : formatter(state, exception));
-        if (CurrentConfig.SamplingRate.HasValue)
-            message.TryAdd(LoggingConstants.KeySamplingRate, CurrentConfig.SamplingRate.Value);
-        if (exception != null)
-            message.TryAdd(LoggingConstants.KeyException, exception);
+        logEntry.TryAdd(LoggingConstants.KeyTimestamp, timestamp.ToString("o"));
+        logEntry.TryAdd(LoggingConstants.KeyLogLevel, logLevel.ToString());
+        logEntry.TryAdd(LoggingConstants.KeyService, Service);
+        logEntry.TryAdd(LoggingConstants.KeyLoggerName, _name);
+        logEntry.TryAdd(LoggingConstants.KeyMessage, message);
 
-        _systemWrapper.LogLine(JsonSerializer.Serialize(message, JsonSerializerOptions));
+        if (CurrentConfig.SamplingRate.HasValue)
+            logEntry.TryAdd(LoggingConstants.KeySamplingRate, CurrentConfig.SamplingRate.Value);
+        if (exception != null)
+            logEntry.TryAdd(LoggingConstants.KeyException, exception);
+
+        return logEntry;
+    }
+
+    /// <summary>
+    ///     Gets a formatted log entry.
+    /// </summary>
+    /// <param name="logLevel">Entry will be written on this level.</param>
+    /// <param name="timestamp">Entry timestamp.</param>
+    /// <param name="message">The message to be written. Can be also an object.</param>
+    /// <param name="exception">The exception related to this entry.</param>
+    /// <param name="logFormatter">The custom log entry formatter.</param>
+    private object GetFormattedLogEntry(LogLevel logLevel, DateTime timestamp, object message,
+        Exception exception, ILogFormatter logFormatter)
+    {
+        if (logFormatter is null)
+            return null;
+
+        var logEntry = new LogEntry
+        {
+            Timestamp = timestamp,
+            Level = logLevel,
+            Service = Service,
+            Name = _name,
+            Message = message,
+            Exception = exception,
+            SamplingRate = CurrentConfig.SamplingRate,
+        };
+
+        var extraKeys = new Dictionary<string, object>();
+
+        // Add Custom Keys
+        foreach (var (key, value) in Logger.GetAllKeys())
+        {
+            switch (key)
+            {
+                case LoggingConstants.KeyColdStart:
+                    logEntry.ColdStart = (bool)value;
+                    break;
+                case LoggingConstants.KeyXRayTraceId:
+                    logEntry.XRayTraceId = value as string;
+                    break;
+                case LoggingConstants.KeyCorrelationId:
+                    logEntry.CorrelationId = value as string;
+                    break;
+                default:
+                    extraKeys.TryAdd(key, value);
+                    break;
+            }
+        }
+
+        // Add Extra Fields
+        if (CurrentScope?.ExtraKeys is not null)
+        {
+            foreach (var (key, value) in CurrentScope.ExtraKeys)
+            {
+                if (!string.IsNullOrWhiteSpace(key))
+                    extraKeys.TryAdd(key, value);
+            }
+        }
+
+        if (extraKeys.Any())
+            logEntry.ExtraKeys = extraKeys;
+
+        // Add Lambda Context Keys
+        if (PowertoolsLambdaContext.Instance is not null)
+        {
+            logEntry.LambdaContext = new LogEntryLambdaContext
+            {
+                FunctionName = PowertoolsLambdaContext.Instance.FunctionName,
+                FunctionVersion = PowertoolsLambdaContext.Instance.FunctionVersion,
+                MemoryLimitInMB = PowertoolsLambdaContext.Instance.MemoryLimitInMB,
+                InvokedFunctionArn = PowertoolsLambdaContext.Instance.InvokedFunctionArn,
+                AwsRequestId = PowertoolsLambdaContext.Instance.AwsRequestId,
+            };
+        }
+
+        try
+        {
+            var logObject = logFormatter.FormatLogEntry(logEntry);
+            if (logObject is not null)
+                return logObject;
+
+            return new
+            {
+                logEntry.Timestamp,
+                Level = LogLevel.Error.ToString(),
+                Message = $"{logFormatter.GetType().FullName} returned null value"
+            };
+        }
+        catch (Exception e)
+        {
+            return new
+            {
+                logEntry.Timestamp,
+                Level = LogLevel.Error.ToString(),
+                Message = $"{logFormatter.GetType().FullName} raised error: {e.Message}.",
+                Exception = e
+            };
+        }
     }
 
     /// <summary>

--- a/libraries/src/AWS.Lambda.Powertools.Logging/LogEntry.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/LogEntry.cs
@@ -1,0 +1,92 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+namespace AWS.Lambda.Powertools.Logging;
+
+/// <summary>
+/// Powertools Log Entry
+/// </summary>
+public class LogEntry
+{
+    /// <summary>
+    /// Indicates the cold start.
+    /// </summary>
+    /// <value>The cold start value.</value>
+    public bool ColdStart { get; internal set; }
+    
+    /// <summary>
+    /// Gets the X-Ray trace identifier.
+    /// </summary>
+    /// <value>The X-Ray trace identifier.</value>
+    public string XRayTraceId { get; internal set; }
+    
+    /// <summary>
+    /// Gets the correlation identifier.
+    /// </summary>
+    /// <value>The correlation identifier.</value>
+    public string CorrelationId { get; internal set; }
+    
+    /// <summary>
+    /// Log entry timestamp in UTC.
+    /// </summary>
+    public DateTime Timestamp { get; internal set; }
+ 
+    /// <summary>
+    /// Log entry Level is used for logging.
+    /// </summary>
+    public LogLevel Level { get; internal set; }
+    
+    /// <summary>
+    /// Service name is used for logging.
+    /// </summary>
+    public string Service { get; internal set; }
+    
+    /// <summary>
+    /// Logger name is used for logging.
+    /// </summary>
+    public string Name { get; internal set; }
+    
+    /// <summary>
+    /// Log entry Level is used for logging.
+    /// </summary>
+    public object Message { get; internal set; }
+    
+    /// <summary>
+    /// Dynamically set a percentage of logs to DEBUG level.
+    /// This can be also set using the environment variable <c>POWERTOOLS_LOGGER_SAMPLE_RATE</c>.
+    /// </summary>
+    /// <value>The sampling rate.</value>
+    public double? SamplingRate { get; internal set; }
+    
+    /// <summary>
+    /// Gets the appended additional keys to a log entry.
+    /// <value>The extra keys.</value>
+    /// </summary>
+    public Dictionary<string, object> ExtraKeys { get; internal set; }
+    
+    /// <summary>
+    /// The exception related to this entry.
+    /// </summary>
+    public Exception Exception { get; internal set; }
+    
+    /// <summary>
+    /// The Lambda Context related to this entry.
+    /// </summary>
+    public LogEntryLambdaContext LambdaContext { get; internal set; }
+}

--- a/libraries/src/AWS.Lambda.Powertools.Logging/LogEntryLambdaContext.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/LogEntryLambdaContext.cs
@@ -1,0 +1,56 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+namespace AWS.Lambda.Powertools.Logging;
+
+/// <summary>
+/// Powertools Log Entry Lambda Context
+/// </summary>
+public class LogEntryLambdaContext
+{
+    /// <summary>
+    /// The AWS request ID associated with the request.
+    /// This is the same ID returned to the client that called invoke().
+    /// This ID is reused for retries on the same request.
+    /// </summary>
+    public string AwsRequestId { get; internal set; }
+    
+    /// <summary>
+    /// Name of the Lambda function that is running.
+    /// </summary>
+    public string FunctionName { get; internal set; }
+        
+    /// <summary>
+    /// The Lambda function version that is executing.
+    /// If an alias is used to invoke the function, then this will be
+    /// the version the alias points to.
+    /// </summary>
+    public string FunctionVersion { get; internal set; }
+    
+    /// <summary>
+    /// The ARN used to invoke this function.
+    /// It can be function ARN or alias ARN.
+    /// An unqualified ARN executes the $LATEST version and aliases execute
+    /// the function version they are pointing to.
+    /// </summary>
+    public int MemoryLimitInMB { get; internal set; }
+        
+    /// <summary>
+    /// The CloudWatch log group name associated with the invoked function.
+    /// It can be null if the IAM user provided does not have permission for
+    /// CloudWatch actions.
+    /// </summary>
+    public string InvokedFunctionArn { get; internal set; }
+}

--- a/libraries/src/AWS.Lambda.Powertools.Logging/LogFormatException.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/LogFormatException.cs
@@ -23,7 +23,7 @@ namespace AWS.Lambda.Powertools.Logging;
 public class LogFormatException : Exception
 {
     /// <summary>
-    /// Creates a new IdempotencyConfigurationException
+    /// Creates a new LogFormatException
     /// </summary>
     public LogFormatException()
     {

--- a/libraries/src/AWS.Lambda.Powertools.Logging/LogFormatException.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/LogFormatException.cs
@@ -1,0 +1,41 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System;
+
+namespace AWS.Lambda.Powertools.Logging;
+
+/// <summary>
+/// Exception thrown when LogFormatter returns invalid object or error:
+/// </summary>
+public class LogFormatException : Exception
+{
+    /// <summary>
+    /// Creates a new IdempotencyConfigurationException
+    /// </summary>
+    public LogFormatException()
+    {
+    }
+
+    /// <inheritdoc />
+    public LogFormatException(string message) : base(message)
+    {
+    }
+
+    /// <inheritdoc />
+    public LogFormatException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Logger.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Logger.cs
@@ -44,6 +44,11 @@ public class Logger
     internal static ILoggerProvider LoggerProvider { get; set; }
 
     /// <summary>
+    ///     The logger formatter instance
+    /// </summary>
+    private static ILogFormatter _logFormatter;
+
+    /// <summary>
     ///     Gets the scope.
     /// </summary>
     /// <value>The scope.</value>
@@ -404,7 +409,7 @@ public class Logger
     {
         LoggerInstance.LogWarning(message, args);
     }
-    
+
     #endregion
 
     #region Error
@@ -533,7 +538,7 @@ public class Logger
     {
         LoggerInstance.LogCritical(message, args);
     }
-    
+
     #endregion
 
     #region Log
@@ -606,9 +611,9 @@ public class Logger
     }
 
     #endregion
-    
+
     #endregion
-    
+
     #region JSON Logger Methods
 
     /// <summary>
@@ -758,7 +763,7 @@ public class Logger
     #region ExtraKeys Logger Methods
 
     #region Debug
-    
+
     /// <summary>
     /// Formats and writes a debug log message.
     /// </summary>
@@ -810,11 +815,11 @@ public class Logger
     {
         LoggerInstance.LogDebug(extraKeys, message, args);
     }
-    
+
     #endregion
 
     #region Trace
-    
+
     /// <summary>
     /// Formats and writes a trace log message.
     /// </summary>
@@ -870,7 +875,7 @@ public class Logger
     #endregion
 
     #region Information
-    
+
     /// <summary>
     /// Formats and writes an informational log message.
     /// </summary>
@@ -922,7 +927,7 @@ public class Logger
     {
         LoggerInstance.LogInformation(extraKeys, message, args);
     }
-    
+
     #endregion
 
     #region Warning
@@ -978,7 +983,7 @@ public class Logger
     {
         LoggerInstance.LogWarning(extraKeys, message, args);
     }
-    
+
     #endregion
 
     #region Error
@@ -1094,7 +1099,7 @@ public class Logger
     #endregion
 
     #region Log
-    
+
     /// <summary>
     /// Formats and writes a log message at the specified log level.
     /// </summary>
@@ -1150,8 +1155,34 @@ public class Logger
     {
         LoggerInstance.Log(logLevel, extraKeys, message, args);
     }
-    
+
     #endregion
+
+    #endregion
+
+    #region Custom Log Formatter
+
+    /// <summary>
+    ///     Set the log formatter.
+    /// </summary>
+    /// <param name="logFormatter">The log formatter.</param>
+    public static void UseFormatter(ILogFormatter logFormatter)
+    {
+        _logFormatter = logFormatter ?? throw new ArgumentNullException(nameof(logFormatter));
+    }
+
+    /// <summary>
+    ///     Set the log formatter to default.
+    /// </summary>
+    public static void UseDefaultFormatter()
+    {
+        _logFormatter = null;
+    }
+
+    /// <summary>
+    ///     Returns the log formatter.
+    /// </summary>
+    internal static ILogFormatter GetFormatter() => _logFormatter;
 
     #endregion
 }

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/LogFormatterTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/LogFormatterTest.cs
@@ -1,0 +1,246 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using AWS.Lambda.Powertools.Common;
+using AWS.Lambda.Powertools.Logging.Internal;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using NSubstitute.ReturnsExtensions;
+using Xunit;
+
+namespace AWS.Lambda.Powertools.Logging.Tests
+{
+    [Collection("Sequential")]
+    public class LogFormatterTest
+    {
+        [Fact]
+        public void Log_WhenCustomFormatter_LogsCustomFormat()
+        {
+            // Arrange
+            const bool coldStart = false;
+            var xrayTraceId = Guid.NewGuid().ToString();
+            var correlationId = Guid.NewGuid().ToString();
+            var logLevel = LogLevel.Information;
+            var minimumLevel = LogLevel.Information;
+            var loggerName = Guid.NewGuid().ToString();
+            var service = Guid.NewGuid().ToString();
+            var message = Guid.NewGuid().ToString();
+
+            Logger.AppendKey(LoggingConstants.KeyColdStart, coldStart);
+            Logger.AppendKey(LoggingConstants.KeyXRayTraceId, xrayTraceId);
+            Logger.AppendKey(LoggingConstants.KeyCorrelationId, correlationId);
+
+            var configurations = Substitute.For<IPowertoolsConfigurations>();
+            configurations.Service.Returns(service);
+
+            var globalExtraKeys = new Dictionary<string, object>
+            {
+                { Guid.NewGuid().ToString(), Guid.NewGuid().ToString() },
+                { Guid.NewGuid().ToString(), Guid.NewGuid().ToString() }
+            };
+            Logger.AppendKeys(globalExtraKeys);
+
+            var lambdaContext = new LogEntryLambdaContext
+            {
+                FunctionName = Guid.NewGuid().ToString(),
+                FunctionVersion = Guid.NewGuid().ToString(),
+                InvokedFunctionArn = Guid.NewGuid().ToString(),
+                AwsRequestId = Guid.NewGuid().ToString(),
+                MemoryLimitInMB = (new Random()).Next()
+            };
+
+            var eventArgs = new AspectEventArgs
+            {
+                Name = Guid.NewGuid().ToString(),
+                Args = new object[]
+                {
+                    new
+                    {
+                        Source = "Test"
+                    },
+                    lambdaContext
+                }
+            };
+            PowertoolsLambdaContext.Extract(eventArgs);
+
+            var logFormatter = Substitute.For<ILogFormatter>();
+            var formattedLogEntry = new
+            {
+                Message = message,
+                Service = service,
+                CorrelationIds = new
+                {
+                    lambdaContext.AwsRequestId,
+                    XRayTraceId = xrayTraceId
+                },
+                LambdaFunction = new
+                {
+                    Name = lambdaContext.FunctionName,
+                    Arn = lambdaContext.InvokedFunctionArn,
+                    MemorySize = lambdaContext.MemoryLimitInMB,
+                    Version = lambdaContext.FunctionVersion,
+                    ColdStart = coldStart,
+                },
+                Level = logLevel.ToString(),
+                Logger = new
+                {
+                    Name = loggerName
+                }
+            };
+
+            logFormatter.FormatLogEntry(new LogEntry()).ReturnsForAnyArgs(formattedLogEntry);
+            Logger.UseFormatter(logFormatter);
+
+            var systemWrapper = Substitute.For<ISystemWrapper>();
+            var logger = new PowertoolsLogger(loggerName, configurations, systemWrapper, () =>
+                new LoggerConfiguration
+                {
+                    Service = service,
+                    MinimumLevel = minimumLevel,
+                    LoggerOutputCase = LoggerOutputCase.PascalCase
+                });
+
+            var scopeExtraKeys = new Dictionary<string, object>
+            {
+                { Guid.NewGuid().ToString(), Guid.NewGuid().ToString() },
+                { Guid.NewGuid().ToString(), Guid.NewGuid().ToString() }
+            };
+
+            // Act
+            logger.LogInformation(scopeExtraKeys, message);
+
+            // Assert
+            logFormatter.Received(1).FormatLogEntry(Arg.Is<LogEntry>
+            (
+                x =>
+                    x.ColdStart == coldStart &&
+                    x.XRayTraceId == xrayTraceId &&
+                    x.CorrelationId == correlationId &&
+                    x.Service == service &&
+                    x.Name == loggerName &&
+                    x.Level == logLevel &&
+                    x.Message.ToString() == message &&
+                    x.Exception == null &&
+                    x.ExtraKeys != null &&
+                    x.ExtraKeys.Count == globalExtraKeys.Count + scopeExtraKeys.Count &&
+                    x.ExtraKeys.ContainsKey(globalExtraKeys.First().Key) &&
+                    x.ExtraKeys[globalExtraKeys.First().Key] == globalExtraKeys.First().Value &&
+                    x.ExtraKeys.ContainsKey(globalExtraKeys.Last().Key) &&
+                    x.ExtraKeys[globalExtraKeys.Last().Key] == globalExtraKeys.Last().Value &&
+                    x.ExtraKeys.ContainsKey(scopeExtraKeys.First().Key) &&
+                    x.ExtraKeys[scopeExtraKeys.First().Key] == scopeExtraKeys.First().Value &&
+                    x.ExtraKeys.ContainsKey(scopeExtraKeys.Last().Key) &&
+                    x.ExtraKeys[scopeExtraKeys.Last().Key] == scopeExtraKeys.Last().Value &&
+                    x.LambdaContext != null &&
+                    x.LambdaContext.FunctionName == lambdaContext.FunctionName &&
+                    x.LambdaContext.FunctionVersion == lambdaContext.FunctionVersion &&
+                    x.LambdaContext.MemoryLimitInMB == lambdaContext.MemoryLimitInMB &&
+                    x.LambdaContext.InvokedFunctionArn == lambdaContext.InvokedFunctionArn &&
+                    x.LambdaContext.AwsRequestId == lambdaContext.AwsRequestId
+            ));
+            systemWrapper.Received(1).LogLine(JsonSerializer.Serialize(formattedLogEntry));
+            
+            //Clean up
+            Logger.UseDefaultFormatter();
+            Logger.RemoveAllKeys();
+            PowertoolsLambdaContext.Clear();
+            LoggingAspectHandler.ResetForTest();
+        }
+    }
+    
+    [Collection("Sequential")]
+    public class LogFormatterNullTest
+    {
+        [Fact]
+        public void Log_WhenCustomFormatterReturnNull_LogsError()
+        {
+            // Arrange
+            var loggerName = Guid.NewGuid().ToString();
+            var service = Guid.NewGuid().ToString();
+            var message = Guid.NewGuid().ToString();
+
+            var configurations = Substitute.For<IPowertoolsConfigurations>();
+            configurations.Service.Returns(service);
+
+            var logFormatter = Substitute.For<ILogFormatter>();
+            logFormatter.FormatLogEntry(new LogEntry()).ReturnsNullForAnyArgs();
+            Logger.UseFormatter(logFormatter);
+
+            var systemWrapper = Substitute.For<ISystemWrapper>();
+            var logger = new PowertoolsLogger(loggerName, configurations, systemWrapper, () =>
+                new LoggerConfiguration
+                {
+                    Service = service,
+                    MinimumLevel = LogLevel.Information,
+                    LoggerOutputCase = LoggerOutputCase.PascalCase
+                });
+
+            // Act
+            logger.LogInformation(message);
+
+            // Assert
+            logFormatter.Received(1).FormatLogEntry(Arg.Any<LogEntry>());
+            systemWrapper.Received(1).LogLine(Arg.Is<string>(x => x.Contains("Error") && x.Contains("null")));
+            
+            //Clean up
+            Logger.UseDefaultFormatter();
+        }
+    }
+    
+    [Collection("Sequential")]
+    public class LogFormatterExceptionTest
+    {
+        [Fact]
+        public void Log_WhenCustomFormatterRaisesException_LogsError()
+        {
+            // Arrange
+            var loggerName = Guid.NewGuid().ToString();
+            var service = Guid.NewGuid().ToString();
+            var message = Guid.NewGuid().ToString();
+            var errorMessage = Guid.NewGuid().ToString();
+
+            var configurations = Substitute.For<IPowertoolsConfigurations>();
+            configurations.Service.Returns(service);
+
+            var logFormatter = Substitute.For<ILogFormatter>();
+            logFormatter.FormatLogEntry(new LogEntry()).ThrowsForAnyArgs(new Exception(errorMessage));
+            Logger.UseFormatter(logFormatter);
+
+            var systemWrapper = Substitute.For<ISystemWrapper>();
+            var logger = new PowertoolsLogger(loggerName, configurations, systemWrapper, () =>
+                new LoggerConfiguration
+                {
+                    Service = service,
+                    MinimumLevel = LogLevel.Information,
+                    LoggerOutputCase = LoggerOutputCase.PascalCase
+                });
+
+            // Act
+            logger.LogInformation(message);
+
+            // Assert
+            logFormatter.Received(1).FormatLogEntry(Arg.Any<LogEntry>());
+            systemWrapper.Received(1).LogLine(Arg.Is<string>(x => x.Contains("Error") && x.Contains(errorMessage)));
+            
+            //Clean up
+            Logger.UseDefaultFormatter();
+        }
+    }
+}

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/LogFormatterTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/LogFormatterTest.cs
@@ -169,7 +169,7 @@ namespace AWS.Lambda.Powertools.Logging.Tests
     public class LogFormatterNullTest
     {
         [Fact]
-        public void Log_WhenCustomFormatterReturnNull_LogsError()
+        public void Log_WhenCustomFormatterReturnNull_ThrowsLogFormatException()
         {
             // Arrange
             var loggerName = Guid.NewGuid().ToString();
@@ -193,12 +193,13 @@ namespace AWS.Lambda.Powertools.Logging.Tests
                 });
 
             // Act
-            logger.LogInformation(message);
+            void Act() => logger.LogInformation(message);
 
             // Assert
+            Assert.Throws<LogFormatException>(Act);
             logFormatter.Received(1).FormatLogEntry(Arg.Any<LogEntry>());
-            systemWrapper.Received(1).LogLine(Arg.Is<string>(x => x.Contains("Error") && x.Contains("null")));
-            
+            systemWrapper.DidNotReceiveWithAnyArgs().LogLine(Arg.Any<string>());
+
             //Clean up
             Logger.UseDefaultFormatter();
         }
@@ -208,7 +209,7 @@ namespace AWS.Lambda.Powertools.Logging.Tests
     public class LogFormatterExceptionTest
     {
         [Fact]
-        public void Log_WhenCustomFormatterRaisesException_LogsError()
+        public void Log_WhenCustomFormatterRaisesException_ThrowsLogFormatException()
         {
             // Arrange
             var loggerName = Guid.NewGuid().ToString();
@@ -233,12 +234,13 @@ namespace AWS.Lambda.Powertools.Logging.Tests
                 });
 
             // Act
-            logger.LogInformation(message);
+            void Act() => logger.LogInformation(message);
 
             // Assert
+            Assert.Throws<LogFormatException>(Act);
             logFormatter.Received(1).FormatLogEntry(Arg.Any<LogEntry>());
-            systemWrapper.Received(1).LogLine(Arg.Is<string>(x => x.Contains("Error") && x.Contains(errorMessage)));
-            
+            systemWrapper.DidNotReceiveWithAnyArgs().LogLine(Arg.Any<string>());
+
             //Clean up
             Logger.UseDefaultFormatter();
         }

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/PowertoolsLoggerTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/PowertoolsLoggerTest.cs
@@ -27,8 +27,14 @@ using Xunit;
 
 namespace AWS.Lambda.Powertools.Logging.Tests
 {
+    [Collection("Sequential")]
     public class PowertoolsLoggerTest
     {
+        public PowertoolsLoggerTest()
+        {
+            Logger.UseDefaultFormatter();
+        }
+        
         private static void Log_WhenMinimumLevelIsBelowLogLevel_Logs(LogLevel logLevel, LogLevel minimumLevel)
         {
             // Arrange


### PR DESCRIPTION
Issue number: #366

## Summary
This PR allows users to being their own log formatter

### Changes
No changes to exiting functionalities only adding a new feature.

### User experience

```c#
    /**
     * Handler for requests to Lambda function.
     */
    public class Function
    {
        /// <summary>
        /// Function constructor
        /// </summary>
        public Function()
        {
            Logger.UseFormatter(new CustomLogFormatter());
        }

        [Logging(CorrelationIdPath = "/headers/my_request_id_header", SamplingRate = 0.7)]
        public async Task<APIGatewayProxyResponse> FunctionHandler
            (APIGatewayProxyRequest apigProxyEvent, ILambdaContext context)
        {
            ...
        }
    }
```

CustomLogFormatter implementation

```c#
    public class CustomLogFormatter : ILogFormatter
    {
        public object FormatLogEntry(LogEntry logEntry)
        {
            return new
            {
                Message = logEntry.Message,
                Service = logEntry.Service,
                CorrelationIds = new 
                {
                    AwsRequestId = logEntry.LambdaContext?.AwsRequestId,
                    XRayTraceId = logEntry.XRayTraceId,
                    CorrelationId = logEntry.CorrelationId
                },
                LambdaFunction = new
                {
                    Name = logEntry.LambdaContext?.FunctionName,
                    Arn = logEntry.LambdaContext?.InvokedFunctionArn,
                    MemoryLimitInMB = logEntry.LambdaContext?.MemoryLimitInMB,
                    Version = logEntry.LambdaContext?.FunctionVersion,
                    ColdStart = logEntry.ColdStart,
                },
                Level = logEntry.Level.ToString(),
                Timestamp = logEntry.Timestamp.ToString("o"),
                Logger = new
                {
                    Name = logEntry.Name,
                    SampleRate = logEntry.SamplingRate
                },
            };
        }
    }
```

Example CloudWatch Logs excerpt

```json
    {
        "Message": "Test Message",
        "Service": "lambda-example",
        "CorrelationIds": {
            "AwsRequestId": "52fdfc07-2182-154f-163f-5f0f9a621d72",
            "XRayTraceId": "1-61b7add4-66532bb81441e1b060389429",
            "CorrelationId": "correlation_id_value"
        },
        "LambdaFunction": {
            "Name": "test",
            "Arn": "arn:aws:lambda:eu-west-1:12345678910:function:test",
            "MemorySize": 128,
            "Version": "$LATEST",
            "ColdStart": true
        },
        "Level": "Information",
        "Timestamp": "2021-12-13T20:32:22.5774262Z",
        "Logger": {
            "Name": "AWS.Lambda.Powertools.Logging.Logger",
            "SampleRate": 0.7
        }
    }
```

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
