### PR TITLE
chore: Update versions for release 1.8.1

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
 	"Core": {
-		"Logging": "1.3.2",
-		"Metrics": "1.4.2",
+		"Logging": "1.3.3",
+		"Metrics": "1.4.3",
 		"Tracing": "1.3.2"
 	},
 	"Utilities": {


### PR DESCRIPTION
> Please provide the issue number

Issue number: #506 

## Summary

Update versions for release 1.8.1

Logging: 1.3.3
Metrics: 1.4.3

### Changes

In this release we are happy to introduce two new converters for DateOnly and TimeOnly types. These are not supported by default on .NET 6 but will be included in Powertools.
We also fixed two bugs reported on the metrics utility.

- Do not throw exception when decorating a non Lambda handler method
- Do not throw exception when Metadata uses and existing metrics key
- Do not throw exception on second invocation when using Metadata

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
