### PR TITLE
chore: Fix Max depth serialization bug when using Batch RecordHanderResult and Tracing 

### DIFF
--- a/libraries/src/AWS.Lambda.Powertools.BatchProcessing/RecordHandlerResult.cs
+++ b/libraries/src/AWS.Lambda.Powertools.BatchProcessing/RecordHandlerResult.cs
@@ -23,7 +23,7 @@ public class RecordHandlerResult
     /// <summary>
     /// Returns an empty <see cref="RecordHandlerResult"/> value.
     /// </summary>
-    public static readonly RecordHandlerResult None = new();
+    public static RecordHandlerResult None { get; } = null!;
 
     /// <summary>
     /// Convenience method for the creation of a <see cref="RecordHandlerResult"/>.

--- a/libraries/src/AWS.Lambda.Powertools.Tracing/Internal/XRayRecorder.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Tracing/Internal/XRayRecorder.cs
@@ -1,12 +1,12 @@
 /*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
@@ -41,7 +41,8 @@ internal class XRayRecorder : IXRayRecorder
     ///     Gets the instance.
     /// </summary>
     /// <value>The instance.</value>
-    public static IXRayRecorder Instance => _instance ??= new XRayRecorder(AWSXRayRecorder.Instance, PowertoolsConfigurations.Instance);
+    public static IXRayRecorder Instance =>
+        _instance ??= new XRayRecorder(AWSXRayRecorder.Instance, PowertoolsConfigurations.Instance);
 
     public XRayRecorder(IAWSXRayRecorder awsxRayRecorder, IPowertoolsConfigurations powertoolsConfigurations)
     {
@@ -56,7 +57,7 @@ internal class XRayRecorder : IXRayRecorder
     ///     Checks whether current execution is in AWS Lambda.
     /// </summary>
     /// <returns>Returns true if current execution is in AWS Lambda.</returns>
-    private static bool _isLambda; 
+    private static bool _isLambda;
 
     /// <summary>
     ///     Gets the emitter.
@@ -119,7 +120,19 @@ internal class XRayRecorder : IXRayRecorder
     public void EndSubsegment()
     {
         if (_isLambda)
-            _awsxRayRecorder.EndSubsegment();
+        {
+            try
+            {
+                _awsxRayRecorder.EndSubsegment();
+            }
+            catch (Exception e)
+            {
+                _awsxRayRecorder.AddException(e);
+                _awsxRayRecorder.MarkFault();
+                _awsxRayRecorder.MarkError();
+                _awsxRayRecorder.EndSubsegment();
+            }
+        }
     }
 
     /// <summary>

--- a/libraries/src/Directory.Packages.props
+++ b/libraries/src/Directory.Packages.props
@@ -9,13 +9,13 @@
     <PackageVersion Include="AWSSDK.AppConfig" Version="3.7.301" />
     <PackageVersion Include="AWSSDK.AppConfigData" Version="3.7.301.15" />
     <PackageVersion Include="AWSSDK.DynamoDBv2" Version="3.7.301.18" />
-    <PackageVersion Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.12.0" />
+    <PackageVersion Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.13.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageVersion Include="AWSSDK.SecretsManager" Version="3.7.302.29" />
     <PackageVersion Include="AWSSDK.SimpleSystemsManagement" Version="3.7.303.2" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageVersion Include="AWSSDK.XRay" Version="3.7.300.54" />
-    <PackageVersion Include="AWSXRayRecorder.Core" Version="2.14.0" />
+    <PackageVersion Include="AWSSDK.XRay" Version="3.7.400.8" />
+    <PackageVersion Include="AWSXRayRecorder.Core" Version="2.15.0" />
     <PackageVersion Include="Amazon.Lambda.DynamoDBEvents" Version="3.1.0" />
     <PackageVersion Include="Amazon.Lambda.KinesisEvents" Version="2.2.0" />
     <PackageVersion Include="Amazon.Lambda.SQSEvents" Version="2.2.0" />

--- a/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/Handlers/Handlers.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/Handlers/Handlers.cs
@@ -83,4 +83,24 @@ public class HandlerFunctions
             throw new Exception("Failed");
         return new[] { "A", "B" };
     }
+    
+    [Tracing(CaptureMode = TracingCaptureMode.ResponseAndError)]
+    public string DecoratedHandlerCaptureResponse()
+    {
+        DecoratedMethodCaptureDisabled();
+        return "Hello World";
+    }
+
+    [Tracing(CaptureMode = TracingCaptureMode.Disabled)]
+    public string DecoratedMethodCaptureDisabled()
+    {
+        DecoratedMethodCaptureEnabled();
+        return "DecoratedMethod Disabled";
+    }
+    
+    [Tracing(CaptureMode = TracingCaptureMode.ResponseAndError)]
+    private string DecoratedMethodCaptureEnabled()
+    {
+        return "DecoratedMethod Enabled";
+    }
 }

--- a/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/XRayRecorderTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/XRayRecorderTests.cs
@@ -171,8 +171,10 @@ public class XRayRecorderTests
         tracing.EndSubsegment();
 
         // Assert
-        awsXray.Received(2).EndSubsegment();
+        awsXray.Received(1).BeginSubsegment("Error in Tracing utility - see Exceptions tab");
+        awsXray.Received(1).MarkError();
         awsXray.Received(1).AddException(exception);
+        awsXray.Received(2).EndSubsegment();
     }
 
     [Fact]


### PR DESCRIPTION
> Please provide the issue number

Issue number: #630 

## Summary

### Changes

- Update RecordHanderResult to avoid object cycle on static property, this was breaking LitJson parser on X-Ray SDK with Max allowed object depth reached.
- Tracing  now takes into account the CaptureMode set for each method
- XRayRecorder now captures the exceptions from EndSubsegment call and does not surface exception to the client
- Update nuget packages for X-Ray SDK

### User experience

> Please share what the user experience looks like before and after this change

Now when exceptions occour inside X-Ray SDK EndSubsegment we catch those and create a new SubSegment in CloudWatch Traces, this prevents the app from crashing.

![image](https://github.com/user-attachments/assets/161ca3be-9ef3-43d2-9208-850b48a4df17)


## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
