### PR TITLE
feat: Automatic Register XRay for all services

### DIFF
--- a/docs/core/tracing.md
+++ b/docs/core/tracing.md
@@ -268,6 +268,7 @@ You should make sure to instrument the SDK clients explicitly based on the funct
         }
     }
     ```
+
 To instrument clients for some services and not others, call Register instead of RegisterForAllServices. Replace the highlighted text with the name of the service's client interface.
 
 ```c#

--- a/docs/core/tracing.md
+++ b/docs/core/tracing.md
@@ -244,5 +244,35 @@ under a subsegment, or you are doing multithreaded programming. Refer examples b
 
 ## Instrumenting SDK clients and HTTP calls
 
-User should make sure to instrument the SDK clients explicitly based on the function dependency. Refer details on
-[how to instrument SDK client with Xray](https://docs.aws.amazon.com/xray/latest/devguide/xray-sdk-dotnet-sdkclients.html) and [outgoing http calls](https://docs.aws.amazon.com/xray/latest/devguide/xray-sdk-dotnet-httpclients.html).
+You should make sure to instrument the SDK clients explicitly based on the function dependency. You can instrument all of your AWS SDK for .NET clients by calling RegisterForAllServices before you create them.
+
+=== "Function.cs"
+
+    ```c# hl_lines="14"
+    using Amazon.DynamoDBv2;
+    using Amazon.DynamoDBv2.Model;
+    using AWS.Lambda.Powertools.Tracing;
+    
+    public class Function
+    {
+        private static IAmazonDynamoDB _dynamoDb;
+
+        /// <summary>
+        /// Function constructor
+        /// </summary>
+        public Function()
+        {
+            Tracing.RegisterForAllServices();
+            
+            _dynamoDb = new AmazonDynamoDBClient();
+        }
+    }
+    ```
+To instrument clients for some services and not others, call Register instead of RegisterForAllServices. Replace the highlighted text with the name of the service's client interface.
+
+```c#
+Tracing.Register<IAmazonDynamoDB>()
+```
+
+This functionality is a thin wrapper for AWS X-Ray .NET SDK. Refer details on [how to instrument SDK client with Xray](https://docs.aws.amazon.com/xray/latest/devguide/xray-sdk-dotnet-sdkclients.html) and [outgoing http calls](https://docs.aws.amazon.com/xray/latest/devguide/xray-sdk-dotnet-httpclients.html).
+

--- a/libraries/src/AWS.Lambda.Powertools.Tracing/AWS.Lambda.Powertools.Tracing.csproj
+++ b/libraries/src/AWS.Lambda.Powertools.Tracing/AWS.Lambda.Powertools.Tracing.csproj
@@ -32,6 +32,7 @@
     <ItemGroup>
         <PackageReference Include="AWSSDK.XRay" Version="3.7.102.25" />
         <PackageReference Include="AWSXRayRecorder.Core" Version="2.14.0" />
+        <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.12.0" />
     </ItemGroup>
     <ItemGroup>
         <None Include="README.md" Pack="true" PackagePath="\" />

--- a/libraries/src/AWS.Lambda.Powertools.Tracing/AWS.Lambda.Powertools.Tracing.csproj
+++ b/libraries/src/AWS.Lambda.Powertools.Tracing/AWS.Lambda.Powertools.Tracing.csproj
@@ -30,7 +30,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="AWSSDK.XRay" Version="3.7.102.25" />
+        <PackageReference Include="AWSSDK.XRay" Version="3.7.200.34" />
         <PackageReference Include="AWSXRayRecorder.Core" Version="2.14.0" />
         <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.12.0" />
     </ItemGroup>

--- a/libraries/src/AWS.Lambda.Powertools.Tracing/Internal/TracingAspectHandler.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Tracing/Internal/TracingAspectHandler.cs
@@ -116,14 +116,15 @@ internal class TracingAspectHandler : IMethodAspectHandler
         if (_captureAnnotations)
         {
             _xRayRecorder.AddAnnotation("ColdStart", _isColdStart);
-
-            _isColdStart = false;
+            
             _captureAnnotations = false;
             _isAnnotationsCaptured = true;
 
             if (_powertoolsConfigurations.IsServiceDefined)
                 _xRayRecorder.AddAnnotation("Service", _powertoolsConfigurations.Service);
         }
+        
+        _isColdStart = false;
     }
 
     /// <summary>

--- a/libraries/src/AWS.Lambda.Powertools.Tracing/Tracing.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Tracing/Tracing.cs
@@ -15,6 +15,7 @@
 
 using System;
 using Amazon.XRay.Recorder.Core.Internal.Entities;
+using Amazon.XRay.Recorder.Handlers.AwsSdk;
 using AWS.Lambda.Powertools.Common;
 using AWS.Lambda.Powertools.Tracing.Internal;
 
@@ -238,5 +239,21 @@ public static class Tracing
             return nameSpace;
 
         return PowertoolsConfigurations.Instance.Service;
+    }
+    
+    /// <summary>
+    ///     Registers X-Ray for all instances of <see cref="Amazon.Runtime.AmazonServiceClient"/>.
+    /// </summary>
+    public static void RegisterForAllServices()
+    {
+        AWSSDKHandler.RegisterXRayForAllServices();
+    }
+
+    /// <summary>
+    ///     Registers X-Ray for the given type of <see cref="Amazon.Runtime.AmazonServiceClient"/>.
+    /// </summary>
+    public static void Register<T>()
+    {
+        AWSSDKHandler.RegisterXRay<T>();
     }
 }


### PR DESCRIPTION
Issue number: #249

## Summary

This PR adds a thin wrapper around AWSSDKHandler.RegisterXRayForAllServices() andAWSSDKHandler.RegisterXRay<IAmazonxxxService>()

### Changes

Adds two wrapper static methods to Tracing class.

### User experience

User now can call following wrapper methods instead of sdk methods

- Tracing.RegisterForAllServices() instead of AWSSDKHandler.RegisterXRayForAllServices();
- Tracing.Register<IAmazonxxxService>() instead of AWSSDKHandler.RegisterXRay<IAmazonxxxService>()

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
