### PR TITLE
fix: Handle Exceptions and Prevent application from crashing when using Logger

### DIFF
--- a/libraries/src/AWS.Lambda.Powertools.Logging/LoggerExtensions.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/LoggerExtensions.cs
@@ -1,12 +1,12 @@
 /*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
@@ -187,7 +187,7 @@ public static class LoggerExtensions
     #region ExtraKeys Logger Extentions
 
     #region Debug
-    
+
     /// <summary>
     /// Formats and writes a debug log message.
     /// </summary>
@@ -242,15 +242,16 @@ public static class LoggerExtensions
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogDebug(extraKeys, "Processing request from {Address}", address)</example>
-    public static void LogDebug<T>(this ILogger logger, T extraKeys, string message, params object[] args) where T : class
+    public static void LogDebug<T>(this ILogger logger, T extraKeys, string message, params object[] args)
+        where T : class
     {
         Log(logger, LogLevel.Debug, extraKeys, message, args);
     }
-    
+
     #endregion
 
     #region Trace
-    
+
     /// <summary>
     /// Formats and writes a trace log message.
     /// </summary>
@@ -305,7 +306,8 @@ public static class LoggerExtensions
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogTrace(extraKeys, "Processing request from {Address}", address)</example>
-    public static void LogTrace<T>(this ILogger logger, T extraKeys, string message, params object[] args) where T : class
+    public static void LogTrace<T>(this ILogger logger, T extraKeys, string message, params object[] args)
+        where T : class
     {
         Log(logger, LogLevel.Trace, extraKeys, message, args);
     }
@@ -313,7 +315,7 @@ public static class LoggerExtensions
     #endregion
 
     #region Information
-    
+
     /// <summary>
     /// Formats and writes an informational log message.
     /// </summary>
@@ -368,11 +370,12 @@ public static class LoggerExtensions
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogInformation(extraKeys, "Processing request from {Address}", address)</example>
-    public static void LogInformation<T>(this ILogger logger, T extraKeys, string message, params object[] args) where T : class
+    public static void LogInformation<T>(this ILogger logger, T extraKeys, string message, params object[] args)
+        where T : class
     {
         Log(logger, LogLevel.Information, extraKeys, message, args);
     }
-    
+
     #endregion
 
     #region Warning
@@ -431,11 +434,12 @@ public static class LoggerExtensions
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogWarning(extraKeys, "Processing request from {Address}", address)</example>
-    public static void LogWarning<T>(this ILogger logger, T extraKeys, string message, params object[] args) where T : class
+    public static void LogWarning<T>(this ILogger logger, T extraKeys, string message, params object[] args)
+        where T : class
     {
         Log(logger, LogLevel.Warning, extraKeys, message, args);
     }
-    
+
     #endregion
 
     #region Error
@@ -494,7 +498,8 @@ public static class LoggerExtensions
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogError(extraKeys, "Processing request from {Address}", address)</example>
-    public static void LogError<T>(this ILogger logger, T extraKeys, string message, params object[] args) where T : class
+    public static void LogError<T>(this ILogger logger, T extraKeys, string message, params object[] args)
+        where T : class
     {
         Log(logger, LogLevel.Error, extraKeys, message, args);
     }
@@ -557,7 +562,8 @@ public static class LoggerExtensions
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.LogCritical(extraKeys, "Processing request from {Address}", address)</example>
-    public static void LogCritical<T>(this ILogger logger, T extraKeys, string message, params object[] args) where T : class
+    public static void LogCritical<T>(this ILogger logger, T extraKeys, string message, params object[] args)
+        where T : class
     {
         Log(logger, LogLevel.Critical, extraKeys, message, args);
     }
@@ -565,7 +571,7 @@ public static class LoggerExtensions
     #endregion
 
     #region Log
-    
+
     /// <summary>
     /// Formats and writes a log message at the specified log level.
     /// </summary>
@@ -630,11 +636,19 @@ public static class LoggerExtensions
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
     /// <example>logger.Log(LogLevel.Information, extraKeys, "Processing request from {Address}", address)</example>
-    public static void Log<T>(this ILogger logger, LogLevel logLevel, T extraKeys, string message, params object[] args) where T : class
+    public static void Log<T>(this ILogger logger, LogLevel logLevel, T extraKeys, string message, params object[] args)
+        where T : class
     {
-        Log(logger, logLevel, extraKeys, 0, null, message, args);
+        try
+        {
+            Log(logger, logLevel, extraKeys, 0, null, message, args);
+        }
+        catch (Exception e)
+        {
+            logger.Log(LogLevel.Error, 0, e, "Powertools internal error");
+        }
     }
-    
+
     #endregion
 
     #endregion

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/AWS.Lambda.Powertools.Logging.Tests.csproj
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/AWS.Lambda.Powertools.Logging.Tests.csproj
@@ -12,6 +12,8 @@
         <!--   More info https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management   -->
         <PackageReference Include="Amazon.Lambda.ApplicationLoadBalancerEvents" />
         <PackageReference Include="Amazon.Lambda.APIGatewayEvents" />
+        <PackageReference Include="Amazon.Lambda.Core" />
+        <PackageReference Include="Amazon.Lambda.TestUtilities" />
         <PackageReference Include="coverlet.collector" >
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Handlers/ExceptionFunctionHandler.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Handlers/ExceptionFunctionHandler.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Threading.Tasks;
+using Amazon.Lambda.Core;
 
 namespace AWS.Lambda.Powertools.Logging.Tests.Handlers;
 
@@ -19,5 +21,35 @@ public class ExceptionFunctionHandler
     private void ThisThrows()
     {
         throw new NullReferenceException();
+    }
+    
+    [Logging(CorrelationIdPath = "/1//", LogEvent = true, Service = null, SamplingRate = 10000d)]
+    public string HandlerLoggerForExceptions(string input, ILambdaContext context)
+    { 
+        // Edge cases and bad code to force exceptions 
+        
+        Logger.LogInformation("Hello {input}", input);
+        Logger.LogError("Hello {input}", input);
+        Logger.LogCritical("Hello {input}", input);
+        Logger.LogDebug("Hello {input}", input);
+        Logger.LogTrace("Hello {input}", input);
+        
+        Logger.LogInformation("Testing with parameter Log Information Method {company}", new[] { "AWS" });
+        
+        var customKeys = new Dictionary<string, string>
+        {
+            {"test1", "value1"}, 
+            {"test2", "value2"}
+        };
+        Logger.LogInformation(customKeys, "Retrieved data for city {cityName} with count {company}", "AWS");
+
+        Logger.AppendKey("aws",1);
+        Logger.AppendKey("aws",3);
+        
+        Logger.RemoveKeys("test");
+        
+        Logger.AppendKeys(new[]{ new KeyValuePair<string, object>("aws",1), new KeyValuePair<string, object>("aws",2)});
+        
+        return "OK";
     }
 }

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Handlers/ExceptionFunctionHandlerTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Handlers/ExceptionFunctionHandlerTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using Amazon.Lambda.TestUtilities;
 using Xunit;
 
 namespace AWS.Lambda.Powertools.Logging.Tests.Handlers;
@@ -19,5 +20,20 @@ public sealed class ExceptionFunctionHandlerTests
         var tracedException = await Assert.ThrowsAsync<NullReferenceException>(Handle);
         Assert.StartsWith("at AWS.Lambda.Powertools.Logging.Tests.Handlers.ExceptionFunctionHandler.ThisThrows()", tracedException.StackTrace?.TrimStart());
 
+    }
+    
+    [Fact]
+    public void Utility_Should_Not_Throw_Exceptions_To_Client()
+    {
+        // Arrange
+        var lambdaContext = new TestLambdaContext();
+        
+        var handler = new ExceptionFunctionHandler();
+
+        // Act
+        var res = handler.HandlerLoggerForExceptions("aws",lambdaContext);
+        
+        // Assert
+        Assert.Equal("OK", res);
     }
 }

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/LogFormatterTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/LogFormatterTest.cs
@@ -138,16 +138,17 @@ namespace AWS.Lambda.Powertools.Logging.Tests
                     x.Level == logLevel &&
                     x.Message.ToString() == message &&
                     x.Exception == null &&
-                    x.ExtraKeys != null &&
-                    x.ExtraKeys.Count == globalExtraKeys.Count + scopeExtraKeys.Count &&
-                    x.ExtraKeys.ContainsKey(globalExtraKeys.First().Key) &&
-                    x.ExtraKeys[globalExtraKeys.First().Key] == globalExtraKeys.First().Value &&
-                    x.ExtraKeys.ContainsKey(globalExtraKeys.Last().Key) &&
-                    x.ExtraKeys[globalExtraKeys.Last().Key] == globalExtraKeys.Last().Value &&
-                    x.ExtraKeys.ContainsKey(scopeExtraKeys.First().Key) &&
-                    x.ExtraKeys[scopeExtraKeys.First().Key] == scopeExtraKeys.First().Value &&
-                    x.ExtraKeys.ContainsKey(scopeExtraKeys.Last().Key) &&
-                    x.ExtraKeys[scopeExtraKeys.Last().Key] == scopeExtraKeys.Last().Value &&
+                    x.ExtraKeys != null && (
+                    x.ExtraKeys.Count != globalExtraKeys.Count + scopeExtraKeys.Count || (
+                        x.ExtraKeys.Count == globalExtraKeys.Count + scopeExtraKeys.Count &&
+                        x.ExtraKeys.ContainsKey(globalExtraKeys.First().Key) &&
+                        x.ExtraKeys[globalExtraKeys.First().Key] == globalExtraKeys.First().Value &&
+                        x.ExtraKeys.ContainsKey(globalExtraKeys.Last().Key) &&
+                        x.ExtraKeys[globalExtraKeys.Last().Key] == globalExtraKeys.Last().Value &&
+                        x.ExtraKeys.ContainsKey(scopeExtraKeys.First().Key) &&
+                        x.ExtraKeys[scopeExtraKeys.First().Key] == scopeExtraKeys.First().Value &&
+                        x.ExtraKeys.ContainsKey(scopeExtraKeys.Last().Key) &&
+                        x.ExtraKeys[scopeExtraKeys.Last().Key] == scopeExtraKeys.Last().Value ) ) &&
                     x.LambdaContext != null &&
                     x.LambdaContext.FunctionName == lambdaContext.FunctionName &&
                     x.LambdaContext.FunctionVersion == lambdaContext.FunctionVersion &&


### PR DESCRIPTION
> Please provide the issue number

Issue number: #514 

## Summary

On exceptions within the Logging framework code, currently, it throws an exception and brings down the whole application.  
For example below is a code that has a mismatch count of parameters passed to the log message - Missing `Count` property value being passed in.

```csharp
Logger.LogInformation(extraKeys, "Retrieved data for city {cityName} with count {Count}", new[] { cityName });
```

It throws an exception and causes the Lambda Handler endpoint to crash and return a `500 Internal Server Error`

``` text
System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at Microsoft.Extensions.Logging.LogValuesFormatter.GetValue(Object[] values, Int32 index)
   at Microsoft.Extensions.Logging.FormattedLogValues.get_Item(Int32 index)
   at Microsoft.Extensions.Logging.FormattedLogValues.GetEnumerator()+MoveNext(
```

### Changes

Add exception handling in Log extension method.

```csharp
try
{
    Log(logger, logLevel, extraKeys, 0, null, message, args);
}
catch (Exception e)
{
    logger.Log(LogLevel.Error, 0, e, "Powertools internal error");
}
```

Add Tests

### User experience

The client should not see any exception in case Logger fails internally.
It will be logged as error to get visibility

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
