### PR TITLE
fix: Metrics throws exception when decorating non handler methods

### DIFF
--- a/libraries/src/AWS.Lambda.Powertools.Metrics/IMetrics.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/IMetrics.cs
@@ -23,7 +23,7 @@ namespace AWS.Lambda.Powertools.Metrics;
 ///     Implements the <see cref="System.IDisposable" />
 /// </summary>
 /// <seealso cref="System.IDisposable" />
-public interface IMetrics : IDisposable
+public interface IMetrics 
 {
     /// <summary>
     ///     Adds metric

--- a/libraries/src/AWS.Lambda.Powertools.Metrics/Metrics.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/Metrics.cs
@@ -25,13 +25,13 @@ namespace AWS.Lambda.Powertools.Metrics;
 ///     Implements the <see cref="IMetrics" />
 /// </summary>
 /// <seealso cref="IMetrics" />
-public class Metrics : IMetrics
+public class Metrics : IMetrics, IDisposable
 {
     /// <summary>
     ///     The instance
     /// </summary>
     private static IMetrics _instance;
-
+    
     /// <summary>
     ///     The context
     /// </summary>
@@ -177,19 +177,19 @@ public class Metrics : IMetrics
     /// <summary>
     ///     Implements interface that sets default dimension list
     /// </summary>
-    /// <param name="defaultDimensions">Default Dimension List</param>
+    /// <param name="defaultDimension">Default Dimension List</param>
     /// <exception cref="System.ArgumentNullException">
     ///     'SetDefaultDimensions' method requires a valid key pair. 'Null' or empty
     ///     values are not allowed.
     /// </exception>
-    void IMetrics.SetDefaultDimensions(Dictionary<string, string> defaultDimensions)
+    void IMetrics.SetDefaultDimensions(Dictionary<string, string> defaultDimension)
     {
-        foreach (var item in defaultDimensions)
+        foreach (var item in defaultDimension)
             if (string.IsNullOrWhiteSpace(item.Key) || string.IsNullOrWhiteSpace(item.Value))
                 throw new ArgumentNullException(
                     $"'SetDefaultDimensions' method requires a valid key pair. 'Null' or empty values are not allowed.");
 
-        _context.SetDefaultDimensions(DictionaryToList(defaultDimensions));
+        _context.SetDefaultDimensions(DictionaryToList(defaultDimension));
     }
 
     /// <summary>
@@ -272,7 +272,21 @@ public class Metrics : IMetrics
     /// </summary>
     public void Dispose()
     {
-        _instance.Flush();
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+    
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="disposing"></param>
+    protected virtual void Dispose(bool disposing)
+    {
+        // Cleanup
+        if (disposing)
+        {
+            _instance.Flush();
+        }
     }
 
     /// <summary>

--- a/libraries/src/AWS.Lambda.Powertools.Metrics/Metrics.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/Metrics.cs
@@ -91,11 +91,11 @@ public class Metrics : IMetrics, IDisposable
     {
         if (string.IsNullOrWhiteSpace(key))
             throw new ArgumentNullException(
-                $"'AddMetric' method requires a valid metrics key. 'Null' or empty values are not allowed.");
+                nameof(key), "'AddMetric' method requires a valid metrics key. 'Null' or empty values are not allowed.");
         
         if (value < 0) {
             throw new ArgumentException(
-                "'AddMetric' method requires a valid metrics value. Value must be >= 0.");
+                "'AddMetric' method requires a valid metrics value. Value must be >= 0.", nameof(value));
         }
 
         var metrics = _context.GetMetrics();
@@ -150,8 +150,8 @@ public class Metrics : IMetrics, IDisposable
     void IMetrics.AddDimension(string key, string value)
     {
         if (string.IsNullOrWhiteSpace(key))
-            throw new ArgumentNullException(
-                $"'AddDimension' method requires a valid dimension key. 'Null' or empty values are not allowed.");
+            throw new ArgumentNullException(nameof(key),
+                "'AddDimension' method requires a valid dimension key. 'Null' or empty values are not allowed.");
 
         _context.AddDimension(key, value);
     }
@@ -168,8 +168,8 @@ public class Metrics : IMetrics, IDisposable
     void IMetrics.AddMetadata(string key, object value)
     {
         if (string.IsNullOrWhiteSpace(key))
-            throw new ArgumentNullException(
-                $"'AddMetadata' method requires a valid metadata key. 'Null' or empty values are not allowed.");
+            throw new ArgumentNullException(nameof(key),
+                "'AddMetadata' method requires a valid metadata key. 'Null' or empty values are not allowed.");
 
         _context.AddMetadata(key, value);
     }
@@ -186,8 +186,8 @@ public class Metrics : IMetrics, IDisposable
     {
         foreach (var item in defaultDimension)
             if (string.IsNullOrWhiteSpace(item.Key) || string.IsNullOrWhiteSpace(item.Value))
-                throw new ArgumentNullException(
-                    $"'SetDefaultDimensions' method requires a valid key pair. 'Null' or empty values are not allowed.");
+                throw new ArgumentNullException(nameof(item.Key),
+                    "'SetDefaultDimensions' method requires a valid key pair. 'Null' or empty values are not allowed.");
 
         _context.SetDefaultDimensions(DictionaryToList(defaultDimension));
     }
@@ -258,8 +258,8 @@ public class Metrics : IMetrics, IDisposable
         Dictionary<string, string> defaultDimensions, MetricResolution metricResolution)
     {
         if (string.IsNullOrWhiteSpace(metricName))
-            throw new ArgumentNullException(
-                $"'PushSingleMetric' method requires a valid metrics key. 'Null' or empty values are not allowed.");
+            throw new ArgumentNullException(nameof(metricName),
+                "'PushSingleMetric' method requires a valid metrics key. 'Null' or empty values are not allowed.");
 
         using var context = InitializeContext(nameSpace, service, defaultDimensions);
         context.AddMetric(metricName, value, unit, metricResolution);

--- a/libraries/src/AWS.Lambda.Powertools.Metrics/Metrics.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/Metrics.cs
@@ -65,15 +65,15 @@ public class Metrics : IMetrics
     internal Metrics(IPowertoolsConfigurations powertoolsConfigurations, string nameSpace = null, string service = null,
         bool raiseOnEmptyMetrics = false, bool captureColdStartEnabled = false)
     {
-        if (_instance != null) return;
+        _instance ??= this;
 
-        _instance = this;
         _powertoolsConfigurations = powertoolsConfigurations;
         _raiseOnEmptyMetrics = raiseOnEmptyMetrics;
         _captureColdStartEnabled = captureColdStartEnabled;
         _context = InitializeContext(nameSpace, service, null);
         
         _powertoolsConfigurations.SetExecutionEnvironment(this);
+        
     }
 
     /// <summary>

--- a/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/EMFValidationTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/EMFValidationTests.cs
@@ -467,7 +467,7 @@ namespace AWS.Lambda.Powertools.Metrics.Tests
 
             // Assert
             var exception = Assert.Throws<ArgumentException>(act);
-            Assert.Equal("'AddMetric' method requires a valid metrics value. Value must be >= 0.", exception.Message);
+            Assert.Equal("'AddMetric' method requires a valid metrics value. Value must be >= 0. (Parameter 'value')", exception.Message);
 
             // RESET
             handler.ResetForTest();

--- a/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/Handlers/ExceptionFunctionHandler.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/Handlers/ExceptionFunctionHandler.cs
@@ -7,13 +7,28 @@ namespace AWS.Lambda.Powertools.Metrics.Tests.Handlers;
 public class ExceptionFunctionHandler
 {
     [Metrics(Namespace = "ns", Service = "svc")]
-    public async Task<string> Handle(string input)
+    public Task<string> Handle(string input)
     {
         ThisThrows();
+        return Task.FromResult(input.ToUpper(CultureInfo.InvariantCulture));
+    }
+    
+    [Metrics(Namespace = "ns", Service = "svc")]
+    public Task<string> HandleDecoratorOutsideHandler(string input)
+    {
+        MethodDecorated();
+        
+        Metrics.AddMetric($"Metric Name", 1, MetricUnit.Count);
 
-        await Task.Delay(1);
+        return Task.FromResult(input.ToUpper(CultureInfo.InvariantCulture));
+    }
 
-        return input.ToUpper(CultureInfo.InvariantCulture);
+    [Metrics(Namespace = "ns", Service = "svc")]
+    private void MethodDecorated()
+    {
+        // NOOP
+        Metrics.AddMetric($"Metric Name", 1, MetricUnit.Count);
+        Metrics.AddMetric($"Metric Name Decorated", 1, MetricUnit.Count);
     }
 
     private void ThisThrows()

--- a/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/Handlers/ExceptionFunctionHandler.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/Handlers/ExceptionFunctionHandler.cs
@@ -22,16 +22,33 @@ public class ExceptionFunctionHandler
 
         return Task.FromResult(input.ToUpper(CultureInfo.InvariantCulture));
     }
+    
+    [Metrics(Namespace = "ns", Service = "svc")]
+    public Task<string> HandleDecoratorOutsideHandlerException(string input)
+    {
+        MethodDecorated();
+        
+        Metrics.AddMetric($"Metric Name", 1, MetricUnit.Count);
+        
+        ThisThrowsDecorated();
+        
+        return Task.FromResult(input.ToUpper(CultureInfo.InvariantCulture));
+    }
 
     [Metrics(Namespace = "ns", Service = "svc")]
     private void MethodDecorated()
     {
-        // NOOP
         Metrics.AddMetric($"Metric Name", 1, MetricUnit.Count);
         Metrics.AddMetric($"Metric Name Decorated", 1, MetricUnit.Count);
     }
 
     private void ThisThrows()
+    {
+        throw new NullReferenceException();
+    }
+    
+    [Metrics(Namespace = "ns", Service = "svc")]
+    private void ThisThrowsDecorated()
     {
         throw new NullReferenceException();
     }

--- a/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/Handlers/ExceptionFunctionHandlerTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/Handlers/ExceptionFunctionHandlerTests.cs
@@ -20,7 +20,21 @@ public sealed class ExceptionFunctionHandlerTests
         // Assert
         var tracedException = await Assert.ThrowsAsync<NullReferenceException>(Handle);
         Assert.StartsWith("at AWS.Lambda.Powertools.Metrics.Tests.Handlers.ExceptionFunctionHandler.ThisThrows()", tracedException.StackTrace?.TrimStart());
+    }
+    
+    [Fact]
+    public async Task Stack_Trace_Included_When_Decorator_Present_In_Method()
+    {
+        // Arrange
+        Metrics.ResetForTest();
+        var handler = new ExceptionFunctionHandler();
 
+        // Act
+        Task Handle() => handler.HandleDecoratorOutsideHandlerException("whatever");
+        
+        // Assert
+        var tracedException = await Assert.ThrowsAsync<NullReferenceException>(Handle);
+        Assert.StartsWith("at AWS.Lambda.Powertools.Metrics.Tests.Handlers.ExceptionFunctionHandler.__a$_around_ThisThrows", tracedException.StackTrace?.TrimStart());
     }
     
     [Fact]

--- a/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/Handlers/ExceptionFunctionHandlerTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/Handlers/ExceptionFunctionHandlerTests.cs
@@ -22,4 +22,21 @@ public sealed class ExceptionFunctionHandlerTests
         Assert.StartsWith("at AWS.Lambda.Powertools.Metrics.Tests.Handlers.ExceptionFunctionHandler.ThisThrows()", tracedException.StackTrace?.TrimStart());
 
     }
+    
+    [Fact]
+    public async Task Decorator_In_Non_Handler_Method_Does_Not_Throw_Exception()
+    {
+        // Arrange
+        Metrics.ResetForTest();
+        var handler = new ExceptionFunctionHandler();
+
+        // Act
+        Task Handle() => handler.HandleDecoratorOutsideHandler("whatever");
+        
+        // Assert
+        var tracedException = await Record.ExceptionAsync(Handle);
+        Assert.Null(tracedException);
+        //Assert.StartsWith("at AWS.Lambda.Powertools.Metrics.Tests.Handlers.ExceptionFunctionHandler.ThisThrows()", tracedException.StackTrace?.TrimStart());
+
+    }
 }

--- a/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/Handlers/ExceptionFunctionHandlerTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/Handlers/ExceptionFunctionHandlerTests.cs
@@ -36,7 +36,5 @@ public sealed class ExceptionFunctionHandlerTests
         // Assert
         var tracedException = await Record.ExceptionAsync(Handle);
         Assert.Null(tracedException);
-        //Assert.StartsWith("at AWS.Lambda.Powertools.Metrics.Tests.Handlers.ExceptionFunctionHandler.ThisThrows()", tracedException.StackTrace?.TrimStart());
-
     }
 }


### PR DESCRIPTION
> Please provide the issue number

Issue number: #498 

## Summary

Even though Metrics decorator should be used exclusively to decorate the handler, utilities should not throw exceptions when used incorrectly.

Update Metrics constructor to not return and set all values.

### Current Behaviour

Currently Metrics throws NullReferenceException when decorating non handler (no Lambda context) methods.

``` csharp
System.NullReferenceException: Object reference not set to an instance of an object.
   at AWS.Lambda.Powertools.Metrics.Metrics.AWS.Lambda.Powertools.Metrics.IMetrics.Flush(Boolean metricsOverflow) in /aws-lambda-powertools-dotnet/libraries/src/AWS.Lambda.Powertools.Metrics/Metrics.cs:line 204
   at AWS.Lambda.Powertools.Metrics.MetricsAspectHandler.OnExit(AspectEventArgs eventArgs) in /aws-lambda-powertools-dotnet/libraries/src/AWS.Lambda.Powertools.Metrics/Internal/MetricsAspectHandler.cs:line 71
   at AWS.Lambda.Powertools.Common.MethodAspectAttribute.WrapSync[T](Func`2 target, Object[] args, AspectEventArgs eventArgs) in /aws-lambda-powertools-dotnet/libraries/src/AWS.Lambda.Powertools.Common/Aspects/MethodAspectAttribute.cs:line 72
   at AWS.Lambda.Powertools.Common.UniversalWrapperAspect.Handle(Object instance, Type type, MethodBase method, Func`2 target, String name, Object[] args, Type returnType, Attribute[] triggers) in /aws-lambda-powertools-dotnet/libraries/src/AWS.Lambda.Powertools.Common/Aspects/UniversalWrapperAspect.cs:line 87
   at AWS.Lambda.Powertools.Metrics.Tests.Handlers.ExceptionFunctionHandler.__a$_around_MethodDecorated_100663324_w_0(Object[] )
```

Flush method has a null _context

``` csharp
void IMetrics.Flush(bool metricsOverflow)
    {
        if (_context.GetMetrics().Count == 0
            && _raiseOnEmptyMetrics)
            throw new SchemaValidationException(true);

        if (_context.IsSerializable)
        {
            var emfPayload = _context.Serialize();

            Console.WriteLine(emfPayload);

            _context.ClearMetrics();

            if (!metricsOverflow) _context.ClearNonDefaultDimensions();
        }
        else
        {
            if (!_captureColdStartEnabled)
                Console.WriteLine(
                    "##WARNING## Metrics and Metadata have not been specified. No data will be sent to Cloudwatch Metrics.");
        }
    }
```


### Changes

> Please provide a summary of what's being changed

**Fix** : always set the values, but only set instance if null.

``` csharp
    internal Metrics(IPowertoolsConfigurations powertoolsConfigurations, string nameSpace = null, string service = null,
        bool raiseOnEmptyMetrics = false, bool captureColdStartEnabled = false)
    {
        _instance ??= this; // this line updated

        _powertoolsConfigurations = powertoolsConfigurations;
        _raiseOnEmptyMetrics = raiseOnEmptyMetrics;
        _captureColdStartEnabled = captureColdStartEnabled;
        _context = InitializeContext(nameSpace, service, null);
        
        _powertoolsConfigurations.SetExecutionEnvironment(this);
    }
```


### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
