### PR TITLE
chore: Fix logging enum serialization

### DIFF
--- a/libraries/src/AWS.Lambda.Powertools.Logging/Serializers/LogLevelJsonConverter.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Serializers/LogLevelJsonConverter.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+
+namespace AWS.Lambda.Powertools.Logging.Serializers;
+
+internal class LogLevelJsonConverter : JsonConverter<LogLevel>
+{
+    public override LogLevel Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return Enum.TryParse<LogLevel>(reader.GetString(),true, out var val) ? val : default;
+    }
+
+    public override void Write(Utf8JsonWriter writer, LogLevel value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.ToString());
+    }
+}

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Serializers/PowertoolsLoggingSerializer.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Serializers/PowertoolsLoggingSerializer.cs
@@ -153,9 +153,9 @@ internal static class PowertoolsLoggingSerializer
         _jsonOptions.Converters.Add(new TimeOnlyConverter());
 
 #if NET8_0_OR_GREATER
-        _jsonOptions.Converters.Add(new JsonStringEnumConverter<LogLevel>());
+        _jsonOptions.Converters.Add(new LogLevelJsonConverter());
 #elif NET6_0
-        _jsonOptions.Converters.Add(new JsonStringEnumConverter());
+        _jsonOptions.Converters.Add(new LogLevelJsonConverter());
 #endif
 
         _jsonOptions.Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping;

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Handlers/TestHandlers.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Handlers/TestHandlers.cs
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 
+using System.Text.Json.Serialization;
 using Amazon.Lambda.APIGatewayEvents;
 using Amazon.Lambda.ApplicationLoadBalancerEvents;
 using Amazon.Lambda.CloudWatchEvents;
@@ -157,5 +158,27 @@ class TestHandlers
     public void TestLogNoDecorator()
     {
         Logger.LogInformation("test");
+    }
+    
+    [Logging(Service = "test", LoggerOutputCase = LoggerOutputCase.SnakeCase)]
+    public void TestEnums(string input, ILambdaContext context)
+    {
+        Logger.LogInformation(Pet.Dog);
+        Logger.LogInformation(Thing.Five);
+    }
+    
+    public enum Thing
+    {
+        One = 1,
+        Three = 3,
+        Five = 5
+    }
+    
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum Pet
+    {
+        Cat = 1,
+        Dog = 3,
+        Lizard = 5
     }
 }

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Serializers/PowertoolsLoggingSerializerTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Serializers/PowertoolsLoggingSerializerTests.cs
@@ -62,9 +62,9 @@ public class PowertoolsLoggingSerializerTests : IDisposable
             converter => Assert.IsType<DateOnlyConverter>(converter),
             converter => Assert.IsType<TimeOnlyConverter>(converter),
 #if NET8_0_OR_GREATER
-            converter => Assert.IsType<JsonStringEnumConverter<LogLevel>>(converter));
+            converter => Assert.IsType<LogLevelJsonConverter>(converter));
 #elif NET6_0
-            converter => Assert.IsType<JsonStringEnumConverter>(converter));
+            converter => Assert.IsType<LogLevelJsonConverter>(converter));
 #endif
 
         Assert.Equal(JavaScriptEncoder.UnsafeRelaxedJsonEscaping, options.Encoder);
@@ -90,9 +90,9 @@ public class PowertoolsLoggingSerializerTests : IDisposable
             converter => Assert.IsType<DateOnlyConverter>(converter),
             converter => Assert.IsType<TimeOnlyConverter>(converter),
 #if NET8_0_OR_GREATER
-            converter => Assert.IsType<JsonStringEnumConverter<LogLevel>>(converter));
+            converter => Assert.IsType<LogLevelJsonConverter>(converter));
 #elif NET6_0
-            converter => Assert.IsType<JsonStringEnumConverter>(converter));
+            converter => Assert.IsType<LogLevelJsonConverter>(converter));
 #endif
 
         Assert.Equal(JavaScriptEncoder.UnsafeRelaxedJsonEscaping, options.Encoder);

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Utilities/LogLevelJsonConverterTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Utilities/LogLevelJsonConverterTests.cs
@@ -1,0 +1,141 @@
+using System.Text.Json;
+using AWS.Lambda.Powertools.Logging.Serializers;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace AWS.Lambda.Powertools.Logging.Tests.Utilities;
+
+public class LogLevelJsonConverterTests
+{
+    private readonly LogLevelJsonConverter _converter;
+    private readonly JsonSerializerOptions _options;
+
+    public LogLevelJsonConverterTests()
+    {
+        _converter = new LogLevelJsonConverter();
+        _options = new JsonSerializerOptions
+        {
+            Converters = { _converter }
+        };
+    }
+
+    [Theory]
+    [InlineData("Information", LogLevel.Information)]
+    [InlineData("Error", LogLevel.Error)]
+    [InlineData("Warning", LogLevel.Warning)]
+    [InlineData("Debug", LogLevel.Debug)]
+    [InlineData("Trace", LogLevel.Trace)]
+    [InlineData("Critical", LogLevel.Critical)]
+    [InlineData("None", LogLevel.None)]
+    public void Read_ValidLogLevel_ReturnsCorrectEnum(string input, LogLevel expected)
+    {
+        // Arrange
+        var json = $"\"{input}\"";
+        
+        // Act
+        var result = JsonSerializer.Deserialize<LogLevel>(json, _options);
+        
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("information", LogLevel.Information)]
+    [InlineData("ERROR", LogLevel.Error)]
+    [InlineData("Warning", LogLevel.Warning)]
+    [InlineData("deBUG", LogLevel.Debug)]
+    public void Read_CaseInsensitive_ReturnsCorrectEnum(string input, LogLevel expected)
+    {
+        // Arrange
+        var json = $"\"{input}\"";
+        
+        // Act
+        var result = JsonSerializer.Deserialize<LogLevel>(json, _options);
+        
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("InvalidLevel")]
+    [InlineData("NotALevel")]
+    public void Read_InvalidLogLevel_ReturnsDefault(string input)
+    {
+        // Arrange
+        var json = $"\"{input}\"";
+        
+        // Act
+        var result = JsonSerializer.Deserialize<LogLevel>(json, _options);
+        
+        // Assert
+        Assert.Equal(default(LogLevel), result);
+    }
+
+    [Fact]
+    public void Read_NullValue_ReturnsDefault()
+    {
+        // Arrange
+        var json = "null";
+        
+        // Act
+        var result = JsonSerializer.Deserialize<LogLevel>(json, _options);
+        
+        // Assert
+        Assert.Equal(default(LogLevel), result);
+    }
+
+    [Theory]
+    [InlineData(LogLevel.Information, "Information")]
+    [InlineData(LogLevel.Error, "Error")]
+    [InlineData(LogLevel.Warning, "Warning")]
+    [InlineData(LogLevel.Debug, "Debug")]
+    [InlineData(LogLevel.Trace, "Trace")]
+    [InlineData(LogLevel.Critical, "Critical")]
+    [InlineData(LogLevel.None, "None")]
+    public void Write_ValidLogLevel_WritesCorrectString(LogLevel input, string expected)
+    {
+        // Act
+        var result = JsonSerializer.Serialize(input, _options);
+        
+        // Assert
+        Assert.Equal($"\"{expected}\"", result);
+    }
+
+    [Fact]
+    public void Write_DefaultLogLevel_WritesCorrectString()
+    {
+        // Arrange
+        var input = default(LogLevel);
+        
+        // Act
+        var result = JsonSerializer.Serialize(input, _options);
+        
+        // Assert
+        Assert.Equal($"\"{input}\"", result);
+    }
+
+    [Fact]
+    public void Converter_CanConvert_LogLevelType()
+    {
+        // Act
+        var canConvert = _converter.CanConvert(typeof(LogLevel));
+        
+        // Assert
+        Assert.True(canConvert);
+    }
+
+    [Fact]
+    public void SerializeAndDeserialize_RoundTrip_MaintainsValue()
+    {
+        // Arrange
+        var originalValue = LogLevel.Information;
+        
+        // Act
+        var serialized = JsonSerializer.Serialize(originalValue, _options);
+        var deserialized = JsonSerializer.Deserialize<LogLevel>(serialized, _options);
+        
+        // Assert
+        Assert.Equal(originalValue, deserialized);
+    }
+}

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Utilities/PowertoolsLoggerHelpersTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Utilities/PowertoolsLoggerHelpersTests.cs
@@ -1,4 +1,3 @@
-
 #if NET8_0_OR_GREATER
 
 using System;
@@ -70,55 +69,134 @@ public class PowertoolsLoggerHelpersTests : IDisposable
         // Act & Assert
         Assert.NotNull(() => PowertoolsLoggerHelpers.ObjectToDictionary(null));
     }
-    
+
     [Fact]
     public void Should_Log_With_Anonymous()
     {
         var consoleOut = Substitute.For<StringWriter>();
         SystemWrapper.Instance.SetOut(consoleOut);
-        
+
         // Act & Assert
-        Logger.AppendKey("newKey", new 
+        Logger.AppendKey("newKey", new
         {
             name = "my name"
         });
-        
+
         Logger.LogInformation("test");
-        
+
         consoleOut.Received(1).WriteLine(
             Arg.Is<string>(i =>
                 i.Contains("\"new_key\":{\"name\":\"my name\"}"))
         );
     }
-    
+
     [Fact]
     public void Should_Log_With_Complex_Anonymous()
     {
         var consoleOut = Substitute.For<StringWriter>();
         SystemWrapper.Instance.SetOut(consoleOut);
-        
+
         // Act & Assert
-        Logger.AppendKey("newKey", new 
+        Logger.AppendKey("newKey", new
         {
             id = 1,
             name = "my name",
-            Adresses = new {
+            Adresses = new
+            {
                 street = "street 1",
                 number = 1,
-                city = new 
+                city = new
                 {
                     name = "city 1",
                     state = "state 1"
                 }
             }
         });
-        
+
         Logger.LogInformation("test");
-        
+
         consoleOut.Received(1).WriteLine(
             Arg.Is<string>(i =>
-                i.Contains("\"new_key\":{\"id\":1,\"name\":\"my name\",\"adresses\":{\"street\":\"street 1\",\"number\":1,\"city\":{\"name\":\"city 1\",\"state\":\"state 1\"}"))
+                i.Contains(
+                    "\"new_key\":{\"id\":1,\"name\":\"my name\",\"adresses\":{\"street\":\"street 1\",\"number\":1,\"city\":{\"name\":\"city 1\",\"state\":\"state 1\"}"))
         );
+    }
+
+    [Fact]
+    public void ObjectToDictionary_EnumValue_ReturnsOriginalEnum()
+    {
+        // Arrange
+        var enumValue = DayOfWeek.Monday;
+
+        // Act
+        var result = PowertoolsLoggerHelpers.ObjectToDictionary(enumValue);
+
+        // Assert
+        Assert.Equal(enumValue, result);
+    }
+
+    [Fact]
+    public void ObjectToDictionary_ObjectWithNullProperty_ExcludesNullProperty()
+    {
+        // Arrange
+        var objectWithNull = new { name = (string)null, age = 30 };
+
+        // Act
+        var result = PowertoolsLoggerHelpers.ObjectToDictionary(objectWithNull);
+
+        // Assert
+        Assert.IsType<Dictionary<string, object>>(result);
+        var dictionary = (Dictionary<string, object>)result;
+        Assert.Single(dictionary);
+        Assert.Equal(30, dictionary["age"]);
+        Assert.False(dictionary.ContainsKey("name"));
+    }
+
+    [Fact]
+    public void ObjectToDictionary_EmptyAnonymousObject_ReturnsEmptyDictionary()
+    {
+        // Arrange
+        var emptyObject = new { };
+
+        // Act
+        var result = PowertoolsLoggerHelpers.ObjectToDictionary(emptyObject);
+
+        // Assert
+        Assert.IsType<Dictionary<string, object>>(result);
+        var dictionary = (Dictionary<string, object>)result;
+        Assert.Empty(dictionary);
+    }
+
+    [Fact]
+    public void ObjectToDictionary_ObjectWithNestedEnum_ReturnsDictionaryWithEnum()
+    {
+        // Arrange
+        var objectWithEnum = new { name = "test", day = DayOfWeek.Friday };
+
+        // Act
+        var result = PowertoolsLoggerHelpers.ObjectToDictionary(objectWithEnum);
+
+        // Assert
+        Assert.IsType<Dictionary<string, object>>(result);
+        var dictionary = (Dictionary<string, object>)result;
+        Assert.Equal(2, dictionary.Count);
+        Assert.Equal("test", dictionary["name"]);
+        Assert.Equal(DayOfWeek.Friday, dictionary["day"]);
+    }
+
+    [Fact]
+    public void ObjectToDictionary_ObjectWithAllNullProperties_ReturnsEmptyDictionary()
+    {
+        // Arrange
+        var allNullObject = new { name = (string)null, address = (string)null };
+
+        // Act
+        var result = PowertoolsLoggerHelpers.ObjectToDictionary(allNullObject);
+
+        // Assert
+        Assert.IsType<Dictionary<string, object>>(result);
+        var dictionary = (Dictionary<string, object>)result;
+        Assert.Empty(dictionary);
     }
 
     public void Dispose()


### PR DESCRIPTION
> Please provide the issue number

Issue number: #656 

## Summary

### Changes

Serialize enum types correctly.
Add specific JsonConverter for LogLevel

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [ ] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
