### PR TITLE
chore: Sync main with develop for release 1.8.1

### DIFF
--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -311,6 +311,9 @@ You can add high-cardinality data as part of your Metrics log with `AddMetadata`
 !!! info
     **This will not be available during metrics visualization** - Use **dimensions** for this purpose
 
+!!! info
+    Adding metadata with a key that is the same as an existing metric will be ignored
+
 === "Function.cs"
 
     ```csharp hl_lines="9"

--- a/libraries/src/AWS.Lambda.Powertools.BatchProcessing/README.md
+++ b/libraries/src/AWS.Lambda.Powertools.BatchProcessing/README.md
@@ -1,14 +1,59 @@
 # AWS.Lambda.Powertools.BatchProcessing
-...
+
+The batch processing utility handles partial failures when processing batches from Amazon SQS, Amazon Kinesis Data Streams, and Amazon DynamoDB Streams.
 
 ## Key features
-...
+
+* Reports batch item failures to reduce number of retries for a record upon errors
+* Simple interface to process each batch record
+* Bring your own batch processor
+* Parallel processing
+
+## Background
+
+When using SQS, Kinesis Data Streams, or DynamoDB Streams as a Lambda event source, your Lambda functions are triggered with a batch of messages.
+
+If your function fails to process any message from the batch, the entire batch returns to your queue or stream. This same batch is then retried until either condition happens first: a) your Lambda function returns a successful response, b) record reaches maximum retry attempts, or c) when records expire.
+
+This behavior changes when you enable Report Batch Item Failures feature in your Lambda function event source configuration:
+
+* [SQS queues](https://docs.powertools.aws.dev/lambda/dotnet/utilities/batch-processing/#sqs-standard). Only messages reported as failure will return to the queue for a retry, while successful ones will be deleted.
+* [Kinesis data streams](https://docs.powertools.aws.dev/lambda/dotnet/utilities/batch-processing/#kinesis-and-dynamodb-streams) and [DynamoDB streams](https://docs.powertools.aws.dev/lambda/dotnet/utilities/batch-processing/#kinesis-and-dynamodb-streams). Single reported failure will use its sequence number as the stream checkpoint. Multiple reported failures will use the lowest sequence number as checkpoint.
 
 ## Read the docs
-...
+
+For a full list of features go to [docs.powertools.aws.dev/lambda/dotnet/utilities/batch-processing/](https://docs.powertools.aws.dev/lambda/dotnet/utilities/batch-processing/)
+
+GitHub: https://github.com/aws-powertools/powertools-lambda-dotnet/
 
 ## Sample Function
-...
 
-## Sample output
-...
+View the full example here: [github.com/aws-powertools/powertools-lambda-dotnet/tree/develop/examples/BatchProcessing](https://github.com/aws-powertools/powertools-lambda-dotnet/tree/develop/examples/BatchProcessing)
+
+```csharp
+[BatchProcessor(RecordHandler = typeof(CustomSqsRecordHandler))]
+public BatchItemFailuresResponse HandlerUsingAttribute(SQSEvent _)
+{
+    return SqsBatchProcessor.Result.BatchItemFailuresResponse;
+}
+
+public class CustomSqsRecordHandler : ISqsRecordHandler
+{
+    public async Task<RecordHandlerResult> HandleAsync(SQSEvent.SQSMessage record, CancellationToken cancellationToken)
+    {
+        /*
+            Your business logic. 
+            If an exception is thrown, the item will be marked as a partial batch item failure.
+        */
+        
+        var product = JsonSerializer.Deserialize<JsonElement>(record.Body);
+
+        if (product.GetProperty("Id").GetInt16() == 4)
+        {
+            throw new ArgumentException("Error on 4");
+        }
+
+        return await Task.FromResult(RecordHandlerResult.None);
+    }
+}
+```

--- a/libraries/src/AWS.Lambda.Powertools.Common/README.md
+++ b/libraries/src/AWS.Lambda.Powertools.Common/README.md
@@ -1,3 +1,5 @@
 # AWS.Lambda.Powertools.Common
 
 Powertools for AWS Lambda (.NET) Common library
+
+### As of release 1.7.0 of Powertools for AWS Lambda (.NET) this package is no longer required. For that reason It’s being deprecated and is no longer maintained.

--- a/libraries/src/AWS.Lambda.Powertools.Idempotency/README.md
+++ b/libraries/src/AWS.Lambda.Powertools.Idempotency/README.md
@@ -18,9 +18,15 @@ times with the same parameters**. This makes idempotent operations safe to retry
 
 * Prevent Lambda handler function from executing more than once on the same event payload during a time window
 * Ensure Lambda handler returns the same result when called with the same payload
-* Select a subset of the event as the idempotency key using JMESPath expressions
+* Select a subset of the event as the idempotency key using [JMESPath](https://jmespath.org/) expressions
 * Set a time window in which records with the same payload should be considered duplicates
+* Expires in-progress executions if the Lambda function times out halfway through
 
+## Read the docs
+
+For a full list of features go to [docs.powertools.aws.dev/lambda/dotnet/utilities/idempotency/](https://docs.powertools.aws.dev/lambda/dotnet/utilities/idempotency/)
+
+GitHub: https://github.com/aws-powertools/powertools-lambda-dotnet/
 
 ## Installation
 You should install with NuGet:
@@ -35,5 +41,20 @@ Or via the .NET Core command line interface:
 dotnet add package Amazon.Lambda.PowerTools.Idempotency
 ```
 
-## Acknowledgment
-This project has been ported from the Java Idempotency PowerTool Utility
+## Sample Function
+
+```csharp
+public class Function
+{
+    public Function()
+    {
+        Idempotency.Configure(builder => builder.UseDynamoDb("idempotency_table"));
+    }
+
+    [Idempotent]
+    public Task<string> FunctionHandler(string input, ILambdaContext context)
+    {
+        return Task.FromResult(input.ToUpper());
+    }
+}
+```

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Internal/Converters/DateOnlyConverter.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Internal/Converters/DateOnlyConverter.cs
@@ -1,0 +1,52 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace AWS.Lambda.Powertools.Logging.Internal.Converters;
+
+/// <summary>
+/// DateOnly JSON converter
+/// </summary>
+public class DateOnlyConverter : JsonConverter<DateOnly>
+{
+    private const string DateFormat = "yyyy-MM-dd";
+    
+    /// <summary>
+    /// Converts DateOnly from JSON.
+    /// </summary>
+    /// <param name="reader"></param>
+    /// <param name="typeToConvert"></param>
+    /// <param name="options"></param>
+    /// <returns></returns>
+    public override DateOnly Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return DateOnly.ParseExact(reader.GetString()!, DateFormat, CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>
+    /// Converts DateOnly to JSON.
+    /// </summary>
+    /// <param name="writer"></param>
+    /// <param name="value"></param>
+    /// <param name="options"></param>
+    public override void Write(Utf8JsonWriter writer, DateOnly value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.ToString(DateFormat, CultureInfo.InvariantCulture));
+    }
+}

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Internal/Converters/TimeOnlyConverter.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Internal/Converters/TimeOnlyConverter.cs
@@ -1,0 +1,52 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace AWS.Lambda.Powertools.Logging.Internal.Converters;
+
+/// <summary>
+/// TimeOnly JSON converter
+/// </summary>
+internal class TimeOnlyConverter : JsonConverter<TimeOnly>
+{
+    private const string TimeFormat = "HH:mm:ss.FFFFFFF";
+    
+    /// <summary>
+    /// Converts TimeOnly from JSON.
+    /// </summary>
+    /// <param name="reader"></param>
+    /// <param name="typeToConvert"></param>
+    /// <param name="options"></param>
+    /// <returns></returns>
+    public override TimeOnly Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return TimeOnly.ParseExact(reader.GetString()!, TimeFormat, CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>
+    /// Converts TimeOnly to JSON.
+    /// </summary>
+    /// <param name="writer"></param>
+    /// <param name="value"></param>
+    /// <param name="options"></param>
+    public override void Write(Utf8JsonWriter writer, TimeOnly value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.ToString(TimeFormat, CultureInfo.InvariantCulture));
+    }
+}

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Internal/LoggingAspectHandler.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Internal/LoggingAspectHandler.cs
@@ -35,12 +35,12 @@ internal class LoggingAspectHandler : IMethodAspectHandler
     /// <summary>
     ///     The is cold start
     /// </summary>
-    private static bool _isColdStart = true;
+    private bool _isColdStart = true;
 
     /// <summary>
     ///     The initialize context
     /// </summary>
-    private static bool _initializeContext = true;
+    private bool _initializeContext = true;
 
     /// <summary>
     ///     Clear state?
@@ -388,8 +388,6 @@ internal class LoggingAspectHandler : IMethodAspectHandler
     /// </summary>
     internal static void ResetForTest()
     {
-        _isColdStart = true;
-        _initializeContext = true;
         PowertoolsLambdaContext.Clear();
         Logger.LoggerProvider = null;
         Logger.RemoveAllKeys();

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Internal/LoggingAspectHandler.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Internal/LoggingAspectHandler.cs
@@ -35,12 +35,12 @@ internal class LoggingAspectHandler : IMethodAspectHandler
     /// <summary>
     ///     The is cold start
     /// </summary>
-    private bool _isColdStart = true;
+    private static bool _isColdStart = true;
 
     /// <summary>
     ///     The initialize context
     /// </summary>
-    private bool _initializeContext = true;
+    private static bool _initializeContext = true;
 
     /// <summary>
     ///     Clear state?
@@ -388,6 +388,8 @@ internal class LoggingAspectHandler : IMethodAspectHandler
     /// </summary>
     internal static void ResetForTest()
     {
+        _isColdStart = true;
+        _initializeContext = true;
         PowertoolsLambdaContext.Clear();
         Logger.LoggerProvider = null;
         Logger.RemoveAllKeys();

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Internal/LoggingAspectHandler.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Internal/LoggingAspectHandler.cs
@@ -288,6 +288,8 @@ internal class LoggingAspectHandler : IMethodAspectHandler
         jsonOptions.Converters.Add(new ExceptionConverter());
         jsonOptions.Converters.Add(new MemoryStreamConverter());
         jsonOptions.Converters.Add(new ConstantClassConverter());
+        jsonOptions.Converters.Add(new DateOnlyConverter());
+        jsonOptions.Converters.Add(new TimeOnlyConverter());
         return jsonOptions;
     }
 

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Internal/PowertoolsLogger.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Internal/PowertoolsLogger.cs
@@ -466,6 +466,8 @@ internal sealed class PowertoolsLogger : ILogger
         jsonOptions.Converters.Add(new ExceptionConverter());
         jsonOptions.Converters.Add(new MemoryStreamConverter());
         jsonOptions.Converters.Add(new ConstantClassConverter());
+        jsonOptions.Converters.Add(new DateOnlyConverter());
+        jsonOptions.Converters.Add(new TimeOnlyConverter());
         
         jsonOptions.Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping;
         

--- a/libraries/src/AWS.Lambda.Powertools.Logging/README.md
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/README.md
@@ -11,7 +11,7 @@ The logging utility provides a [AWS Lambda](https://aws.amazon.com/lambda/) opti
 
 ## Read the docs
 
-For a full list of features go to [docs.powertools.aws.dev/lambda/dotnet/core/logging/](docs.powertools.aws.dev/lambda/dotnet/core/logging/)
+For a full list of features go to [docs.powertools.aws.dev/lambda/dotnet/core/logging/](https://docs.powertools.aws.dev/lambda/dotnet/core/logging/)
 
 GitHub: https://github.com/aws-powertools/powertools-lambda-dotnet/
 

--- a/libraries/src/AWS.Lambda.Powertools.Metrics/IMetrics.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/IMetrics.cs
@@ -23,7 +23,7 @@ namespace AWS.Lambda.Powertools.Metrics;
 ///     Implements the <see cref="System.IDisposable" />
 /// </summary>
 /// <seealso cref="System.IDisposable" />
-public interface IMetrics : IDisposable
+public interface IMetrics 
 {
     /// <summary>
     ///     Adds metric

--- a/libraries/src/AWS.Lambda.Powertools.Metrics/Metrics.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/Metrics.cs
@@ -25,13 +25,13 @@ namespace AWS.Lambda.Powertools.Metrics;
 ///     Implements the <see cref="IMetrics" />
 /// </summary>
 /// <seealso cref="IMetrics" />
-public class Metrics : IMetrics
+public class Metrics : IMetrics, IDisposable
 {
     /// <summary>
     ///     The instance
     /// </summary>
     private static IMetrics _instance;
-
+    
     /// <summary>
     ///     The context
     /// </summary>
@@ -177,19 +177,19 @@ public class Metrics : IMetrics
     /// <summary>
     ///     Implements interface that sets default dimension list
     /// </summary>
-    /// <param name="defaultDimensions">Default Dimension List</param>
+    /// <param name="defaultDimension">Default Dimension List</param>
     /// <exception cref="System.ArgumentNullException">
     ///     'SetDefaultDimensions' method requires a valid key pair. 'Null' or empty
     ///     values are not allowed.
     /// </exception>
-    void IMetrics.SetDefaultDimensions(Dictionary<string, string> defaultDimensions)
+    void IMetrics.SetDefaultDimensions(Dictionary<string, string> defaultDimension)
     {
-        foreach (var item in defaultDimensions)
+        foreach (var item in defaultDimension)
             if (string.IsNullOrWhiteSpace(item.Key) || string.IsNullOrWhiteSpace(item.Value))
                 throw new ArgumentNullException(
                     $"'SetDefaultDimensions' method requires a valid key pair. 'Null' or empty values are not allowed.");
 
-        _context.SetDefaultDimensions(DictionaryToList(defaultDimensions));
+        _context.SetDefaultDimensions(DictionaryToList(defaultDimension));
     }
 
     /// <summary>
@@ -272,7 +272,21 @@ public class Metrics : IMetrics
     /// </summary>
     public void Dispose()
     {
-        _instance.Flush();
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+    
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="disposing"></param>
+    protected virtual void Dispose(bool disposing)
+    {
+        // Cleanup
+        if (disposing)
+        {
+            _instance.Flush();
+        }
     }
 
     /// <summary>

--- a/libraries/src/AWS.Lambda.Powertools.Metrics/Metrics.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/Metrics.cs
@@ -91,11 +91,11 @@ public class Metrics : IMetrics, IDisposable
     {
         if (string.IsNullOrWhiteSpace(key))
             throw new ArgumentNullException(
-                $"'AddMetric' method requires a valid metrics key. 'Null' or empty values are not allowed.");
+                nameof(key), "'AddMetric' method requires a valid metrics key. 'Null' or empty values are not allowed.");
         
         if (value < 0) {
             throw new ArgumentException(
-                "'AddMetric' method requires a valid metrics value. Value must be >= 0.");
+                "'AddMetric' method requires a valid metrics value. Value must be >= 0.", nameof(value));
         }
 
         var metrics = _context.GetMetrics();
@@ -150,8 +150,8 @@ public class Metrics : IMetrics, IDisposable
     void IMetrics.AddDimension(string key, string value)
     {
         if (string.IsNullOrWhiteSpace(key))
-            throw new ArgumentNullException(
-                $"'AddDimension' method requires a valid dimension key. 'Null' or empty values are not allowed.");
+            throw new ArgumentNullException(nameof(key),
+                "'AddDimension' method requires a valid dimension key. 'Null' or empty values are not allowed.");
 
         _context.AddDimension(key, value);
     }
@@ -168,8 +168,8 @@ public class Metrics : IMetrics, IDisposable
     void IMetrics.AddMetadata(string key, object value)
     {
         if (string.IsNullOrWhiteSpace(key))
-            throw new ArgumentNullException(
-                $"'AddMetadata' method requires a valid metadata key. 'Null' or empty values are not allowed.");
+            throw new ArgumentNullException(nameof(key),
+                "'AddMetadata' method requires a valid metadata key. 'Null' or empty values are not allowed.");
 
         _context.AddMetadata(key, value);
     }
@@ -186,8 +186,8 @@ public class Metrics : IMetrics, IDisposable
     {
         foreach (var item in defaultDimension)
             if (string.IsNullOrWhiteSpace(item.Key) || string.IsNullOrWhiteSpace(item.Value))
-                throw new ArgumentNullException(
-                    $"'SetDefaultDimensions' method requires a valid key pair. 'Null' or empty values are not allowed.");
+                throw new ArgumentNullException(nameof(item.Key),
+                    "'SetDefaultDimensions' method requires a valid key pair. 'Null' or empty values are not allowed.");
 
         _context.SetDefaultDimensions(DictionaryToList(defaultDimension));
     }
@@ -258,8 +258,8 @@ public class Metrics : IMetrics, IDisposable
         Dictionary<string, string> defaultDimensions, MetricResolution metricResolution)
     {
         if (string.IsNullOrWhiteSpace(metricName))
-            throw new ArgumentNullException(
-                $"'PushSingleMetric' method requires a valid metrics key. 'Null' or empty values are not allowed.");
+            throw new ArgumentNullException(nameof(metricName),
+                "'PushSingleMetric' method requires a valid metrics key. 'Null' or empty values are not allowed.");
 
         using var context = InitializeContext(nameSpace, service, defaultDimensions);
         context.AddMetric(metricName, value, unit, metricResolution);

--- a/libraries/src/AWS.Lambda.Powertools.Metrics/Metrics.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/Metrics.cs
@@ -65,15 +65,15 @@ public class Metrics : IMetrics
     internal Metrics(IPowertoolsConfigurations powertoolsConfigurations, string nameSpace = null, string service = null,
         bool raiseOnEmptyMetrics = false, bool captureColdStartEnabled = false)
     {
-        if (_instance != null) return;
+        _instance ??= this;
 
-        _instance = this;
         _powertoolsConfigurations = powertoolsConfigurations;
         _raiseOnEmptyMetrics = raiseOnEmptyMetrics;
         _captureColdStartEnabled = captureColdStartEnabled;
         _context = InitializeContext(nameSpace, service, null);
         
         _powertoolsConfigurations.SetExecutionEnvironment(this);
+        
     }
 
     /// <summary>

--- a/libraries/src/AWS.Lambda.Powertools.Metrics/Model/Metadata.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/Model/Metadata.cs
@@ -1,12 +1,12 @@
 ﻿/*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
@@ -29,7 +29,7 @@ public class Metadata
     /// </summary>
     public Metadata()
     {
-        CloudWatchMetrics = new List<MetricDirective> {new()};
+        CloudWatchMetrics = new List<MetricDirective> { new() };
         CustomMetadata = new Dictionary<string, object>();
     }
 
@@ -66,6 +66,7 @@ public class Metadata
     internal void ClearMetrics()
     {
         _metricDirective.Metrics.Clear();
+        CustomMetadata?.Clear();
     }
 
     /// <summary>
@@ -158,7 +159,7 @@ public class Metadata
     /// <param name="value">Metadata value</param>
     internal void AddMetadata(string key, object value)
     {
-        CustomMetadata.Add(key, value);
+        CustomMetadata.TryAdd(key, value);
     }
 
     /// <summary>

--- a/libraries/src/AWS.Lambda.Powertools.Metrics/Model/RootNode.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/Model/RootNode.cs
@@ -43,14 +43,14 @@ public class RootNode
             var targetMembers = new Dictionary<string, object>();
 
             foreach (var dimension in AWS.ExpandAllDimensionSets()) targetMembers.Add(dimension.Key, dimension.Value);
-
-            foreach (var metadata in AWS.CustomMetadata) targetMembers.Add(metadata.Key, metadata.Value);
-
+            
             foreach (var metricDefinition in AWS.GetMetrics())
             {
                 var values = metricDefinition.Values;
                 targetMembers.Add(metricDefinition.Name, values.Count == 1 ? values[0] : values);
             }
+            
+            foreach (var metadata in AWS.CustomMetadata) targetMembers.TryAdd(metadata.Key, metadata.Value);
 
             return targetMembers;
         }

--- a/libraries/src/AWS.Lambda.Powertools.Metrics/README.md
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/README.md
@@ -13,7 +13,7 @@ These metrics can be visualized through [Amazon CloudWatch Console](https://aws.
 
 ## Read the docs
 
-For a full list of features go to [docs.powertools.aws.dev/lambda/dotnet/core/metrics/](docs.powertools.aws.dev/lambda/dotnet/core/metrics/)
+For a full list of features go to [docs.powertools.aws.dev/lambda/dotnet/core/metrics/](https://docs.powertools.aws.dev/lambda/dotnet/core/metrics/)
 
 GitHub: https://github.com/aws-powertools/powertools-lambda-dotnet/
 

--- a/libraries/src/AWS.Lambda.Powertools.Parameters/README.md
+++ b/libraries/src/AWS.Lambda.Powertools.Parameters/README.md
@@ -11,7 +11,7 @@ The Parameters utility provides high-level functionality to retrieve one or mult
 
 ## Read the docs
 
-For a full list of features go to [docs.powertools.aws.dev/lambda/dotnet/utilities/parameters/](docs.powertools.aws.dev/lambda/dotnet/utilities/parameters/)
+For a full list of features go to [docs.powertools.aws.dev/lambda/dotnet/utilities/parameters/](https://docs.powertools.aws.dev/lambda/dotnet/utilities/parameters/)
 
 GitHub: <https://github.com/aws-powertools/powertools-lambda-dotnet/>
 

--- a/libraries/src/AWS.Lambda.Powertools.Tracing/README.md
+++ b/libraries/src/AWS.Lambda.Powertools.Tracing/README.md
@@ -13,7 +13,7 @@ a provides functionality to reduce the overhead of performing common tracing tas
 
 ## Read the docs
 
-For a full list of features go to [docs.powertools.aws.dev/lambda/dotnet/core/tracing/](docs.powertools.aws.dev/lambda/dotnet/core/tracing/)
+For a full list of features go to [docs.powertools.aws.dev/lambda/dotnet/core/tracing/](https://docs.powertools.aws.dev/lambda/dotnet/core/tracing/)
 
 **GitHub:** https://github.com/aws-powertools/powertools-lambda-dotnet/
 

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/PowertoolsLoggerTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/PowertoolsLoggerTest.cs
@@ -1219,5 +1219,87 @@ namespace AWS.Lambda.Powertools.Logging.Tests
                 $"{Constants.FeatureContextIdentifier}/Logger/{assemblyVersion}");
             env.Received(1).GetEnvironmentVariable("AWS_EXECUTION_ENV");
         }
+        
+        [Fact]
+        public void Log_Should_Serialize_DateOnly()
+        {
+            // Arrange
+            var loggerName = Guid.NewGuid().ToString();
+            var service = Guid.NewGuid().ToString();
+            var logLevel = LogLevel.Information;
+            var randomSampleRate = 0.5;
+
+            var configurations = Substitute.For<IPowertoolsConfigurations>();
+            configurations.Service.Returns(service);
+            configurations.LogLevel.Returns(logLevel.ToString());
+
+            var systemWrapper = Substitute.For<ISystemWrapper>();
+            systemWrapper.GetRandom().Returns(randomSampleRate);
+
+            var logger = new PowertoolsLogger(loggerName, configurations, systemWrapper, () =>
+                new LoggerConfiguration
+                {
+                    Service = null,
+                    MinimumLevel = null,
+                    LoggerOutputCase = LoggerOutputCase.CamelCase
+                });
+
+            var message = new
+            {
+                PropOne = "Value 1",
+                PropTwo = "Value 2",
+                Date = new DateOnly(2022, 1, 1)
+            };
+
+            logger.LogInformation(message);
+
+            // Assert
+            systemWrapper.Received(1).LogLine(
+                Arg.Is<string>(s =>
+                    s.Contains("\"message\":{\"propOne\":\"Value 1\",\"propTwo\":\"Value 2\",\"date\":\"2022-01-01\"}")
+                )
+            );
+        }
+        
+        [Fact]
+        public void Log_Should_Serialize_TimeOnly()
+        {
+            // Arrange
+            var loggerName = Guid.NewGuid().ToString();
+            var service = Guid.NewGuid().ToString();
+            var logLevel = LogLevel.Information;
+            var randomSampleRate = 0.5;
+
+            var configurations = Substitute.For<IPowertoolsConfigurations>();
+            configurations.Service.Returns(service);
+            configurations.LogLevel.Returns(logLevel.ToString());
+
+            var systemWrapper = Substitute.For<ISystemWrapper>();
+            systemWrapper.GetRandom().Returns(randomSampleRate);
+
+            var logger = new PowertoolsLogger(loggerName, configurations, systemWrapper, () =>
+                new LoggerConfiguration
+                {
+                    Service = null,
+                    MinimumLevel = null,
+                    LoggerOutputCase = LoggerOutputCase.CamelCase
+                });
+
+            var message = new
+            {
+                PropOne = "Value 1",
+                PropTwo = "Value 2",
+                Time = new TimeOnly(12, 0, 0)
+            };
+
+            logger.LogInformation(message);
+
+            // Assert
+            systemWrapper.Received(1).LogLine(
+                Arg.Is<string>(s =>
+                    s.Contains("\"message\":{\"propOne\":\"Value 1\",\"propTwo\":\"Value 2\",\"time\":\"12:00:00\"}")
+                )
+            );
+        }
     }
 }

--- a/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/EMFValidationTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/EMFValidationTests.cs
@@ -467,7 +467,7 @@ namespace AWS.Lambda.Powertools.Metrics.Tests
 
             // Assert
             var exception = Assert.Throws<ArgumentException>(act);
-            Assert.Equal("'AddMetric' method requires a valid metrics value. Value must be >= 0.", exception.Message);
+            Assert.Equal("'AddMetric' method requires a valid metrics value. Value must be >= 0. (Parameter 'value')", exception.Message);
 
             // RESET
             handler.ResetForTest();

--- a/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/EMFValidationTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/EMFValidationTests.cs
@@ -546,7 +546,47 @@ namespace AWS.Lambda.Powertools.Metrics.Tests
             var result = consoleOut.ToString();
 
             // Assert
-            Assert.Contains("CloudWatchMetrics\":[{\"Namespace\":\"dotnet-powertools-test\",\"Metrics\":[{\"Name\":\"Time\",\"Unit\":\"Milliseconds\"}],\"Dimensions\":[[\"Service\"],[\"functionVersion\"]]}]},\"Service\":\"testService\",\"functionVersion\":\"$LATEST\",\"env\":\"dev\",\"Time\":100.7}"
+            Assert.Contains("CloudWatchMetrics\":[{\"Namespace\":\"dotnet-powertools-test\",\"Metrics\":[{\"Name\":\"Time\",\"Unit\":\"Milliseconds\"}],\"Dimensions\":[[\"Service\"],[\"functionVersion\"]]}]},\"Service\":\"testService\",\"functionVersion\":\"$LATEST\",\"Time\":100.7,\"env\":\"dev\"}"
+                , result);
+
+            // Reset
+            handler.ResetForTest();
+        }
+        
+        [Fact]
+        public void When_Metrics_And_Metadata_Added_With_Same_Key_Should_Only_Write_Metrics()
+        {
+            // Arrange
+            var methodName = Guid.NewGuid().ToString();
+            var consoleOut = new StringWriter();
+            Console.SetOut(consoleOut);
+            var configurations = Substitute.For<IPowertoolsConfigurations>();
+
+            var metrics = new Metrics(
+                configurations,
+                nameSpace: "dotnet-powertools-test",
+                service: "testService"
+            );
+
+            var handler = new MetricsAspectHandler(
+                metrics,
+                false
+            );
+
+            var eventArgs = new AspectEventArgs { Name = methodName };
+
+            // Act 
+            handler.OnEntry(eventArgs);
+            Metrics.AddDimension("functionVersion", "$LATEST");
+            Metrics.AddMetric("Time", 100.7, MetricUnit.Milliseconds);
+            Metrics.AddMetadata("Time", "dev");
+            handler.OnExit(eventArgs);
+
+            var result = consoleOut.ToString();
+
+            // Assert
+            // No Metadata key was added
+            Assert.Contains("CloudWatchMetrics\":[{\"Namespace\":\"dotnet-powertools-test\",\"Metrics\":[{\"Name\":\"Time\",\"Unit\":\"Milliseconds\"}],\"Dimensions\":[[\"Service\"],[\"functionVersion\"]]}]},\"Service\":\"testService\",\"functionVersion\":\"$LATEST\",\"Time\":100.7}"
                 , result);
 
             // Reset

--- a/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/Handlers/ExceptionFunctionHandler.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/Handlers/ExceptionFunctionHandler.cs
@@ -7,13 +7,28 @@ namespace AWS.Lambda.Powertools.Metrics.Tests.Handlers;
 public class ExceptionFunctionHandler
 {
     [Metrics(Namespace = "ns", Service = "svc")]
-    public async Task<string> Handle(string input)
+    public Task<string> Handle(string input)
     {
         ThisThrows();
+        return Task.FromResult(input.ToUpper(CultureInfo.InvariantCulture));
+    }
+    
+    [Metrics(Namespace = "ns", Service = "svc")]
+    public Task<string> HandleDecoratorOutsideHandler(string input)
+    {
+        MethodDecorated();
+        
+        Metrics.AddMetric($"Metric Name", 1, MetricUnit.Count);
 
-        await Task.Delay(1);
+        return Task.FromResult(input.ToUpper(CultureInfo.InvariantCulture));
+    }
 
-        return input.ToUpper(CultureInfo.InvariantCulture);
+    [Metrics(Namespace = "ns", Service = "svc")]
+    private void MethodDecorated()
+    {
+        // NOOP
+        Metrics.AddMetric($"Metric Name", 1, MetricUnit.Count);
+        Metrics.AddMetric($"Metric Name Decorated", 1, MetricUnit.Count);
     }
 
     private void ThisThrows()

--- a/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/Handlers/ExceptionFunctionHandler.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/Handlers/ExceptionFunctionHandler.cs
@@ -22,16 +22,33 @@ public class ExceptionFunctionHandler
 
         return Task.FromResult(input.ToUpper(CultureInfo.InvariantCulture));
     }
+    
+    [Metrics(Namespace = "ns", Service = "svc")]
+    public Task<string> HandleDecoratorOutsideHandlerException(string input)
+    {
+        MethodDecorated();
+        
+        Metrics.AddMetric($"Metric Name", 1, MetricUnit.Count);
+        
+        ThisThrowsDecorated();
+        
+        return Task.FromResult(input.ToUpper(CultureInfo.InvariantCulture));
+    }
 
     [Metrics(Namespace = "ns", Service = "svc")]
     private void MethodDecorated()
     {
-        // NOOP
         Metrics.AddMetric($"Metric Name", 1, MetricUnit.Count);
         Metrics.AddMetric($"Metric Name Decorated", 1, MetricUnit.Count);
     }
 
     private void ThisThrows()
+    {
+        throw new NullReferenceException();
+    }
+    
+    [Metrics(Namespace = "ns", Service = "svc")]
+    private void ThisThrowsDecorated()
     {
         throw new NullReferenceException();
     }

--- a/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/Handlers/ExceptionFunctionHandlerTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/Handlers/ExceptionFunctionHandlerTests.cs
@@ -20,7 +20,21 @@ public sealed class ExceptionFunctionHandlerTests
         // Assert
         var tracedException = await Assert.ThrowsAsync<NullReferenceException>(Handle);
         Assert.StartsWith("at AWS.Lambda.Powertools.Metrics.Tests.Handlers.ExceptionFunctionHandler.ThisThrows()", tracedException.StackTrace?.TrimStart());
+    }
+    
+    [Fact]
+    public async Task Stack_Trace_Included_When_Decorator_Present_In_Method()
+    {
+        // Arrange
+        Metrics.ResetForTest();
+        var handler = new ExceptionFunctionHandler();
 
+        // Act
+        Task Handle() => handler.HandleDecoratorOutsideHandlerException("whatever");
+        
+        // Assert
+        var tracedException = await Assert.ThrowsAsync<NullReferenceException>(Handle);
+        Assert.StartsWith("at AWS.Lambda.Powertools.Metrics.Tests.Handlers.ExceptionFunctionHandler.__a$_around_ThisThrows", tracedException.StackTrace?.TrimStart());
     }
     
     [Fact]

--- a/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/Handlers/ExceptionFunctionHandlerTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/Handlers/ExceptionFunctionHandlerTests.cs
@@ -22,4 +22,21 @@ public sealed class ExceptionFunctionHandlerTests
         Assert.StartsWith("at AWS.Lambda.Powertools.Metrics.Tests.Handlers.ExceptionFunctionHandler.ThisThrows()", tracedException.StackTrace?.TrimStart());
 
     }
+    
+    [Fact]
+    public async Task Decorator_In_Non_Handler_Method_Does_Not_Throw_Exception()
+    {
+        // Arrange
+        Metrics.ResetForTest();
+        var handler = new ExceptionFunctionHandler();
+
+        // Act
+        Task Handle() => handler.HandleDecoratorOutsideHandler("whatever");
+        
+        // Assert
+        var tracedException = await Record.ExceptionAsync(Handle);
+        Assert.Null(tracedException);
+        //Assert.StartsWith("at AWS.Lambda.Powertools.Metrics.Tests.Handlers.ExceptionFunctionHandler.ThisThrows()", tracedException.StackTrace?.TrimStart());
+
+    }
 }

--- a/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/Handlers/ExceptionFunctionHandlerTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/Handlers/ExceptionFunctionHandlerTests.cs
@@ -36,7 +36,5 @@ public sealed class ExceptionFunctionHandlerTests
         // Assert
         var tracedException = await Record.ExceptionAsync(Handle);
         Assert.Null(tracedException);
-        //Assert.StartsWith("at AWS.Lambda.Powertools.Metrics.Tests.Handlers.ExceptionFunctionHandler.ThisThrows()", tracedException.StackTrace?.TrimStart());
-
     }
 }

--- a/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/Handlers/FunctionHandler.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/Handlers/FunctionHandler.cs
@@ -1,0 +1,44 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System.Globalization;
+using System.Threading.Tasks;
+
+namespace AWS.Lambda.Powertools.Metrics.Tests.Handlers;
+
+public class FunctionHandler
+{
+    [Metrics(Namespace = "ns", Service = "svc")]
+    public async Task<string> HandleSameKey(string input)
+    {
+        Metrics.AddMetric("MyMetric", 1);
+        Metrics.AddMetadata("MyMetric", "meta");
+
+        await Task.Delay(1);
+
+        return input.ToUpper(CultureInfo.InvariantCulture);
+    }
+    
+    [Metrics(Namespace = "ns", Service = "svc")]
+    public async Task<string> HandleTestSecondCall(string input)
+    {
+        Metrics.AddMetric("MyMetric", 1);
+        Metrics.AddMetadata("MyMetadata", "meta");
+        
+        await Task.Delay(1);
+
+        return input.ToUpper(CultureInfo.InvariantCulture);
+    }
+}

--- a/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/Handlers/FunctionHandlerTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/Handlers/FunctionHandlerTests.cs
@@ -1,0 +1,52 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AWS.Lambda.Powertools.Metrics.Tests.Handlers;
+
+[Collection("Sequential")]
+public class FunctionHandlerTests
+{
+    [Fact]
+    public async Task When_Metrics_Add_Metadata_Same_Key_Should_Ignore_Metadata()
+    {
+        // Arrange
+        Metrics.ResetForTest();
+        var handler = new FunctionHandler();
+        
+        // Act
+        var exception = await Record.ExceptionAsync( () => handler.HandleSameKey("whatever"));
+        
+        // Assert
+        Assert.Null(exception);
+    }
+    
+    [Fact]
+    public async Task When_Metrics_Add_Metadata_Second_Invocation_Should_Not_Throw_Exception()
+    {
+        // Arrange
+        Metrics.ResetForTest();
+        var handler = new FunctionHandler();
+
+        // Act
+        var exception = await Record.ExceptionAsync( () => handler.HandleTestSecondCall("whatever"));
+        Assert.Null(exception);
+        
+        exception = await Record.ExceptionAsync( () => handler.HandleTestSecondCall("whatever"));
+        Assert.Null(exception);
+    }
+}

--- a/poetry.lock
+++ b/poetry.lock
@@ -58,17 +58,20 @@ smmap = ">=3.0.1,<6"
 
 [[package]]
 name = "gitpython"
-version = "3.1.35"
+version = "3.1.37"
 description = "GitPython is a Python library used to interact with Git repositories"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "GitPython-3.1.35-py3-none-any.whl", hash = "sha256:c19b4292d7a1d3c0f653858db273ff8a6614100d1eb1528b014ec97286193c09"},
-    {file = "GitPython-3.1.35.tar.gz", hash = "sha256:9cbefbd1789a5fe9bcf621bb34d3f441f3a90c8461d377f84eda73e721d9b06b"},
+    {file = "GitPython-3.1.37-py3-none-any.whl", hash = "sha256:5f4c4187de49616d710a77e98ddf17b4782060a1788df441846bddefbb89ab33"},
+    {file = "GitPython-3.1.37.tar.gz", hash = "sha256:f9b9ddc0761c125d5780eab2d64be4873fc6817c2899cbcb34b02344bdc7bc54"},
 ]
 
 [package.dependencies]
 gitdb = ">=4.0.1,<5"
+
+[package.extras]
+test = ["black", "coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mypy", "pre-commit", "pytest", "pytest-cov", "pytest-sugar"]
 
 [[package]]
 name = "importlib-metadata"

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
 	"Core": {
-		"Logging": "1.3.2",
-		"Metrics": "1.4.2",
+		"Logging": "1.3.3",
+		"Metrics": "1.4.3",
 		"Tracing": "1.3.2"
 	},
 	"Utilities": {


### PR DESCRIPTION
> Please provide the issue number

Issue number: #506 

## Summary

### Changes

In this release we are happy to introduce two new converters for DateOnly and TimeOnly types. These are not supported by default on .NET 6 but will be included in Powertools.
We also fixed two bugs reported on the metrics utility.
- Do not throw exception when decorating a non Lambda handler method
- Do not throw exception when Metadata uses and existing metrics key
- Do not throw exception on second invocation when using Metadata

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
