### PR TITLE
chore: Fix jmespath dependency

### DIFF
--- a/libraries/src/AWS.Lambda.Powertools.Idempotency/AWS.Lambda.Powertools.Idempotency.csproj
+++ b/libraries/src/AWS.Lambda.Powertools.Idempotency/AWS.Lambda.Powertools.Idempotency.csproj
@@ -6,6 +6,8 @@
         <Description>Powertools for AWS Lambda (.NET) - Idempotency package.</Description>
         <AssemblyName>AWS.Lambda.Powertools.Idempotency</AssemblyName>
         <RootNamespace>AWS.Lambda.Powertools.Idempotency</RootNamespace>
+        <Version>1.2.13</Version>
+        <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeInOutput</TargetsForTfmSpecificBuildOutput>
     </PropertyGroup>
     
 
@@ -15,7 +17,12 @@
       <PackageReference Include="Amazon.Lambda.Core" />
       <PackageReference Include="AWSSDK.DynamoDBv2" />
       <ProjectReference Include="..\AWS.Lambda.Powertools.Common\AWS.Lambda.Powertools.Common.csproj" PrivateAssets="all" />
-      <ProjectReference Include="..\AWS.Lambda.Powertools.JMESPath\AWS.Lambda.Powertools.JMESPath.csproj" />
+      <ProjectReference Include="..\AWS.Lambda.Powertools.JMESPath\AWS.Lambda.Powertools.JMESPath.csproj" PrivateAssets="all"/>
     </ItemGroup>
-    
+
+    <Target Name="IncludeInOutput">
+        <ItemGroup>
+            <BuildOutputInPackage Include="$(OutputPath)\AWS.Lambda.Powertools.JMESPath.dll" />
+        </ItemGroup>
+    </Target>
 </Project>

--- a/libraries/src/AWS.Lambda.Powertools.Idempotency/AWS.Lambda.Powertools.Idempotency.csproj
+++ b/libraries/src/AWS.Lambda.Powertools.Idempotency/AWS.Lambda.Powertools.Idempotency.csproj
@@ -6,7 +6,6 @@
         <Description>Powertools for AWS Lambda (.NET) - Idempotency package.</Description>
         <AssemblyName>AWS.Lambda.Powertools.Idempotency</AssemblyName>
         <RootNamespace>AWS.Lambda.Powertools.Idempotency</RootNamespace>
-        <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeInOutput</TargetsForTfmSpecificBuildOutput>
     </PropertyGroup>
     
 
@@ -18,10 +17,4 @@
       <ProjectReference Include="..\AWS.Lambda.Powertools.Common\AWS.Lambda.Powertools.Common.csproj" PrivateAssets="all" />
       <ProjectReference Include="..\AWS.Lambda.Powertools.JMESPath\AWS.Lambda.Powertools.JMESPath.csproj" PrivateAssets="all"/>
     </ItemGroup>
-
-    <Target Name="IncludeInOutput">
-        <ItemGroup>
-            <BuildOutputInPackage Include="$(OutputPath)\AWS.Lambda.Powertools.JMESPath.dll" />
-        </ItemGroup>
-    </Target>
 </Project>

--- a/libraries/src/AWS.Lambda.Powertools.Idempotency/AWS.Lambda.Powertools.Idempotency.csproj
+++ b/libraries/src/AWS.Lambda.Powertools.Idempotency/AWS.Lambda.Powertools.Idempotency.csproj
@@ -6,7 +6,6 @@
         <Description>Powertools for AWS Lambda (.NET) - Idempotency package.</Description>
         <AssemblyName>AWS.Lambda.Powertools.Idempotency</AssemblyName>
         <RootNamespace>AWS.Lambda.Powertools.Idempotency</RootNamespace>
-        <Version>1.2.13</Version>
         <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeInOutput</TargetsForTfmSpecificBuildOutput>
     </PropertyGroup>
     

--- a/libraries/src/Directory.Build.targets
+++ b/libraries/src/Directory.Build.targets
@@ -12,4 +12,15 @@
         <Compile Remove="..\AWS.Lambda.Powertools.Common\obj\**" />
     </ItemGroup>
 
+
+    <ItemGroup Condition="'$(MSBuildProjectName)' == 'AWS.Lambda.Powertools.Idempotency' AND '$(Configuration)'=='Release'">
+
+        <ProjectReference Remove="..\AWS.Lambda.Powertools.JMESPath\AWS.Lambda.Powertools.JMESPath.csproj" />
+
+        <Compile Include="..\AWS.Lambda.Powertools.JMESPath\**\*.cs">
+            <Link>JMESPath\%(RecursiveDir)%(Filename)%(Extension)</Link>
+        </Compile>
+        <Compile Remove="..\AWS.Lambda.Powertools.JMESPath\obj\**" />
+    </ItemGroup>
+
 </Project>

--- a/version.json
+++ b/version.json
@@ -6,7 +6,7 @@
 	},
 	"Utilities": {
 		"Parameters": "1.3.0",
-		"Idempotency": "1.2.0",
+		"Idempotency": "1.2.1",
 		"BatchProcessing": "1.1.1"
 	}
 }


### PR DESCRIPTION
> Please provide the issue number

Issue number: #585 

## Summary

Issue when packaging the Idempotency Nuget package now that we target multiple frameworks due to the open issue on the Nuget repository https://github.com/NuGet/Home/issues/3891

### Changes

Manually adding the JMESPath dll to the output so it is available on the Idempotency Nuget package.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
