### PR TITLE
feat: New batch processing option: 'ThrowOnFullBatchFailure'

### DIFF
--- a/docs/snippets/batch/templates/dynamodb.yaml
+++ b/docs/snippets/batch/templates/dynamodb.yaml
@@ -1,105 +1,118 @@
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
-Description: partial batch response sample
+Description: Example project demoing DynamoDB Streams processing using the Batch Processing Utility in Powertools for AWS Lambda (.NET)
 
 Globals:
   Function:
-    Timeout: 5
-    MemorySize: 256
-    Runtime: nodejs18.x
-    Tracing: Active
+    Timeout: 20
+    Runtime: dotnet8
+    MemorySize: 1024
     Environment:
       Variables:
-        POWERTOOLS_SERVICE_NAME: powertools-dotnet-sample-batch-processing
+        POWERTOOLS_SERVICE_NAME: powertools-dotnet-sample-batch-ddb
         POWERTOOLS_LOG_LEVEL: Debug
-        POWERTOOLS_LOGGER_CASE: PascalCase # Allowed values are: CamelCase, PascalCase and SnakeCase
+        POWERTOOLS_LOGGER_CASE: PascalCase
         POWERTOOLS_BATCH_ERROR_HANDLING_POLICY: DeriveFromEvent
         POWERTOOLS_BATCH_MAX_DEGREE_OF_PARALLELISM: 1
-        POWERTOOLS_BATCH_PARALLEL_ENABLED: false
-        
+        POWERTOOLS_BATCH_PARALLEL_ENABLED : false
+        POWERTOOLS_BATCH_THROW_ON_FULL_BATCH_FAILURE: true
+
 Resources:
-  HelloWorldFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      CodeUri: ./src/HelloWorld/
-      Handler: HelloWorld::HelloWorld.Function::DynamoDbStreamHandlerUsingAttribute
-      Policies:
-        # Lambda Destinations require additional permissions
-        # to send failure records from Kinesis/DynamoDB
-        - Version: '2012-10-17'
-          Statement:
-            Effect: 'Allow'
-            Action:
-              - sqs:GetQueueAttributes
-              - sqs:GetQueueUrl
-              - sqs:SendMessage
-            Resource: !GetAtt SampleDLQ.Arn
-        - KMSDecryptPolicy:
-            KeyId: !Ref CustomerKey
-      Events:
-        DynamoDBStream:
-          Type: DynamoDB
-          Properties:
-            Stream: !GetAtt SampleTable.StreamArn
-            StartingPosition: LATEST
-            MaximumRetryAttempts: 2
-            DestinationConfig:
-              OnFailure:
-                Destination: !GetAtt SampleDLQ.Arn
-            FunctionResponseTypes:
-              - ReportBatchItemFailures
 
-  SampleDLQ:
-    Type: AWS::SQS::Queue
-    Properties:
-      KmsMasterKeyId: !Ref CustomerKey
-
-  SampleTable:
-    Type: AWS::DynamoDB::Table
-    Properties:
-      BillingMode: PAY_PER_REQUEST
-      AttributeDefinitions:
-        - AttributeName: pk
-          AttributeType: S
-        - AttributeName: sk
-          AttributeType: S
-      KeySchema:
-        - AttributeName: pk
-          KeyType: HASH
-        - AttributeName: sk
-          KeyType: RANGE
-      SSESpecification:
-        SSEEnabled: true
-      StreamSpecification:
-        StreamViewType: NEW_AND_OLD_IMAGES
-  
   # --------------
-  # KMS key for encrypted queues
+  # KMS key for encrypted messages / records
   CustomerKey:
     Type: AWS::KMS::Key
     Properties:
       Description: KMS key for encrypted queues
       Enabled: true
       KeyPolicy:
-        Version: '2012-10-17'
+        Version: "2012-10-17"
         Statement:
           - Sid: Enable IAM User Permissions
             Effect: Allow
             Principal:
-              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
-            Action: 'kms:*'
-            Resource: '*'
-          - Sid: Allow use of the key
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action: "kms:*"
+            Resource: "*"
+          - Sid: Allow AWS Lambda to use the key
             Effect: Allow
             Principal:
               Service: lambda.amazonaws.com
             Action:
               - kms:Decrypt
               - kms:GenerateDataKey
-            Resource: '*'
+            Resource: "*"
 
   CustomerKeyAlias:
     Type: AWS::KMS::Alias
     Properties:
-      AliasName: alias/powertools-batch-sqs-demo
+      AliasName: !Sub alias/${AWS::StackName}-kms-key
       TargetKeyId: !Ref CustomerKey
+
+  # --------------
+  # Batch Processing for DynamoDb (DDB) Stream
+  DdbStreamDeadLetterQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      KmsMasterKeyId: !Ref CustomerKey
+
+  DdbTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - AttributeName: id
+          AttributeType: S
+      KeySchema:
+        - AttributeName: id
+          KeyType: HASH
+      StreamSpecification:
+        StreamViewType: NEW_AND_OLD_IMAGES
+
+  DdbStreamBatchProcessorFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./src/HelloWorld/
+      Handler: HelloWorld::HelloWorld.Function::DynamoDbStreamHandlerUsingAttribute
+      Policies:
+        - AWSLambdaDynamoDBExecutionRole
+        - Statement:
+            - Sid: DlqPermissions
+              Effect: Allow
+              Action:
+                - sqs:SendMessage
+                - sqs:SendMessageBatch
+              Resource: !GetAtt DdbStreamDeadLetterQueue.Arn
+            - Sid: KmsKeyPermissions
+              Effect: Allow
+              Action:
+                - kms:GenerateDataKey
+              Resource: !GetAtt CustomerKey.Arn
+      Events:
+        Stream:
+          Type: DynamoDB
+          Properties:
+            BatchSize: 5
+            BisectBatchOnFunctionError: true
+            DestinationConfig:
+              OnFailure:
+                Destination: !GetAtt DdbStreamDeadLetterQueue.Arn
+            Enabled: true
+            FunctionResponseTypes:
+              - ReportBatchItemFailures
+            MaximumRetryAttempts: 2
+            ParallelizationFactor: 1
+            StartingPosition: LATEST
+            Stream: !GetAtt DdbTable.StreamArn
+
+  DdbStreamBatchProcessorFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${DdbStreamBatchProcessorFunction}"
+      RetentionInDays: 7
+
+Outputs:
+  DdbTableName:
+    Description: "DynamoDB Table Name"
+    Value: !Ref DdbTable

--- a/docs/snippets/batch/templates/kinesis.yaml
+++ b/docs/snippets/batch/templates/kinesis.yaml
@@ -1,95 +1,125 @@
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
-Description: partial batch response sample
+Description: Example project demoing Kinesis Data Streams processing using the Batch Processing Utility in Powertools for AWS Lambda (.NET)
 
 Globals:
   Function:
-    Timeout: 5
-    MemorySize: 256
-    Runtime: nodejs18.x
-    Tracing: Active
+    Timeout: 20
+    Runtime: dotnet8
+    MemorySize: 1024
     Environment:
       Variables:
-        POWERTOOLS_SERVICE_NAME: powertools-dotnet-sample-batch-processing
+        POWERTOOLS_SERVICE_NAME: powertools-dotnet-sample-batch-kinesis
         POWERTOOLS_LOG_LEVEL: Debug
-        POWERTOOLS_LOGGER_CASE: PascalCase # Allowed values are: CamelCase, PascalCase and SnakeCase
+        POWERTOOLS_LOGGER_CASE: PascalCase
         POWERTOOLS_BATCH_ERROR_HANDLING_POLICY: DeriveFromEvent
         POWERTOOLS_BATCH_MAX_DEGREE_OF_PARALLELISM: 1
-        POWERTOOLS_BATCH_PARALLEL_ENABLED: false
+        POWERTOOLS_BATCH_PARALLEL_ENABLED : false
+        POWERTOOLS_BATCH_THROW_ON_FULL_BATCH_FAILURE: true
 
 Resources:
-  HelloWorldFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      CodeUri: ./src/HelloWorld/
-      Handler: HelloWorld::HelloWorld.Function::KinesisEventHandlerUsingAttribute
-      Policies:
-        # Lambda Destinations require additional permissions
-        # to send failure records to DLQ from Kinesis/DynamoDB
-        - Version: '2012-10-17'
-          Statement:
-            Effect: 'Allow'
-            Action:
-              - sqs:GetQueueAttributes
-              - sqs:GetQueueUrl
-              - sqs:SendMessage
-            Resource: !GetAtt SampleDLQ.Arn
-        - KMSDecryptPolicy:
-            KeyId: !Ref CustomerKey
-      Events:
-        KinesisStream:
-          Type: Kinesis
-          Properties:
-            Stream: !GetAtt SampleStream.Arn
-            BatchSize: 100
-            StartingPosition: LATEST
-            MaximumRetryAttempts: 2
-            DestinationConfig:
-              OnFailure:
-                Destination: !GetAtt SampleDLQ.Arn
-            FunctionResponseTypes:
-              - ReportBatchItemFailures
 
-  SampleDLQ:
-    Type: AWS::SQS::Queue
-    Properties:
-      KmsMasterKeyId: !Ref CustomerKey
-
-  SampleStream:
-    Type: AWS::Kinesis::Stream
-    Properties:
-      ShardCount: 1
-      StreamEncryption:
-        EncryptionType: KMS
-        KeyId: alias/aws/kinesis
-  
   # --------------
-  # KMS key for encrypted queues
+  # KMS key for encrypted messages / records
   CustomerKey:
     Type: AWS::KMS::Key
     Properties:
       Description: KMS key for encrypted queues
       Enabled: true
       KeyPolicy:
-        Version: '2012-10-17'
+        Version: "2012-10-17"
         Statement:
           - Sid: Enable IAM User Permissions
             Effect: Allow
             Principal:
-              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
-            Action: 'kms:*'
-            Resource: '*'
-          - Sid: Allow use of the key
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action: "kms:*"
+            Resource: "*"
+          - Sid: Allow AWS Lambda to use the key
             Effect: Allow
             Principal:
               Service: lambda.amazonaws.com
             Action:
               - kms:Decrypt
               - kms:GenerateDataKey
-            Resource: '*'
+            Resource: "*"
 
   CustomerKeyAlias:
     Type: AWS::KMS::Alias
     Properties:
-      AliasName: alias/powertools-batch-sqs-demo
+      AliasName: !Sub alias/${AWS::StackName}-kms-key
       TargetKeyId: !Ref CustomerKey
+
+  # --------------
+  # Batch Processing for Kinesis Data Stream
+  KinesisStreamDeadLetterQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      KmsMasterKeyId: !Ref CustomerKey
+
+  KinesisStream:
+    Type: AWS::Kinesis::Stream
+    Properties:
+      ShardCount: 1
+      StreamEncryption:
+        EncryptionType: KMS
+        KeyId: !Ref CustomerKey
+
+  KinesisStreamConsumer:
+    Type: AWS::Kinesis::StreamConsumer
+    Properties:
+      ConsumerName: powertools-dotnet-sample-batch-kds-consumer
+      StreamARN: !GetAtt KinesisStream.Arn
+
+  KinesisBatchProcessorFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Policies:
+        - Statement:
+            - Sid: KinesisStreamConsumerPermissions
+              Effect: Allow
+              Action:
+                - kinesis:DescribeStreamConsumer
+              Resource:
+                - !GetAtt KinesisStreamConsumer.ConsumerARN
+            - Sid: DlqPermissions
+              Effect: Allow
+              Action:
+                - sqs:SendMessage
+                - sqs:SendMessageBatch
+              Resource: !GetAtt KinesisStreamDeadLetterQueue.Arn
+            - Sid: KmsKeyPermissions
+              Effect: Allow
+              Action:
+                - kms:Decrypt
+                - kms:GenerateDataKey
+              Resource: !GetAtt CustomerKey.Arn
+      CodeUri: ./src/HelloWorld/
+      Handler: HelloWorld::HelloWorld.Function::KinesisEventHandlerUsingAttribute
+      Events:
+        Kinesis:
+          Type: Kinesis
+          Properties:
+            BatchSize: 5
+            BisectBatchOnFunctionError: true
+            DestinationConfig:
+              OnFailure:
+                Destination: !GetAtt KinesisStreamDeadLetterQueue.Arn
+            Enabled: true
+            FunctionResponseTypes:
+              - ReportBatchItemFailures
+            MaximumRetryAttempts: 2
+            ParallelizationFactor: 1
+            StartingPosition: LATEST
+            Stream: !GetAtt KinesisStreamConsumer.ConsumerARN
+
+  KinesisBatchProcessorFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${KinesisBatchProcessorFunction}"
+      RetentionInDays: 7
+
+Outputs:
+  KinesisStreamArn:
+    Description: "Kinesis Stream ARN"
+    Value: !GetAtt KinesisStream.Arn

--- a/docs/snippets/batch/templates/sqs.yaml
+++ b/docs/snippets/batch/templates/sqs.yaml
@@ -1,83 +1,106 @@
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
-Description: partial batch response sample
+Description: Example project demoing SQS Queue processing using the Batch Processing Utility in Powertools for AWS Lambda (.NET)
 
 Globals:
   Function:
-    Timeout: 5
-    MemorySize: 256
-    Runtime: nodejs18.x
-    Tracing: Active
+    Timeout: 20
+    Runtime: dotnet8
+    MemorySize: 1024
     Environment:
       Variables:
-        POWERTOOLS_SERVICE_NAME: powertools-dotnet-sample-batch-processing
+        POWERTOOLS_SERVICE_NAME: powertools-dotnet-sample-batch-sqs
         POWERTOOLS_LOG_LEVEL: Debug
-        POWERTOOLS_LOGGER_CASE: PascalCase # Allowed values are: CamelCase, PascalCase and SnakeCase
+        POWERTOOLS_LOGGER_CASE: PascalCase
         POWERTOOLS_BATCH_ERROR_HANDLING_POLICY: DeriveFromEvent
         POWERTOOLS_BATCH_MAX_DEGREE_OF_PARALLELISM: 1
-        POWERTOOLS_BATCH_PARALLEL_ENABLED: false
+        POWERTOOLS_BATCH_PARALLEL_ENABLED : false
+        POWERTOOLS_BATCH_THROW_ON_FULL_BATCH_FAILURE: true
 
 Resources:
-  HelloWorldFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      CodeUri: ./src/HelloWorld/
-      Handler: HelloWorld::HelloWorld.Function::SqsHandlerUsingAttribute
-      Policies:
-        - SQSPollerPolicy:
-            QueueName: !GetAtt SampleQueue.QueueName
-        - KMSDecryptPolicy:
-            KeyId: !Ref CustomerKey
-      Events:
-        Batch:
-          Type: SQS
-          Properties:
-            Queue: !GetAtt SampleQueue.Arn
-            FunctionResponseTypes:
-              - ReportBatchItemFailures
 
-  SampleDLQ:
-    Type: AWS::SQS::Queue
-    Properties:
-      KmsMasterKeyId: !Ref CustomerKey
-
-  SampleQueue:
-    Type: AWS::SQS::Queue
-    Properties:
-      VisibilityTimeout: 30 # Fn timeout * 6
-      SqsManagedSseEnabled: true
-      RedrivePolicy:
-        maxReceiveCount: 2
-        deadLetterTargetArn: !GetAtt SampleDLQ.Arn
-      KmsMasterKeyId: !Ref CustomerKey
-  
   # --------------
-  # KMS key for encrypted queues
+  # KMS key for encrypted messages / records
   CustomerKey:
     Type: AWS::KMS::Key
     Properties:
       Description: KMS key for encrypted queues
       Enabled: true
       KeyPolicy:
-        Version: '2012-10-17'
+        Version: "2012-10-17"
         Statement:
           - Sid: Enable IAM User Permissions
             Effect: Allow
             Principal:
-              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
-            Action: 'kms:*'
-            Resource: '*'
-          - Sid: Allow use of the key
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action: "kms:*"
+            Resource: "*"
+          - Sid: Allow AWS Lambda to use the key
             Effect: Allow
             Principal:
               Service: lambda.amazonaws.com
             Action:
               - kms:Decrypt
               - kms:GenerateDataKey
-            Resource: '*'
+            Resource: "*"
 
   CustomerKeyAlias:
     Type: AWS::KMS::Alias
     Properties:
-      AliasName: alias/powertools-batch-sqs-demo
+      AliasName: !Sub alias/${AWS::StackName}-kms-key
       TargetKeyId: !Ref CustomerKey
+
+  # --------------
+  # Batch Processing for SQS Queue
+  SqsDeadLetterQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      KmsMasterKeyId: !Ref CustomerKey
+
+  SqsQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt SqsDeadLetterQueue.Arn
+        maxReceiveCount: 2
+      KmsMasterKeyId: !Ref CustomerKey
+
+  SqsBatchProcessorFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./src/HelloWorld/
+      Handler: HelloWorld::HelloWorld.Function::SqsHandlerUsingAttribute
+      Policies:
+        - Statement:
+            - Sid: DlqPermissions
+              Effect: Allow
+              Action:
+                - sqs:SendMessage
+                - sqs:SendMessageBatch
+              Resource: !GetAtt SqsDeadLetterQueue.Arn
+            - Sid: KmsKeyPermissions
+              Effect: Allow
+              Action:
+                - kms:Decrypt
+                - kms:GenerateDataKey
+              Resource: !GetAtt CustomerKey.Arn
+      Events:
+        SqsBatch:
+          Type: SQS
+          Properties:
+            BatchSize: 5
+            Enabled: true
+            FunctionResponseTypes:
+              - ReportBatchItemFailures
+            Queue: !GetAtt SqsQueue.Arn
+
+  SqsBatchProcessorFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${SqsBatchProcessorFunction}"
+      RetentionInDays: 7
+
+Outputs:
+  SqsQueueUrl:
+    Description: "SQS Queue URL"
+    Value: !Ref SqsQueue

--- a/examples/BatchProcessing/src/HelloWorld/Function.cs
+++ b/examples/BatchProcessing/src/HelloWorld/Function.cs
@@ -42,58 +42,58 @@ public class Function
         Services.Init();
     }
 
-    [BatchProcessor(RecordHandler = typeof(CustomDynamoDbStreamRecordHandler))]
     [Logging(LogEvent = true)]
+    [BatchProcessor(RecordHandler = typeof(CustomDynamoDbStreamRecordHandler))]
     public BatchItemFailuresResponse DynamoDbStreamHandlerUsingAttribute(DynamoDBEvent _)
     {
         return DynamoDbStreamBatchProcessor.Result.BatchItemFailuresResponse;
     }
-    
-    [BatchProcessor(RecordHandler = typeof(CustomKinesisEventRecordHandler))]
+
     [Logging(LogEvent = true)]
+    [BatchProcessor(RecordHandler = typeof(CustomKinesisEventRecordHandler))]
     public BatchItemFailuresResponse KinesisEventHandlerUsingAttribute(KinesisEvent _)
     {
         return KinesisEventBatchProcessor.Result.BatchItemFailuresResponse;
     }
 
-    [BatchProcessor(RecordHandler = typeof(CustomSqsRecordHandler))]
     [Logging(LogEvent = true)]
+    [BatchProcessor(RecordHandler = typeof(CustomSqsRecordHandler))]
     public BatchItemFailuresResponse SqsHandlerUsingAttribute(SQSEvent _)
     {
         return SqsBatchProcessor.Result.BatchItemFailuresResponse;
     }
-    
-    [BatchProcessor(RecordHandler = typeof(CustomSqsRecordHandler), ErrorHandlingPolicy = BatchProcessorErrorHandlingPolicy.StopOnFirstBatchItemFailure)]
+
     [Logging(LogEvent = true)]
+    [BatchProcessor(RecordHandler = typeof(CustomSqsRecordHandler), ErrorHandlingPolicy = BatchProcessorErrorHandlingPolicy.StopOnFirstBatchItemFailure)]
     public BatchItemFailuresResponse SqsHandlerUsingAttributeWithErrorPolicy(SQSEvent _)
     {
         return SqsBatchProcessor.Result.BatchItemFailuresResponse;
     }
 
     #region More example handlers...
-    
-    [BatchProcessor(RecordHandlerProvider = typeof(CustomSqsRecordHandlerProvider), BatchProcessor = typeof(CustomSqsBatchProcessor))]
+
     [Logging(LogEvent = true)]
+    [BatchProcessor(RecordHandlerProvider = typeof(CustomSqsRecordHandlerProvider), BatchProcessor = typeof(CustomSqsBatchProcessor))]
     public BatchItemFailuresResponse HandlerUsingAttributeAndCustomRecordHandlerProvider(SQSEvent _)
     {
         return SqsBatchProcessor.Result.BatchItemFailuresResponse;
     }
-    
-    [BatchProcessor(RecordHandler = typeof(CustomSqsRecordHandler), BatchProcessor = typeof(CustomSqsBatchProcessor))]
+
     [Logging(LogEvent = true)]
+    [BatchProcessor(RecordHandler = typeof(CustomSqsRecordHandler), BatchProcessor = typeof(CustomSqsBatchProcessor))]
     public BatchItemFailuresResponse HandlerUsingAttributeAndCustomBatchProcessor(SQSEvent _)
     {
         return SqsBatchProcessor.Result.BatchItemFailuresResponse;
     }
-    
-    [BatchProcessor(RecordHandler = typeof(CustomSqsRecordHandler), BatchProcessorProvider = typeof(CustomSqsBatchProcessorProvider))]
+
     [Logging(LogEvent = true)]
+    [BatchProcessor(RecordHandler = typeof(CustomSqsRecordHandler), BatchProcessorProvider = typeof(CustomSqsBatchProcessorProvider))]
     public BatchItemFailuresResponse HandlerUsingAttributeAndCustomBatchProcessorProvider(SQSEvent _)
     {
         var batchProcessor = Services.Provider.GetRequiredService<ISqsBatchProcessor>();
         return batchProcessor.ProcessingResult.BatchItemFailuresResponse;
     }
-    
+
     [Logging(LogEvent = true)]
     public async Task<BatchItemFailuresResponse> HandlerUsingUtility(SQSEvent sqsEvent)
     {
@@ -103,7 +103,7 @@ public class Function
         }));
         return result.BatchItemFailuresResponse;
     }
-    
+
     [Logging(LogEvent = true)]
     public async Task<BatchItemFailuresResponse> HandlerUsingUtilityFromIoc(SQSEvent sqsEvent)
     {
@@ -112,6 +112,6 @@ public class Function
         var result = await batchProcessor.ProcessAsync(sqsEvent, recordHandler);
         return result.BatchItemFailuresResponse;
     }
-    
+
     #endregion
 }

--- a/examples/BatchProcessing/src/HelloWorld/HelloWorld.csproj
+++ b/examples/BatchProcessing/src/HelloWorld/HelloWorld.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFramework>net8.0</TargetFramework>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/examples/BatchProcessing/template.yaml
+++ b/examples/BatchProcessing/template.yaml
@@ -96,6 +96,12 @@ Resources:
               - ReportBatchItemFailures
             Queue: !GetAtt SqsQueue.Arn
 
+  SqsBatchProcessorFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${SqsBatchProcessorFunction}"
+      RetentionInDays: 7
+
   # --------------
   # Batch Processing for DynamoDb (DDB) Stream
   DdbStreamDeadLetterQueue:
@@ -116,7 +122,7 @@ Resources:
       StreamSpecification:
         StreamViewType: NEW_AND_OLD_IMAGES
 
-  DdbStreamProcessorFunction:
+  DdbStreamBatchProcessorFunction:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri: ./src/HelloWorld/
@@ -151,6 +157,12 @@ Resources:
             ParallelizationFactor: 1
             StartingPosition: LATEST
             Stream: !GetAtt DdbTable.StreamArn
+
+  DdbStreamBatchProcessorFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${DdbStreamBatchProcessorFunction}"
+      RetentionInDays: 7
 
   # --------------
   # Batch Processing for Kinesis Data Stream
@@ -214,6 +226,12 @@ Resources:
             ParallelizationFactor: 1
             StartingPosition: LATEST
             Stream: !GetAtt KinesisStreamConsumer.ConsumerARN
+
+  KinesisBatchProcessorFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${KinesisBatchProcessorFunction}"
+      RetentionInDays: 7
 
 Outputs:
   SqsQueueUrl:

--- a/examples/BatchProcessing/template.yaml
+++ b/examples/BatchProcessing/template.yaml
@@ -2,122 +2,110 @@
 # SPDX-License-Identifier: MIT-0
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
-Description: Example project demoing the Batch Processing utility SQS in Powertools for AWS Lambda (.NET)
+Description: Example project demoing the Batch Processing Utility in Powertools for AWS Lambda (.NET)
 
-# More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
   Function:
     Timeout: 20
-    Runtime: dotnet6
-    MemorySize: 256
+    Runtime: dotnet8
+    MemorySize: 1024
     Environment:
       Variables:
-        POWERTOOLS_SERVICE_NAME: powertools-dotnet-sample-batch-processing
+        POWERTOOLS_SERVICE_NAME: powertools-dotnet-sample-batch
         POWERTOOLS_LOG_LEVEL: Debug
-        POWERTOOLS_LOGGER_CASE: SnakeCase # Allowed values are: CamelCase, PascalCase and SnakeCase
+        POWERTOOLS_LOGGER_CASE: SnakeCase
         POWERTOOLS_BATCH_ERROR_HANDLING_POLICY: DeriveFromEvent
         POWERTOOLS_BATCH_MAX_DEGREE_OF_PARALLELISM: 1
         POWERTOOLS_BATCH_PARALLEL_ENABLED : false
+        POWERTOOLS_BATCH_THROW_ON_FULL_BATCH_FAILURE: true
 
 Resources:
-  
+
   # --------------
-  # KMS key for encrypted queues
+  # KMS key for encrypted messages / records
   CustomerKey:
     Type: AWS::KMS::Key
     Properties:
       Description: KMS key for encrypted queues
       Enabled: true
       KeyPolicy:
-        Version: '2012-10-17'
+        Version: "2012-10-17"
         Statement:
           - Sid: Enable IAM User Permissions
             Effect: Allow
             Principal:
-              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
-            Action: 'kms:*'
-            Resource: '*'
-          - Sid: Allow use of the key
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action: "kms:*"
+            Resource: "*"
+          - Sid: Allow AWS Lambda to use the key
             Effect: Allow
             Principal:
               Service: lambda.amazonaws.com
             Action:
               - kms:Decrypt
               - kms:GenerateDataKey
-            Resource: '*'
-  
+            Resource: "*"
+
   CustomerKeyAlias:
     Type: AWS::KMS::Alias
     Properties:
-      AliasName: alias/powertools-batch-sqs-demo
+      AliasName: alias/powertools-dotnet-sample-batch-kms-key
       TargetKeyId: !Ref CustomerKey
 
   # --------------
-  # SQS DL Queue
-  DemoDlqSqsQueue:
+  # Batch Processing for SQS Queue
+  SqsDeadLetterQueue:
     Type: AWS::SQS::Queue
     Properties:
       KmsMasterKeyId: !Ref CustomerKey
-  
-  # --------------
-  # SQS Queue
-  DemoSqsQueue:
+
+  SqsQueue:
     Type: AWS::SQS::Queue
     Properties:
       RedrivePolicy:
-        deadLetterTargetArn:
-          Fn::GetAtt:
-            - "DemoDlqSqsQueue"
-            - "Arn"
+        deadLetterTargetArn: !GetAtt SqsDeadLetterQueue.Arn
         maxReceiveCount: 2
       KmsMasterKeyId: !Ref CustomerKey
-  
-  # --------------
-  # Batch Processing for SQS
-  SampleSqsBatchProcessorFunction:
-    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+
+  SqsBatchProcessorFunction:
+    Type: AWS::Serverless::Function
     Properties:
-      FunctionName: powertools-dotnet-sample-batch-processor-sqs
       CodeUri: ./src/HelloWorld/
       Handler: HelloWorld::HelloWorld.Function::SqsHandlerUsingAttribute
-      # ReservedConcurrentExecutions: 1
       Policies:
         - Statement:
-            - Sid: SQSDeleteGetAttribute
+            - Sid: DlqPermissions
               Effect: Allow
               Action:
-                - sqs:DeleteMessageBatch
-                - sqs:GetQueueAttributes
-              Resource: !GetAtt DemoSqsQueue.Arn
-            - Sid: SQSSendMessageBatch
-              Effect: Allow
-              Action:
-                - sqs:SendMessageBatch
                 - sqs:SendMessage
-              Resource: !GetAtt DemoDlqSqsQueue.Arn
-            - Sid: SQSKMSKey
+                - sqs:SendMessageBatch
+              Resource: !GetAtt SqsDeadLetterQueue.Arn
+            - Sid: KmsKeyPermissions
               Effect: Allow
               Action:
-                - kms:GenerateDataKey
                 - kms:Decrypt
+                - kms:GenerateDataKey
               Resource: !GetAtt CustomerKey.Arn
       Events:
         SqsBatch:
-          Type: SQS # More info about SQS Event Source: https://github.com/aws/serverless-application-model/blob/master/versions/2016-10-31.md#sqs
+          Type: SQS
           Properties:
-            Queue: !GetAtt DemoSqsQueue.Arn
             BatchSize: 5
-#            MaximumBatchingWindowInSeconds: 300
-            FunctionResponseTypes: 
+            Enabled: true
+            FunctionResponseTypes:
               - ReportBatchItemFailures
-  
+            Queue: !GetAtt SqsQueue.Arn
+
   # --------------
-  # Batch Processing for DynamoDb
-  
-  SampleDynamoDBTable:
+  # Batch Processing for DynamoDb (DDB) Stream
+  DdbStreamDeadLetterQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      KmsMasterKeyId: !Ref CustomerKey
+
+  DdbTable:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: powertools-dotnet-sample-dynamodb-table
       BillingMode: PAY_PER_REQUEST
       AttributeDefinitions:
         - AttributeName: id
@@ -127,28 +115,51 @@ Resources:
           KeyType: HASH
       StreamSpecification:
         StreamViewType: NEW_AND_OLD_IMAGES
-        
-  DemoDynamoDBStreamProcessorFunction:
+
+  DdbStreamProcessorFunction:
     Type: AWS::Serverless::Function
     Properties:
-      FunctionName: powertools-dotnet-sample-batch-processor-dynamodb
       CodeUri: ./src/HelloWorld/
       Handler: HelloWorld::HelloWorld.Function::DynamoDbStreamHandlerUsingAttribute
-      Policies: AWSLambdaDynamoDBExecutionRole
+      Policies:
+        - AWSLambdaDynamoDBExecutionRole
+        - Statement:
+            - Sid: DlqPermissions
+              Effect: Allow
+              Action:
+                - sqs:SendMessage
+                - sqs:SendMessageBatch
+              Resource: !GetAtt DdbStreamDeadLetterQueue.Arn
+            - Sid: KmsKeyPermissions
+              Effect: Allow
+              Action:
+                - kms:GenerateDataKey
+              Resource: !GetAtt CustomerKey.Arn
       Events:
         Stream:
           Type: DynamoDB
           Properties:
-            Stream: !GetAtt SampleDynamoDBTable.StreamArn
-            BatchSize: 100
-            StartingPosition: TRIM_HORIZON
+            BatchSize: 5
+            BisectBatchOnFunctionError: true
+            DestinationConfig:
+              OnFailure:
+                Destination: !GetAtt DdbStreamDeadLetterQueue.Arn
+            Enabled: true
             FunctionResponseTypes:
               - ReportBatchItemFailures
-        
+            MaximumRetryAttempts: 2
+            ParallelizationFactor: 1
+            StartingPosition: LATEST
+            Stream: !GetAtt DdbTable.StreamArn
+
   # --------------
-  # Batch Processing for Kinesis Data Streams
-  
-  DemoKinesisStream:
+  # Batch Processing for Kinesis Data Stream
+  KinesisStreamDeadLetterQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      KmsMasterKeyId: !Ref CustomerKey
+
+  KinesisStream:
     Type: AWS::Kinesis::Stream
     Properties:
       ShardCount: 1
@@ -156,42 +167,61 @@ Resources:
         EncryptionType: KMS
         KeyId: !Ref CustomerKey
 
-  StreamConsumer:
-    Type: "AWS::Kinesis::StreamConsumer"
+  KinesisStreamConsumer:
+    Type: AWS::Kinesis::StreamConsumer
     Properties:
-      StreamARN: !GetAtt DemoKinesisStream.Arn
-      ConsumerName: KinesisBatchHandlerConsumer
-  
-  
-  SampleKinesisEventBatchProcessorFunction:
+      ConsumerName: powertools-dotnet-sample-batch-kds-consumer
+      StreamARN: !GetAtt KinesisStream.Arn
+
+  KinesisBatchProcessorFunction:
     Type: AWS::Serverless::Function
     Properties:
-      FunctionName: powertools-dotnet-sample-batch-processor-kinesis-data-stream
-      Runtime: dotnet6
+      Policies:
+        - Statement:
+            - Sid: KinesisStreamConsumerPermissions
+              Effect: Allow
+              Action:
+                - kinesis:DescribeStreamConsumer
+              Resource:
+                - !GetAtt KinesisStreamConsumer.ConsumerARN
+            - Sid: DlqPermissions
+              Effect: Allow
+              Action:
+                - sqs:SendMessage
+                - sqs:SendMessageBatch
+              Resource: !GetAtt KinesisStreamDeadLetterQueue.Arn
+            - Sid: KmsKeyPermissions
+              Effect: Allow
+              Action:
+                - kms:Decrypt
+                - kms:GenerateDataKey
+              Resource: !GetAtt CustomerKey.Arn
       CodeUri: ./src/HelloWorld/
       Handler: HelloWorld::HelloWorld.Function::KinesisEventHandlerUsingAttribute
-      MemorySize: 256
       Events:
         Kinesis:
           Type: Kinesis
           Properties:
-            Stream: !GetAtt StreamConsumer.ConsumerARN
+            BatchSize: 5
+            BisectBatchOnFunctionError: true
+            DestinationConfig:
+              OnFailure:
+                Destination: !GetAtt KinesisStreamDeadLetterQueue.Arn
+            Enabled: true
+            FunctionResponseTypes:
+              - ReportBatchItemFailures
+            MaximumRetryAttempts: 2
+            ParallelizationFactor: 1
             StartingPosition: LATEST
-            BatchSize: 2
+            Stream: !GetAtt KinesisStreamConsumer.ConsumerARN
 
 Outputs:
-  DemoSqsQueue:
-    Description: "ARN for main SQS queue"
-    Value: !GetAtt DemoSqsQueue.Arn
-  DemoDlqSqsQueue:
-    Description: "ARN for DLQ"
-    Value: !GetAtt DemoDlqSqsQueue.Arn
-  SampleSqsBatchProcessorFunction:
-    Description: "SQS Batch Handler - Lambda Function ARN"
-    Value: !GetAtt SampleSqsBatchProcessorFunction.Arn
-  DemoKinesisQueue:
-    Description: "ARN for Kinesis Stream"
-    Value: !GetAtt DemoKinesisStream.Arn
-  DemoSQSConsumerFunction:
-    Description: "SQS Batch Handler - Lambda Function ARN"
-    Value: !GetAtt SampleKinesisEventBatchProcessorFunction.Arn
+  SqsQueueUrl:
+    Description: "SQS Queue URL"
+    Value: !Ref SqsQueue
+  DdbTableName:
+    Description: "DynamoDB Table Name"
+    Value: !Ref DdbTable
+  KinesisStreamArn:
+    Description: "Kinesis Stream ARN"
+    Value: !GetAtt KinesisStream.Arn

--- a/examples/BatchProcessing/template.yaml
+++ b/examples/BatchProcessing/template.yaml
@@ -13,7 +13,7 @@ Globals:
       Variables:
         POWERTOOLS_SERVICE_NAME: powertools-dotnet-sample-batch
         POWERTOOLS_LOG_LEVEL: Debug
-        POWERTOOLS_LOGGER_CASE: SnakeCase
+        POWERTOOLS_LOGGER_CASE: PascalCase
         POWERTOOLS_BATCH_ERROR_HANDLING_POLICY: DeriveFromEvent
         POWERTOOLS_BATCH_MAX_DEGREE_OF_PARALLELISM: 1
         POWERTOOLS_BATCH_PARALLEL_ENABLED : false
@@ -49,7 +49,7 @@ Resources:
   CustomerKeyAlias:
     Type: AWS::KMS::Alias
     Properties:
-      AliasName: alias/powertools-dotnet-sample-batch-kms-key
+      AliasName: !Sub alias/${AWS::StackName}-kms-key
       TargetKeyId: !Ref CustomerKey
 
   # --------------

--- a/examples/BatchProcessing/test/HelloWorld.Test/HelloWorld.Tests.csproj
+++ b/examples/BatchProcessing/test/HelloWorld.Test/HelloWorld.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+		<TargetFramework>net8.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />

--- a/libraries/src/AWS.Lambda.Powertools.BatchProcessing/BatchProcessorAttribute.cs
+++ b/libraries/src/AWS.Lambda.Powertools.BatchProcessing/BatchProcessorAttribute.cs
@@ -133,44 +133,44 @@ public class BatchProcessorAttribute : UniversalWrapperAttribute
     /// <summary>
     /// Type of batch processor.
     /// </summary>
-    public Type BatchProcessor;
+    public Type BatchProcessor { get; set; }
 
     /// <summary>
     /// Type of batch processor provider.
     /// </summary>
-    public Type BatchProcessorProvider;
+    public Type BatchProcessorProvider { get; set; }
 
     /// <summary>
     /// Type of record handler.
     /// </summary>
-    public Type RecordHandler;
+    public Type RecordHandler { get; set; }
 
     /// <summary>
     /// Type of record handler provider.
     /// </summary>
-    public Type RecordHandlerProvider;
+    public Type RecordHandlerProvider { get; set; }
 
     /// <summary>
     /// Error handling policy.
     /// </summary>
-    public BatchProcessorErrorHandlingPolicy ErrorHandlingPolicy;
+    public BatchProcessorErrorHandlingPolicy ErrorHandlingPolicy { get; set; }
 
     /// <summary>
     /// Batch processing enabled (default false)
     /// </summary>
-    public bool BatchParallelProcessingEnabled = PowertoolsConfigurations.Instance.BatchParallelProcessingEnabled;
+    public bool BatchParallelProcessingEnabled { get; set; } = PowertoolsConfigurations.Instance.BatchParallelProcessingEnabled;
 
     /// <summary>
     /// The maximum degree of parallelism to apply during batch processing.
     /// Must enable BatchParallelProcessingEnabled
     /// </summary>
-    public int MaxDegreeOfParallelism = PowertoolsConfigurations.Instance.BatchProcessingMaxDegreeOfParallelism;
+    public int MaxDegreeOfParallelism { get; set; } = PowertoolsConfigurations.Instance.BatchProcessingMaxDegreeOfParallelism;
 
     /// <summary>
     /// By default, the Batch processor throws a <see cref="BatchProcessingException"/> on full batch failure.
     /// This behaviour can be disabled by setting this value to false.
     /// </summary>
-    public bool ThrowOnFullBatchFailure = PowertoolsConfigurations.Instance.BatchThrowOnFullBatchFailureEnabled;
+    public bool ThrowOnFullBatchFailure { get; set; } = PowertoolsConfigurations.Instance.BatchThrowOnFullBatchFailureEnabled;
 
     private static readonly Dictionary<Type, BatchEventType> EventTypes = new()
     {

--- a/libraries/src/AWS.Lambda.Powertools.BatchProcessing/BatchProcessorAttribute.cs
+++ b/libraries/src/AWS.Lambda.Powertools.BatchProcessing/BatchProcessorAttribute.cs
@@ -23,6 +23,7 @@ using Amazon.Lambda.KinesisEvents;
 using Amazon.Lambda.SQSEvents;
 using AspectInjector.Broker;
 using AWS.Lambda.Powertools.BatchProcessing.DynamoDb;
+using AWS.Lambda.Powertools.BatchProcessing.Exceptions;
 using AWS.Lambda.Powertools.BatchProcessing.Internal;
 using AWS.Lambda.Powertools.BatchProcessing.Kinesis;
 using AWS.Lambda.Powertools.BatchProcessing.Sqs;
@@ -157,13 +158,19 @@ public class BatchProcessorAttribute : UniversalWrapperAttribute
     /// <summary>
     /// Batch processing enabled (default false)
     /// </summary>
-    public bool BatchParallelProcessingEnabled = PowertoolsConfigurations.Instance.BatchParallelProcessingEnabled; 
+    public bool BatchParallelProcessingEnabled = PowertoolsConfigurations.Instance.BatchParallelProcessingEnabled;
 
     /// <summary>
     /// The maximum degree of parallelism to apply during batch processing.
     /// Must enable BatchParallelProcessingEnabled
     /// </summary>
     public int MaxDegreeOfParallelism = PowertoolsConfigurations.Instance.BatchProcessingMaxDegreeOfParallelism;
+
+    /// <summary>
+    /// By default, the Batch processor throws a <see cref="BatchProcessingException"/> on full batch failure.
+    /// This behaviour can be disabled by setting this value to false.
+    /// </summary>
+    public bool ThrowOnFullBatchFailure = PowertoolsConfigurations.Instance.BatchThrowOnFullBatchFailureEnabled;
 
     private static readonly Dictionary<Type, BatchEventType> EventTypes = new()
     {
@@ -332,7 +339,8 @@ public class BatchProcessorAttribute : UniversalWrapperAttribute
             CancellationToken = CancellationToken.None,
             ErrorHandlingPolicy = errorHandlingPolicy,
             MaxDegreeOfParallelism = MaxDegreeOfParallelism,
-            BatchParallelProcessingEnabled = BatchParallelProcessingEnabled
+            BatchParallelProcessingEnabled = BatchParallelProcessingEnabled,
+            ThrowOnFullBatchFailure = ThrowOnFullBatchFailure
         });
     }
 }

--- a/libraries/src/AWS.Lambda.Powertools.BatchProcessing/BatchProcessorAttribute.cs
+++ b/libraries/src/AWS.Lambda.Powertools.BatchProcessing/BatchProcessorAttribute.cs
@@ -91,6 +91,10 @@ namespace AWS.Lambda.Powertools.BatchProcessing;
 ///             <term>POWERTOOLS_BATCH_PROCESSING_MAX_DEGREE_OF_PARALLELISM</term>
 ///             <description>int, defaults to 1 (no parallelism). Specify -1 to automatically use the value of <see cref="System.Environment.ProcessorCount">ProcessorCount</see>.</description>
 ///         </item>
+///         <item>
+///             <term>POWERTOOLS_BATCH_THROW_ON_FULL_BATCH_FAILURE</term>
+///             <description>bool, defaults to true. Controls if an exception is thrown on full batch failure.</description>
+///         </item>
 ///     </list>
 ///                                                                                                   <br/>
 ///     Parameters                                                                                    <br/>
@@ -123,6 +127,10 @@ namespace AWS.Lambda.Powertools.BatchProcessing;
 ///         <item>
 ///             <term>MaxDegreeOfParallelism</term>
 ///             <description>int, defaults to 1 (no parallelism). Specify -1 to automatically use the value of <see cref="System.Environment.ProcessorCount">ProcessorCount</see>.</description>
+///         </item>
+///         <item>
+///             <term>ThrowOnFullBatchFailure</term>
+///             <description>bool, defaults to true. Controls if an exception is thrown on full batch failure.</description>
 ///         </item>
 ///     </list>
 /// </summary>

--- a/libraries/src/AWS.Lambda.Powertools.BatchProcessing/ProcessingOptions.cs
+++ b/libraries/src/AWS.Lambda.Powertools.BatchProcessing/ProcessingOptions.cs
@@ -13,7 +13,9 @@
  * permissions and limitations under the License.
  */
 
+using System;
 using System.Threading;
+using AWS.Lambda.Powertools.BatchProcessing.Exceptions;
 
 namespace AWS.Lambda.Powertools.BatchProcessing;
 
@@ -28,17 +30,22 @@ public class ProcessingOptions
     public CancellationToken? CancellationToken { get; init; }
 
     /// <summary>
-    /// The maximum degree of parallelism to apply during batch processing.
+    /// The maximum degree of parallelism to apply during batch processing if <see cref="BatchParallelProcessingEnabled"/> is enabled (default is -1, which means <see cref="Environment.ProcessorCount"/>).
     /// </summary>
     public int? MaxDegreeOfParallelism { get; init; }
 
     /// <summary>
-    /// The error handling policy to apply during batch processing.
+    /// The error handling policy to apply during batch processing (default is <see cref="BatchProcessorErrorHandlingPolicy.DeriveFromEvent"/>).
     /// </summary>
     public BatchProcessorErrorHandlingPolicy? ErrorHandlingPolicy { get; init; }
 
     /// <summary>
-    /// Batch processing enabled (default false)
+    /// Controls whether parallel batch processing is enabled (default false).
     /// </summary>
-    public bool BatchParallelProcessingEnabled { get; init; }
+    public bool BatchParallelProcessingEnabled { get; init; } = false;
+
+    /// <summary>
+    /// Controls whether the Batch processor throws a <see cref="BatchProcessingException"/> on full batch failure (default true).
+    /// </summary>
+    public bool ThrowOnFullBatchFailure { get; init; } = true;
 }

--- a/libraries/src/AWS.Lambda.Powertools.Common/Core/Constants.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Common/Core/Constants.cs
@@ -124,5 +124,10 @@ internal static class Constants
     /// <summary>
     /// Constant for POWERTOOLS_BATCH_PARALLEL_ENABLED environment variable
     /// </summary>
-    public const string BatchParallelProcessingEnabled = "POWERTOOLS_BATCH_PARALLEL_ENABLED";
+    internal const string BatchParallelProcessingEnabled = "POWERTOOLS_BATCH_PARALLEL_ENABLED";
+
+    /// <summary>
+    /// Constant for POWERTOOLS_BATCH_THROW_ON_FULL_BATCH_FAILURE environment variable
+    /// </summary>
+    internal const string BatchThrowOnFullBatchFailureEnv = "POWERTOOLS_BATCH_THROW_ON_FULL_BATCH_FAILURE";
 }

--- a/libraries/src/AWS.Lambda.Powertools.Common/Core/IPowertoolsConfigurations.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Common/Core/IPowertoolsConfigurations.cs
@@ -156,6 +156,10 @@ public interface IPowertoolsConfigurations
     /// </summary>
     /// <value>Defaults to 1 (no parallelism). Specify -1 to automatically use the value of <see cref="System.Environment.ProcessorCount">ProcessorCount</see>.</value>
     int BatchProcessingMaxDegreeOfParallelism { get; }
-    
-    
+
+    /// <summary>
+    /// Gets a value indicating whether Batch processing will throw an exception on full batch failure.
+    /// </summary>
+    /// <value>Defaults to true</value>
+    bool BatchThrowOnFullBatchFailureEnabled { get; }
 }

--- a/libraries/src/AWS.Lambda.Powertools.Common/Core/PowertoolsConfigurations.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Common/Core/PowertoolsConfigurations.cs
@@ -214,4 +214,7 @@ public class PowertoolsConfigurations : IPowertoolsConfigurations
 
     /// <inheritdoc />
     public int BatchProcessingMaxDegreeOfParallelism => GetEnvironmentVariableOrDefault(Constants.BatchMaxDegreeOfParallelismEnv, 1);
+
+    /// <inheritdoc />
+    public bool BatchThrowOnFullBatchFailureEnabled => GetEnvironmentVariableOrDefault(Constants.BatchThrowOnFullBatchFailureEnv, true);
 }

--- a/libraries/tests/AWS.Lambda.Powertools.BatchProcessing.Tests/Handlers/SQS/HandlerTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.BatchProcessing.Tests/Handlers/SQS/HandlerTests.cs
@@ -44,7 +44,7 @@ public class HandlerTests : IDisposable
     
         return Task.CompletedTask;
     }
-    
+
     [Fact]
     public Task Sqs_Handler_All_Fail_Using_Attribute_Should_Throw_BatchProcessingException()
     {
@@ -186,9 +186,152 @@ public class HandlerTests : IDisposable
     
         return Task.CompletedTask;
     }
-    
+
+    [Fact]
+    public Task Sqs_Handler_Using_Attribute_All_Fail_Should_Not_Throw_BatchProcessingException_With_Throw_On_Full_Batch_Failure_False_Attribute()
+    {
+        // Arrange
+        var request = new SQSEvent
+        {
+            Records = TestHelper.SqsMessages
+        };
+        var function = new HandlerFunction();
+
+        // Act
+        var response = function.HandlerUsingAttributeAllFail_ThrowOnFullBatchFailureFalseAttribute(request);
+
+        // Assert
+        Assert.Equal(5, response.BatchItemFailures.Count);
+        Assert.Equal("1", response.BatchItemFailures[0].ItemIdentifier);
+        Assert.Equal("2", response.BatchItemFailures[1].ItemIdentifier);
+        Assert.Equal("3", response.BatchItemFailures[2].ItemIdentifier);
+        Assert.Equal("4", response.BatchItemFailures[3].ItemIdentifier);
+        Assert.Equal("5", response.BatchItemFailures[4].ItemIdentifier);
+
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public Task Sqs_Handler_Using_Attribute_All_Fail_Should_Not_Throw_BatchProcessingException_With_Throw_On_Full_Batch_Failure_False_Env()
+    {
+        // Arrange
+        Environment.SetEnvironmentVariable("POWERTOOLS_BATCH_THROW_ON_FULL_BATCH_FAILURE", "false");
+        var request = new SQSEvent
+        {
+            Records = TestHelper.SqsMessages
+        };
+        var function = new HandlerFunction();
+
+        // Act
+        var response = function.HandlerUsingAttributeAllFail_ThrowOnFullBatchFailureFalseEnv(request);
+
+        // Assert
+        Assert.Equal(5, response.BatchItemFailures.Count);
+        Assert.Equal("1", response.BatchItemFailures[0].ItemIdentifier);
+        Assert.Equal("2", response.BatchItemFailures[1].ItemIdentifier);
+        Assert.Equal("3", response.BatchItemFailures[2].ItemIdentifier);
+        Assert.Equal("4", response.BatchItemFailures[3].ItemIdentifier);
+        Assert.Equal("5", response.BatchItemFailures[4].ItemIdentifier);
+
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task Sqs_Handler_Using_Utility_All_Fail_Should_Not_Throw_BatchProcessingException_With_Throw_On_Full_Batch_Failure_False_Option()
+    {
+        // Arrange
+        var request = new SQSEvent
+        {
+            Records = TestHelper.SqsMessages
+        };
+        var function = new HandlerFunction();
+
+        // Act
+        var response = await function.HandlerUsingUtilityAllFail_ThrowOnFullBatchFailureFalseOption(request);
+
+        // Assert
+        Assert.Equal(5, response.BatchItemFailures.Count);
+        Assert.Equal("1", response.BatchItemFailures[0].ItemIdentifier);
+        Assert.Equal("2", response.BatchItemFailures[1].ItemIdentifier);
+        Assert.Equal("3", response.BatchItemFailures[2].ItemIdentifier);
+        Assert.Equal("4", response.BatchItemFailures[3].ItemIdentifier);
+        Assert.Equal("5", response.BatchItemFailures[4].ItemIdentifier);
+    }
+
+    [Fact]
+    public Task Sqs_Fifo_Handler_Using_Attribute_All_Fail_With_Stop_On_First_Error_Attr_Should_Not_Throw_BatchProcessingException_With_Throw_On_Full_Batch_Failure_False_Attribute()
+    {
+        // Arrange
+        var request = new SQSEvent
+        {
+            Records = TestHelper.SqsFifoMessagesWithFirstMessagePoisened
+        };
+        var function = new HandlerFunction();
+
+        // Act
+        var response = function.HandlerUsingAttributeFailAll_StopOnFirstErrorAttr_ThrowOnFullBatchFailureFalseAttr(request);
+
+        // Assert
+        Assert.Equal(5, response.BatchItemFailures.Count);
+        Assert.Equal("1", response.BatchItemFailures[0].ItemIdentifier);
+        Assert.Equal("2", response.BatchItemFailures[1].ItemIdentifier);
+        Assert.Equal("3", response.BatchItemFailures[2].ItemIdentifier);
+        Assert.Equal("4", response.BatchItemFailures[3].ItemIdentifier);
+        Assert.Equal("5", response.BatchItemFailures[4].ItemIdentifier);
+
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public Task Sqs_Fifo_Handler_Using_Attribute_All_Fail_With_Stop_On_First_Error_Attr_Should_Not_Throw_BatchProcessingException_With_Throw_On_Full_Batch_Failure_False_Env()
+    {
+        // Arrange
+        Environment.SetEnvironmentVariable("POWERTOOLS_BATCH_THROW_ON_FULL_BATCH_FAILURE", "false");
+        var request = new SQSEvent
+        {
+            Records = TestHelper.SqsFifoMessagesWithFirstMessagePoisened
+        };
+        var function = new HandlerFunction();
+
+        // Act
+        var response = function.HandlerUsingAttributeFailAll_StopOnFirstErrorAttr_ThrowOnFullBatchFailureFalseEnv(request);
+
+        // Assert
+        Assert.Equal(5, response.BatchItemFailures.Count);
+        Assert.Equal("1", response.BatchItemFailures[0].ItemIdentifier);
+        Assert.Equal("2", response.BatchItemFailures[1].ItemIdentifier);
+        Assert.Equal("3", response.BatchItemFailures[2].ItemIdentifier);
+        Assert.Equal("4", response.BatchItemFailures[3].ItemIdentifier);
+        Assert.Equal("5", response.BatchItemFailures[4].ItemIdentifier);
+
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task Sqs_Fifo_Handler_Using_Utility_All_Fail_With_Stop_On_First_Error_Attr_Should_Not_Throw_BatchProcessingException_With_Throw_On_Full_Batch_Failure_False_Option()
+    {
+        // Arrange
+        var request = new SQSEvent
+        {
+            Records = TestHelper.SqsFifoMessagesWithFirstMessagePoisened
+        };
+        var function = new HandlerFunction();
+
+        // Act
+        var response = await function.HandlerUsingUtility_StopOnFirstErrorOption_ThrowOnFullBatchFailureFalseOption(request);
+
+        // Assert
+        Assert.Equal(5, response.BatchItemFailures.Count);
+        Assert.Equal("1", response.BatchItemFailures[0].ItemIdentifier);
+        Assert.Equal("2", response.BatchItemFailures[1].ItemIdentifier);
+        Assert.Equal("3", response.BatchItemFailures[2].ItemIdentifier);
+        Assert.Equal("4", response.BatchItemFailures[3].ItemIdentifier);
+        Assert.Equal("5", response.BatchItemFailures[4].ItemIdentifier);
+    }
+
     public void Dispose()
     {
+        Environment.SetEnvironmentVariable("POWERTOOLS_BATCH_THROW_ON_FULL_BATCH_FAILURE", "true");
         Environment.SetEnvironmentVariable("POWERTOOLS_BATCH_PARALLEL_ENABLED", "false");
         Environment.SetEnvironmentVariable("POWERTOOLS_BATCH_ERROR_HANDLING_POLICY", null);
     }

--- a/libraries/tests/AWS.Lambda.Powertools.BatchProcessing.Tests/Helpers/Helpers.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.BatchProcessing.Tests/Helpers/Helpers.cs
@@ -32,7 +32,7 @@ internal static class Helpers
         new SQSEvent.SQSMessage
         {
             MessageId = "1",
-            Body = "{\"Id\":1,\"Name\":\"product-4\",\"Price\":14}",
+            Body = "{\"Id\":1,\"Name\":\"product-1\",\"Price\":14}",
             EventSourceArn = "arn:aws:sqs:us-east-2:123456789012:my-queue"
         },
         new SQSEvent.SQSMessage
@@ -44,7 +44,7 @@ internal static class Helpers
         new SQSEvent.SQSMessage
         {
             MessageId = "3",
-            Body = "{\"Id\":3,\"Name\":\"product-4\",\"Price\":14}",
+            Body = "{\"Id\":3,\"Name\":\"product-3\",\"Price\":14}",
             EventSourceArn = "arn:aws:sqs:us-east-2:123456789012:my-queue"
         },
         new SQSEvent.SQSMessage
@@ -56,7 +56,7 @@ internal static class Helpers
         new SQSEvent.SQSMessage
         {
             MessageId = "5",
-            Body = "{\"Id\":5,\"Name\":\"product-4\",\"Price\":14}",
+            Body = "{\"Id\":5,\"Name\":\"product-5\",\"Price\":14}",
             EventSourceArn = "arn:aws:sqs:us-east-2:123456789012:my-queue"
         },
     };
@@ -66,7 +66,7 @@ internal static class Helpers
         new SQSEvent.SQSMessage
         {
             MessageId = "1",
-            Body = "{\"Id\":1,\"Name\":\"product-4\",\"Price\":14}",
+            Body = "{\"Id\":1,\"Name\":\"product-1\",\"Price\":14}",
             EventSourceArn = "arn:aws:sqs:us-east-2:123456789012:my-queue.fifo"
         },
         new SQSEvent.SQSMessage
@@ -78,7 +78,7 @@ internal static class Helpers
         new SQSEvent.SQSMessage
         {
             MessageId = "3",
-            Body = "{\"Id\":3,\"Name\":\"product-4\",\"Price\":14}",
+            Body = "{\"Id\":3,\"Name\":\"product-3\",\"Price\":14}",
             EventSourceArn = "arn:aws:sqs:us-east-2:123456789012:my-queue.fifo"
         },
         new SQSEvent.SQSMessage
@@ -90,10 +90,44 @@ internal static class Helpers
         new SQSEvent.SQSMessage
         {
             MessageId = "5",
-            Body = "{\"Id\":5,\"Name\":\"product-4\",\"Price\":14}",
+            Body = "{\"Id\":5,\"Name\":\"product-5\",\"Price\":14}",
             EventSourceArn = "arn:aws:sqs:us-east-2:123456789012:my-queue.fifo"
         },
     };
+
+    internal static List<SQSEvent.SQSMessage> SqsFifoMessagesWithFirstMessagePoisened =>
+    [
+        new SQSEvent.SQSMessage
+        {
+            MessageId = "1",
+            Body = "fail",
+            EventSourceArn = "arn:aws:sqs:us-east-2:123456789012:my-queue.fifo"
+        },
+        new SQSEvent.SQSMessage
+        {
+            MessageId = "2",
+            Body = "{\"Id\":2,\"Name\":\"product-2\",\"Price\":14}",
+            EventSourceArn = "arn:aws:sqs:us-east-2:123456789012:my-queue.fifo"
+        },
+        new SQSEvent.SQSMessage
+        {
+            MessageId = "3",
+            Body = "{\"Id\":3,\"Name\":\"product-3\",\"Price\":14}",
+            EventSourceArn = "arn:aws:sqs:us-east-2:123456789012:my-queue.fifo"
+        },
+        new SQSEvent.SQSMessage
+        {
+            MessageId = "4",
+            Body = "{\"Id\":4,\"Name\":\"product-4\",\"Price\":14}",
+            EventSourceArn = "arn:aws:sqs:us-east-2:123456789012:my-queue.fifo"
+        },
+        new SQSEvent.SQSMessage
+        {
+            MessageId = "5",
+            Body = "{\"Id\":5,\"Name\":\"product-5\",\"Price\":14}",
+            EventSourceArn = "arn:aws:sqs:us-east-2:123456789012:my-queue.fifo"
+        }
+    ];
 
     internal static List<DynamoDBEvent.DynamodbStreamRecord> DynamoDbMessages => new()
     {


### PR DESCRIPTION
Added new batch processing option: `ThrowOnFullBatchFailure` to control if a `BatchProcessingException` should be raised on full batch failure or not.

> Please provide the issue number

Issue number: #608 

## Summary

### Changes

> Please provide a summary of what's being changed

This PR introduces a new batch processing option: `ThrowOnFullBatchFailure` to control if a `BatchProcessingException` should be raised on full batch failure or not.

The processing option can be set via:

- A new `ThrowOnFullBatchFailure` field on the `BatchProcessor` attribute (applied in non-utility mode).
- A new environment variable `POWERTOOLS_BATCH_THROW_ON_FULL_BATCH_FAILURE` (applied in non-utility mode).
- Directly on the `AWS.Lambda.Powertools.BatchProcessing.ProcessingOptions` in utility mode.

To maintain current behavior, the new setting defaults to `true`, but as pointed out on a similar feature request in the Powertools for AWS Lambda (TypeScript) repo, here: https://github.com/aws-powertools/powertools-lambda-typescript/issues/2122 we might want to change that for the next major version release.

To maintain feature parity, the new setting has been named similar to how it has been implemented in Powertools for AWS Lambda (TypeScript), see: https://github.com/arnabrahman/aws-lambda-powertools-typescript/blob/main/packages/batch/src/types.ts#L32

### User experience

> Please share what the user experience looks like before and after this change

Imagine a scenario where processing of an entire batch has failed: if `ThrowOnFullBatchFailure` is set to `false` then the Batch Processor will _not_ throw an exception after batch processing has completed. Instead, it will simply return the ids of the items that failed processing (all batch items in this case) and exit gracefully.

In the scenario that a Lambda function is configured with `ErrorHandlingPolicy = StopOnFirstBatchItemFailure` and the first batch item fails processing, then the entire batch is marked as failed (as per the docs: https://docs.powertools.aws.dev/lambda/dotnet/utilities/batch-processing/#error-handling-policy). In this case, if `ThrowOnFullBatchFailure` is set to `false`, then the same behavior as outlined above will apply (in other words, the new `ThrowOnFullBatchFailure` option is compatible with the different error handling policies we have today).

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change? No</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
