### PR TITLE
chore: include mermaid in mkdocs config. Fix identation and line numbers idempotency

### DIFF
--- a/docs/utilities/idempotency.md
+++ b/docs/utilities/idempotency.md
@@ -140,7 +140,7 @@ You can quickly start by configuring `Idempotency` and using it with the `Idempo
 !!! warning "Important"
     Initialization and configuration of the `Idempotency` must be performed outside the handler, preferably in the constructor.
 
-    ```csharp hl_lines="4 7"
+    ```csharp hl_lines="5 8"
     public class Function
     {
         public Function()
@@ -167,7 +167,7 @@ When using `Idempotent` attribute on another method, you must tell which paramet
 
 !!! info "The parameter must be serializable in JSON. We use `System.Text.Json` internally to (de)serialize objects"
 
-    ```csharp hl_lines="4 13-14"
+    ```csharp hl_lines="5 14-15"
     public class Function
     {
         public Function()
@@ -211,7 +211,7 @@ If we were to treat the entire request as our idempotency key, a simple HTTP hea
 
 === "Payment function"
 
-    ```csharp hl_lines="3"
+    ```csharp hl_lines="4"
     Idempotency.Configure(builder =>
             builder
                 .WithOptions(optionsBuilder =>
@@ -221,7 +221,7 @@ If we were to treat the entire request as our idempotency key, a simple HTTP hea
 
 === "Sample event"
 
-    ```json hl_lines="27"
+    ```json hl_lines="28"
     {
     "version": "2.0",
     "routeKey": "ANY /createpayment",
@@ -257,25 +257,25 @@ If we were to treat the entire request as our idempotency key, a simple HTTP hea
 ### Lambda timeouts
 
 ???+ note
-This is automatically done when you decorate your Lambda handler with [Idempotent attribute](#idempotent-attribute).
-
-To prevent against extended failed retries when a [Lambda function times out](https://aws.amazon.com/premiumsupport/knowledge-center/lambda-verify-invocation-timeouts/){target="_blank"},
-Powertools for AWS Lambda (.NET) calculates and includes the remaining invocation available time as part of the idempotency record.
+    This is automatically done when you decorate your Lambda handler with [Idempotent attribute](#idempotent-attribute).
+    
+    To prevent against extended failed retries when a [Lambda function times out](https://aws.amazon.com/premiumsupport/knowledge-center/lambda-verify-invocation-timeouts/){target="_blank"},
+    Powertools for AWS Lambda (.NET) calculates and includes the remaining invocation available time as part of the idempotency record.
 
 ???+ example
-If a second invocation happens **after** this timestamp, and the record is marked as `INPROGRESS`, we will execute the invocation again as if it was in the `EXPIRED` state (e.g, `Expired` field elapsed).
+    If a second invocation happens **after** this timestamp, and the record is marked as `INPROGRESS`, we will execute the invocation again as if it was in the `EXPIRED` state (e.g, `Expired` field elapsed).
 
     This means that if an invocation expired during execution, it will be quickly executed again on the next retry.
 
 ???+ important
-If you are only using the [Idempotent attribute](#Idempotent-attribute-on-another-method) to guard isolated parts of your code,
-you must use `RegisterLambdaContext` available in the `Idempotency` static class to benefit from this protection.
+    If you are only using the [Idempotent attribute](#Idempotent-attribute-on-another-method) to guard isolated parts of your code,
+    you must use `RegisterLambdaContext` available in the `Idempotency` static class to benefit from this protection.
 
 Here is an example on how you register the Lambda context in your handler:
 
 === "Registering the Lambda context"
 
-    ```csharp hl_lines="9" title="Registering the Lambda context"
+    ```csharp hl_lines="10" title="Registering the Lambda context"
     public class Function
     {
         public Function()
@@ -331,7 +331,7 @@ If an Exception is raised _outside_ the scope of the decorated method and after 
 
 === "Handling exceptions"
 
-    ```csharp hl_lines="2-4 8-10" title="Exception not affecting idempotency record sample"
+    ```csharp hl_lines="10-12 16-18 21" title="Exception not affecting idempotency record sample"
     public class Function
     {
         public Function()
@@ -675,7 +675,7 @@ With **`PayloadValidationJMESPath`**, you can provide an additional JMESPath exp
 
 === "Function.cs"
 
-    ```csharp
+    ```csharp hl_lines="6"
     Idempotency.Configure(builder =>
             builder
                 .WithOptions(optionsBuilder =>
@@ -730,7 +730,7 @@ This means that we will throw **`IdempotencyKeyException`** if the evaluation of
 
 === "Function.cs"
 
-    ```csharp
+    ```csharp hl_lines="9"
     public App() 
     {
       Idempotency.Configure(builder =>
@@ -752,7 +752,7 @@ This means that we will throw **`IdempotencyKeyException`** if the evaluation of
 
 === "Success Event"
 
-    ```json
+    ```json hl_lines="6"
     {
         "user": {
             "uid": "BB0D045C-8878-40C8-889E-38B3CB0A61B1",
@@ -782,7 +782,7 @@ When creating the `DynamoDBPersistenceStore`, you can set a custom [`AmazonDynam
 
 === "Custom AmazonDynamoDBClient"
 
-    ```csharp
+    ```csharp hl_lines="3 9"
     public Function()
     {
         AmazonDynamoDBClient customClient = new AmazonDynamoDBClient(RegionEndpoint.APSouth1);
@@ -804,14 +804,16 @@ With this setting, we will save the idempotency key in the sort key instead of t
 
 You can optionally set a static value for the partition key using the `StaticPkValue` parameter.
 
-```csharp title="Reusing a DynamoDB table that uses a composite primary key"
-Idempotency.Configure(builder => 
-    builder.UseDynamoDb(storeBuilder => 
-        storeBuilder.
-            WithTableName("TABLE_NAME")
-            .WithSortKeyAttr("sort_key")
-    ));
-```
+=== "Reusing a DynamoDB table that uses a composite primary key"
+
+    ```csharp hl_lines="5"
+    Idempotency.Configure(builder => 
+        builder.UseDynamoDb(storeBuilder => 
+            storeBuilder.
+                WithTableName("TABLE_NAME")
+                .WithSortKeyAttr("sort_key")
+        ));
+    ```
 
 Data would then be stored in DynamoDB like this:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,13 +26,13 @@ theme:
   palette:  
     - scheme: default
       primary: blue
-      accent: deep orange
+      accent: deep blue
       toggle:
         icon: material/toggle-switch-off-outline
         name: Switch to dark mode
     - scheme: slate
       primary: blue
-      accent: orange
+      accent: deep blue
       toggle:
         icon: material/toggle-switch
         name: Switch to light mode
@@ -69,9 +69,15 @@ markdown_extensions:
       permalink: true
       toc_depth: 4
   - attr_list
-  - pymdownx.emoji
+  - pymdownx.emoji:
+      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_generator: !!python/name:materialx.emoji.to_svg
   - pymdownx.inlinehilite
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
 
 copyright: Copyright &copy; 2023 Amazon Web Services
 
@@ -88,3 +94,9 @@ extra_javascript:
 extra:
   version:
     provider: mike
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/aws-powertools/powertools-lambda-dotnet
+    - icon: fontawesome/brands/discord
+      link: https://discord.gg/B8zZKbbyET
+      name: Join our Discord Server!


### PR DESCRIPTION
> Please provide the issue number

Issue number: #396 

## Summary

include mermaid in mkdocs config. Fix identation and line numbers idempotency

### Changes

> Please provide a summary of what's being changed

include mermaid in mkdocs config. Fix identation and line numbers idempotency

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
