### PR TITLE
chore: Remove TypeInfoResolver from non AOT mode.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -59,6 +59,8 @@ body:
       label: AWS Lambda function runtime
       options:
         - dotnet6
+        - dotnet8
+        - dotnet8 (AOT)
     validations:
       required: true
   - type: textarea

--- a/libraries/src/AWS.Lambda.Powertools.Common/Utils/RuntimeFeatureWrapper.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Common/Utils/RuntimeFeatureWrapper.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace AWS.Lambda.Powertools.Common.Utils;
+
+/// <summary>
+/// Wrapper for RuntimeFeature
+/// </summary>
+public static class RuntimeFeatureWrapper
+{
+    private static Func<bool> _isDynamicCodeSupportedFunc = () => RuntimeFeature.IsDynamicCodeSupported;
+    
+    /// <summary>
+    /// Check to see if IsDynamicCodeSupported
+    /// </summary>
+    public static bool IsDynamicCodeSupported => _isDynamicCodeSupportedFunc();
+
+// For testing purposes
+    internal static void SetIsDynamicCodeSupported(bool value)
+    {
+        _isDynamicCodeSupportedFunc = () => value;
+    }
+
+// To reset after tests
+    internal static void Reset()
+    {
+        _isDynamicCodeSupportedFunc = () => RuntimeFeature.IsDynamicCodeSupported;
+    }
+}

--- a/version.json
+++ b/version.json
@@ -1,12 +1,12 @@
 {
 	"Core": {
-		"Logging": "1.6.0",
+		"Logging": "1.6.1",
 		"Metrics": "1.7.1",
 		"Tracing": "1.5.1"
 	},
 	"Utilities": {
 		"Parameters": "1.3.0",
 		"Idempotency": "1.2.2",
-		"BatchProcessing": "1.1.2"
+		"BatchProcessing": "1.2.0"
 	}
 }


### PR DESCRIPTION
> Please provide the issue number

Issue number: #656 

## Summary

### Changes

Check if the code supports dynamic code, if it does do not add `TypinfoResolver`
Features are now behind `RuntimeFeature.IsDynamicCodeSupported`

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
