### PR TITLE
docs: add link to Powertools for AWS Lambda workshop

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ nav:
   - Roadmap: roadmap.md
   - API Reference: api/" target="_blank
   - We Made This (Community): we_made_this.md
+  - Workshop 🆕: https://s12d.com/powertools-for-aws-lambda-workshop" target="_blank
   - Core utilities:
       - core/logging.md
       - core/metrics.md


### PR DESCRIPTION
> Please provide the issue number

Issue number: #580

## Summary

### Changes

> Please provide a summary of what's being changed

This PR adds a link to the Powertools for AWS Lambda workshop in the documentation sidebar. This will allow customers to know about the existence of the workshop.

### User experience

> Please share what the user experience looks like before and after this change

![image](https://github.com/aws-powertools/powertools-lambda-dotnet/assets/7353869/9fb36972-aaad-4475-9e0b-2d2609164039)

_Note: the screenshot is from the TypeScript docs, however it'll look the same in yours_

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
