### PR TITLE
chore: add e2e tests for idempotency method

### DIFF
--- a/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Handlers/IdempotencyFunctionMethodDecorated.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Handlers/IdempotencyFunctionMethodDecorated.cs
@@ -1,0 +1,99 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Amazon.DynamoDBv2;
+using Amazon.Lambda.APIGatewayEvents;
+using Amazon.Lambda.Core;
+
+namespace AWS.Lambda.Powertools.Idempotency.Tests.Handlers;
+
+public class IdempotencyFunctionMethodDecorated
+{
+    public bool MethodCalled;
+
+    public IdempotencyFunctionMethodDecorated(AmazonDynamoDBClient client)
+    {
+        Idempotency.Configure(builder =>
+            builder
+                .UseDynamoDb(storeBuilder =>
+                    storeBuilder
+                        .WithTableName("idempotency_table")
+                        .WithDynamoDBClient(client)
+                ));
+    }
+
+    
+    public async Task<APIGatewayProxyResponse> Handle(APIGatewayProxyRequest apigProxyEvent, ILambdaContext context)
+    {
+        Idempotency.RegisterLambdaContext(context);
+        var result= await InternalFunctionHandler(apigProxyEvent);
+
+        return result;
+    }
+    
+    private async Task<APIGatewayProxyResponse> InternalFunctionHandler(APIGatewayProxyRequest apigProxyEvent)
+    {
+        Dictionary<string, string> headers = new()
+        {
+            {"Content-Type", "application/json"},
+            {"Access-Control-Allow-Origin", "*"},
+            {"Access-Control-Allow-Methods", "GET, OPTIONS"},
+            {"Access-Control-Allow-Headers", "*"}
+        };
+
+        try
+        {
+            var address = JsonDocument.Parse(apigProxyEvent.Body).RootElement.GetProperty("address").GetString();
+            var pageContents = await GetPageContents(address);
+            var output = $"{{ \"message\": \"hello world\", \"location\": \"{pageContents}\" }}";
+
+            return new APIGatewayProxyResponse
+            {
+                Body = output,
+                StatusCode = 200,
+                Headers = headers
+            };
+
+        }
+        catch (IOException)
+        {
+            return new APIGatewayProxyResponse
+            {
+                Body = "{}",
+                StatusCode = 500,
+                Headers = headers
+            };
+        }
+    }
+    
+    [Idempotent]
+    private async Task<string> GetPageContents(string address)
+    {
+        MethodCalled = true;
+        
+        var client = new HttpClient();
+        using var response = await client.GetAsync(address);
+        using var content = response.Content;
+        var pageContent = await content.ReadAsStringAsync();
+        
+        return pageContent;
+    }
+}

--- a/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/IdempotencyTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/IdempotencyTest.cs
@@ -1,24 +1,26 @@
 /*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
 
+using System;
 using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;
 using Amazon.Lambda.APIGatewayEvents;
+using Amazon.Lambda.TestUtilities;
 using AWS.Lambda.Powertools.Idempotency.Tests.Handlers;
 using AWS.Lambda.Powertools.Idempotency.Tests.Persistence;
 using FluentAssertions;
@@ -57,6 +59,42 @@ public class IdempotencyTest : IClassFixture<DynamoDbFixture>
 
         var response2 = await function.Handle(request);
         function.HandlerExecuted.Should().BeFalse();
+
+        JsonSerializer.Serialize(response).Should().Be(JsonSerializer.Serialize(response));
+        response2.Body.Should().Contain("hello world");
+
+        var scanResponse = await _client.ScanAsync(new ScanRequest
+        {
+            TableName = _tableName
+        });
+        scanResponse.Count.Should().Be(1);
+    }
+    
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task EndToEndTestMethod() 
+    {
+        var function = new IdempotencyFunctionMethodDecorated(_client);
+        
+        var options = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        };
+        
+        var context = new TestLambdaContext
+        {
+            RemainingTime = TimeSpan.FromSeconds(30)
+        };
+        
+        var request = JsonSerializer.Deserialize<APIGatewayProxyRequest>(await File.ReadAllTextAsync("./resources/apigw_event2.json"),options);
+        
+        var response = await function.Handle(request, context);
+        function.MethodCalled.Should().BeTrue();
+
+        function.MethodCalled = false;
+
+        var response2 = await function.Handle(request, context);
+        function.MethodCalled.Should().BeFalse();
 
         JsonSerializer.Serialize(response).Should().Be(JsonSerializer.Serialize(response));
         response2.Body.Should().Contain("hello world");

--- a/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Internal/IdempotentAspectTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Internal/IdempotentAspectTests.cs
@@ -310,7 +310,7 @@ public class IdempotentAspectTests : IDisposable
     {
         // Arrange
         var store = Substitute.For<BasePersistenceStore>();
-        store.SaveInProgress(Arg.Any<JsonDocument>(), Arg.Any<DateTimeOffset>(), Arg.Any<double>())
+        store.SaveInProgress(Arg.Any<JsonDocument>(), Arg.Any<DateTimeOffset>(), null)
             .Throws(new IdempotencyItemAlreadyExistsException());
 
         Idempotency.Configure(builder => builder.WithPersistenceStore(store));

--- a/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Internal/IdempotentAspectTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Internal/IdempotentAspectTests.cs
@@ -310,8 +310,8 @@ public class IdempotentAspectTests : IDisposable
     {
         // Arrange
         var store = Substitute.For<BasePersistenceStore>();
-        store.SaveInProgress(Arg.Any<JsonDocument>(), Arg.Any<DateTimeOffset>(), null)
-            .Throws(new IdempotencyItemAlreadyExistsException());
+        store.SaveInProgress(Arg.Any<JsonDocument>(), Arg.Any<DateTimeOffset>(), Arg.Any<double>())
+            .Returns(_ => throw new IdempotencyItemAlreadyExistsException());
 
         Idempotency.Configure(builder => builder.WithPersistenceStore(store));
 
@@ -327,7 +327,7 @@ public class IdempotentAspectTests : IDisposable
             .Returns(record);
 
         // Act
-        var function = new IdempotencyInternalFunction(false);
+        var function = new IdempotencyInternalFunction(true);
         Basket resultBasket = function.HandleRequest(product, new TestLambdaContext());
 
         // assert


### PR DESCRIPTION
> Please provide the issue number

Issue number: #512

## Summary

We were missing a test for the E2E journey when decorating a method and not the handler

### Changes

Add missing E2E tests

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
