### PR TITLE
fix: Error when decorating duplicate generic method - Tracing

### DIFF
--- a/libraries/src/AWS.Lambda.Powertools.Common/Aspects/UniversalWrapperAspect.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Common/Aspects/UniversalWrapperAspect.cs
@@ -83,7 +83,8 @@ public class UniversalWrapperAspect
         };
 
         var wrappers = triggers.OfType<UniversalWrapperAttribute>().ToArray();
-        var handler = GetMethodHandler(method, returnType, wrappers);
+        // Target.Method is more precise for cases when decorating generic methods
+        var handler = GetMethodHandler(target.Method, returnType, wrappers);
         return handler(target, args, eventArgs);
     }
 

--- a/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/Handlers/FunctionHandlerForGeneric.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/Handlers/FunctionHandlerForGeneric.cs
@@ -1,0 +1,46 @@
+using System.Globalization;
+using System.Threading.Tasks;
+
+namespace AWS.Lambda.Powertools.Tracing.Tests.Handlers;
+
+public class FunctionHandlerForGeneric
+{   
+    [Tracing(CaptureMode = TracingCaptureMode.ResponseAndError)]
+    public async Task<string> Handle(string input)
+    {
+        GenericMethod<int>(1);
+        GenericMethod<double>(2);
+        
+        GenericMethod<int>(1);
+        
+        GenericMethod<int>();
+        GenericMethod<double>();
+        
+        GenericMethod2<int>(1);
+        GenericMethod2<double>(2);
+        
+        GenericMethod<int>();
+        GenericMethod<double>();
+
+        await Task.Delay(1);
+
+        return input.ToUpper(CultureInfo.InvariantCulture);
+    }
+
+    [Tracing]
+    private T GenericMethod<T>(T x)
+    {
+        return default;
+    }
+    
+    [Tracing]
+    private T GenericMethod<T>()
+    {
+        return default;
+    }
+    
+    [Tracing]
+    private void GenericMethod2<T>(T x)
+    {
+    }
+}

--- a/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/Handlers/HandlerTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/Handlers/HandlerTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace AWS.Lambda.Powertools.Tracing.Tests.Handlers;
 
-public sealed class ExceptionFunctionHandlerTests
+public sealed class HandlerTests
 {
     [Fact]
     public async Task Stack_Trace_Included_When_Decorator_Present()
@@ -18,6 +18,19 @@ public sealed class ExceptionFunctionHandlerTests
         // Assert
         var tracedException = await Assert.ThrowsAsync<NullReferenceException>(Handle);
         Assert.StartsWith("at AWS.Lambda.Powertools.Tracing.Tests.Handlers.ExceptionFunctionHandler.ThisThrows()", tracedException.StackTrace?.TrimStart());
+
+    }
+    
+    [Fact]
+    public async Task When_Decorator_Present_In_Generic_Method_Should_Not_Throw_When_Type_Changes()
+    {
+        // Arrange
+        var handler = new FunctionHandlerForGeneric();
+
+        // Act
+        await handler.Handle("whatever");
+        
+        // Assert
 
     }
 }


### PR DESCRIPTION
> Please provide the issue number

Issue number: #571 

## Summary

Decorating a generic method with Tracing utility and calling that method more than once with different T would cause an exception, because the T that we cache would mismatch the new T resulting in `System.InvalidCastException`.

### Changes

The fix is to change the cache key to use the full method name coming from the target method that was decorated, this will take into account the T, return T and T parameters making the key unique.
Added tests to validate generic method decoration.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
