### PR TITLE
chore: Remove the build target step in DIrectory.Build.targets to include JM…

### DIFF
--- a/libraries/src/Directory.Build.targets
+++ b/libraries/src/Directory.Build.targets
@@ -12,15 +12,4 @@
         <Compile Remove="..\AWS.Lambda.Powertools.Common\obj\**" />
     </ItemGroup>
 
-
-    <ItemGroup Condition="'$(MSBuildProjectName)' == 'AWS.Lambda.Powertools.Idempotency' AND '$(Configuration)'=='Release'">
-
-        <ProjectReference Remove="..\AWS.Lambda.Powertools.JMESPath\AWS.Lambda.Powertools.JMESPath.csproj" />
-
-        <Compile Include="..\AWS.Lambda.Powertools.JMESPath\**\*.cs">
-            <Link>JMESPath\%(RecursiveDir)%(Filename)%(Extension)</Link>
-        </Compile>
-        <Compile Remove="..\AWS.Lambda.Powertools.JMESPath\obj\**" />
-    </ItemGroup>
-
 </Project>


### PR DESCRIPTION
…ESPath in the Idempotency project

> Please provide the issue number

Issue number: #626 

## Summary

### Changes

Remove the build target step in DIrectory.Build.targets to include JMESPath in the Idempotency project


### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
