### PR TITLE
chore: Disable dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,61 +3,64 @@
 # Please see the documentation for all configuration options:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
-version: 2
-updates:
-  - package-ecosystem: "nuget" # See documentation for possible values
-    directory: "/libraries/" # Location of package manifests
-    schedule:
-      interval: "weekly"
-    target-branch: "develop"
-    commit-message:
-      prefix: chore
-      include: scope
-  - package-ecosystem: "nuget" # See documentation for possible values
-    directory: "/examples/Idempotency/" # Location of package manifests
-    schedule:
-      interval: "weekly"
-    target-branch: "develop"
-    commit-message:
-      prefix: chore
-      include: scope
-  - package-ecosystem: "nuget" # See documentation for possible values
-    directory: "/examples/Logging/" # Location of package manifests
-    schedule:
-      interval: "weekly"
-    target-branch: "develop"
-    commit-message:
-      prefix: chore
-      include: scope
-  - package-ecosystem: "nuget" # See documentation for possible values
-    directory: "/examples/Metrics/" # Location of package manifests
-    schedule:
-      interval: "weekly"
-    target-branch: "develop"
-    commit-message:
-      prefix: chore
-      include: scope
-  - package-ecosystem: "nuget" # See documentation for possible values
-    directory: "/examples/Parameters/" # Location of package manifests
-    schedule:
-      interval: "weekly"
-    target-branch: "develop"
-    commit-message:
-      prefix: chore
-      include: scope
-  - package-ecosystem: "nuget" # See documentation for possible values
-    directory: "/examples/ServerlessApi/" # Location of package manifests
-    schedule:
-      interval: "weekly"
-    target-branch: "develop"
-    commit-message:
-      prefix: chore
-      include: scope
-  - package-ecosystem: "nuget" # See documentation for possible values
-    directory: "/examples/Tracing/" # Location of package manifests
-    schedule:
-      interval: "weekly"
-    target-branch: "develop"
-    commit-message:
-      prefix: chore
-      include: scope
+# Until there is support for Nuget central package management dependabot needs to be disabled 
+# https://github.com/dependabot/dependabot-core/issues/4999
+
+# version: 2
+# updates:
+#   - package-ecosystem: "nuget" # See documentation for possible values
+#     directory: "/libraries/" # Location of package manifests
+#     schedule:
+#       interval: "weekly"
+#     target-branch: "develop"
+#     commit-message:
+#       prefix: chore
+#       include: scope
+#   - package-ecosystem: "nuget" # See documentation for possible values
+#     directory: "/examples/Idempotency/" # Location of package manifests
+#     schedule:
+#       interval: "weekly"
+#     target-branch: "develop"
+#     commit-message:
+#       prefix: chore
+#       include: scope
+#   - package-ecosystem: "nuget" # See documentation for possible values
+#     directory: "/examples/Logging/" # Location of package manifests
+#     schedule:
+#       interval: "weekly"
+#     target-branch: "develop"
+#     commit-message:
+#       prefix: chore
+#       include: scope
+#   - package-ecosystem: "nuget" # See documentation for possible values
+#     directory: "/examples/Metrics/" # Location of package manifests
+#     schedule:
+#       interval: "weekly"
+#     target-branch: "develop"
+#     commit-message:
+#       prefix: chore
+#       include: scope
+#   - package-ecosystem: "nuget" # See documentation for possible values
+#     directory: "/examples/Parameters/" # Location of package manifests
+#     schedule:
+#       interval: "weekly"
+#     target-branch: "develop"
+#     commit-message:
+#       prefix: chore
+#       include: scope
+#   - package-ecosystem: "nuget" # See documentation for possible values
+#     directory: "/examples/ServerlessApi/" # Location of package manifests
+#     schedule:
+#       interval: "weekly"
+#     target-branch: "develop"
+#     commit-message:
+#       prefix: chore
+#       include: scope
+#   - package-ecosystem: "nuget" # See documentation for possible values
+#     directory: "/examples/Tracing/" # Location of package manifests
+#     schedule:
+#       interval: "weekly"
+#     target-branch: "develop"
+#     commit-message:
+#       prefix: chore
+#       include: scope


### PR DESCRIPTION
disable dependabot
https://github.com/dependabot/dependabot-core/issues/4999

> Please provide the issue number 

Issue number: #463 

## Summary

Disable dependabot until https://github.com/dependabot/dependabot-core/issues/4999 is supported

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
