### PR TITLE
feat: Add DateOnly and TimeOnly converters

### DIFF
--- a/libraries/src/AWS.Lambda.Powertools.Logging/Internal/Converters/DateOnlyConverter.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Internal/Converters/DateOnlyConverter.cs
@@ -1,0 +1,52 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace AWS.Lambda.Powertools.Logging.Internal.Converters;
+
+/// <summary>
+/// DateOnly JSON converter
+/// </summary>
+public class DateOnlyConverter : JsonConverter<DateOnly>
+{
+    private const string DateFormat = "yyyy-MM-dd";
+    
+    /// <summary>
+    /// Converts DateOnly from JSON.
+    /// </summary>
+    /// <param name="reader"></param>
+    /// <param name="typeToConvert"></param>
+    /// <param name="options"></param>
+    /// <returns></returns>
+    public override DateOnly Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return DateOnly.ParseExact(reader.GetString()!, DateFormat, CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>
+    /// Converts DateOnly to JSON.
+    /// </summary>
+    /// <param name="writer"></param>
+    /// <param name="value"></param>
+    /// <param name="options"></param>
+    public override void Write(Utf8JsonWriter writer, DateOnly value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.ToString(DateFormat, CultureInfo.InvariantCulture));
+    }
+}

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Internal/Converters/TimeOnlyConverter.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Internal/Converters/TimeOnlyConverter.cs
@@ -1,0 +1,52 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace AWS.Lambda.Powertools.Logging.Internal.Converters;
+
+/// <summary>
+/// TimeOnly JSON converter
+/// </summary>
+internal class TimeOnlyConverter : JsonConverter<TimeOnly>
+{
+    private const string TimeFormat = "HH:mm:ss.FFFFFFF";
+    
+    /// <summary>
+    /// Converts TimeOnly from JSON.
+    /// </summary>
+    /// <param name="reader"></param>
+    /// <param name="typeToConvert"></param>
+    /// <param name="options"></param>
+    /// <returns></returns>
+    public override TimeOnly Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return TimeOnly.ParseExact(reader.GetString()!, TimeFormat, CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>
+    /// Converts TimeOnly to JSON.
+    /// </summary>
+    /// <param name="writer"></param>
+    /// <param name="value"></param>
+    /// <param name="options"></param>
+    public override void Write(Utf8JsonWriter writer, TimeOnly value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.ToString(TimeFormat, CultureInfo.InvariantCulture));
+    }
+}

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Internal/LoggingAspectHandler.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Internal/LoggingAspectHandler.cs
@@ -288,6 +288,8 @@ internal class LoggingAspectHandler : IMethodAspectHandler
         jsonOptions.Converters.Add(new ExceptionConverter());
         jsonOptions.Converters.Add(new MemoryStreamConverter());
         jsonOptions.Converters.Add(new ConstantClassConverter());
+        jsonOptions.Converters.Add(new DateOnlyConverter());
+        jsonOptions.Converters.Add(new TimeOnlyConverter());
         return jsonOptions;
     }
 

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Internal/PowertoolsLogger.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Internal/PowertoolsLogger.cs
@@ -466,6 +466,8 @@ internal sealed class PowertoolsLogger : ILogger
         jsonOptions.Converters.Add(new ExceptionConverter());
         jsonOptions.Converters.Add(new MemoryStreamConverter());
         jsonOptions.Converters.Add(new ConstantClassConverter());
+        jsonOptions.Converters.Add(new DateOnlyConverter());
+        jsonOptions.Converters.Add(new TimeOnlyConverter());
         
         jsonOptions.Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping;
         

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/PowertoolsLoggerTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/PowertoolsLoggerTest.cs
@@ -1219,5 +1219,87 @@ namespace AWS.Lambda.Powertools.Logging.Tests
                 $"{Constants.FeatureContextIdentifier}/Logger/{assemblyVersion}");
             env.Received(1).GetEnvironmentVariable("AWS_EXECUTION_ENV");
         }
+        
+        [Fact]
+        public void Log_Should_Serialize_DateOnly()
+        {
+            // Arrange
+            var loggerName = Guid.NewGuid().ToString();
+            var service = Guid.NewGuid().ToString();
+            var logLevel = LogLevel.Information;
+            var randomSampleRate = 0.5;
+
+            var configurations = Substitute.For<IPowertoolsConfigurations>();
+            configurations.Service.Returns(service);
+            configurations.LogLevel.Returns(logLevel.ToString());
+
+            var systemWrapper = Substitute.For<ISystemWrapper>();
+            systemWrapper.GetRandom().Returns(randomSampleRate);
+
+            var logger = new PowertoolsLogger(loggerName, configurations, systemWrapper, () =>
+                new LoggerConfiguration
+                {
+                    Service = null,
+                    MinimumLevel = null,
+                    LoggerOutputCase = LoggerOutputCase.CamelCase
+                });
+
+            var message = new
+            {
+                PropOne = "Value 1",
+                PropTwo = "Value 2",
+                Date = new DateOnly(2022, 1, 1)
+            };
+
+            logger.LogInformation(message);
+
+            // Assert
+            systemWrapper.Received(1).LogLine(
+                Arg.Is<string>(s =>
+                    s.Contains("\"message\":{\"propOne\":\"Value 1\",\"propTwo\":\"Value 2\",\"date\":\"2022-01-01\"}")
+                )
+            );
+        }
+        
+        [Fact]
+        public void Log_Should_Serialize_TimeOnly()
+        {
+            // Arrange
+            var loggerName = Guid.NewGuid().ToString();
+            var service = Guid.NewGuid().ToString();
+            var logLevel = LogLevel.Information;
+            var randomSampleRate = 0.5;
+
+            var configurations = Substitute.For<IPowertoolsConfigurations>();
+            configurations.Service.Returns(service);
+            configurations.LogLevel.Returns(logLevel.ToString());
+
+            var systemWrapper = Substitute.For<ISystemWrapper>();
+            systemWrapper.GetRandom().Returns(randomSampleRate);
+
+            var logger = new PowertoolsLogger(loggerName, configurations, systemWrapper, () =>
+                new LoggerConfiguration
+                {
+                    Service = null,
+                    MinimumLevel = null,
+                    LoggerOutputCase = LoggerOutputCase.CamelCase
+                });
+
+            var message = new
+            {
+                PropOne = "Value 1",
+                PropTwo = "Value 2",
+                Time = new TimeOnly(12, 0, 0)
+            };
+
+            logger.LogInformation(message);
+
+            // Assert
+            systemWrapper.Received(1).LogLine(
+                Arg.Is<string>(s =>
+                    s.Contains("\"message\":{\"propOne\":\"Value 1\",\"propTwo\":\"Value 2\",\"time\":\"12:00:00\"}")
+                )
+            );
+        }
     }
 }


### PR DESCRIPTION
> Please provide the issue number

Issue number: #501 

## Summary

.NET 6 is missing DateOnly and TimeOnly Json converters. This is causing issues serializing these two types.

### Changes

> Please provide a summary of what's being changed

Added two new converters for DateOnly and TimeOnly.

### User experience

> Please share what the user experience looks like before and after this change

Logging will handle DateOnly fields without any additional or custom logic from application developers.

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
