### PR TITLE
chore: Exception logging to include inner exceptions

### DIFF
--- a/libraries/src/AWS.Lambda.Powertools.Logging/Internal/Converters/ExceptionPropertyExtractor.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Internal/Converters/ExceptionPropertyExtractor.cs
@@ -40,5 +40,6 @@ internal static class ExceptionPropertyExtractor
         yield return new KeyValuePair<string, object>(nameof(Exception.Message), ex.Message);
         yield return new KeyValuePair<string, object>(nameof(Exception.Source), ex.Source);
         yield return new KeyValuePair<string, object>(nameof(Exception.StackTrace), ex.StackTrace);
+        yield return new KeyValuePair<string, object>(nameof(Exception.InnerException), ex.InnerException);
     }
 }

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/PowertoolsLoggerTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/PowertoolsLoggerTest.cs
@@ -1090,6 +1090,90 @@ namespace AWS.Lambda.Powertools.Logging.Tests
                 s.Contains("\"exception\":{\"type\":\"System.InvalidOperationException\",\"message\":\"TestError\",\"source\":\"AWS.Lambda.Powertools.Logging.Tests\",\"stack_trace\":\"   at AWS.Lambda.Powertools.Logging.Tests.PowertoolsLoggerTest.Log_WhenException_LogsExceptionDetails()")
             ));
         }
+        
+        [Fact]
+        public void Log_Inner_Exception()
+        {
+            // Arrange
+            var loggerName = Guid.NewGuid().ToString();
+            var service = Guid.NewGuid().ToString();
+            var error = new InvalidOperationException("Parent exception message",
+                new ArgumentNullException(nameof(service), "Very important inner exception message"));
+            var logLevel = LogLevel.Information;
+            var randomSampleRate = 0.5;
+
+            var configurations = Substitute.For<IPowertoolsConfigurations>();
+            configurations.Service.Returns(service);
+            configurations.LogLevel.Returns(logLevel.ToString());
+
+            var systemWrapper = Substitute.For<ISystemWrapper>();
+            systemWrapper.GetRandom().Returns(randomSampleRate);
+
+            var loggerConfiguration = new LoggerConfiguration
+            {
+                Service = null,
+                MinimumLevel = LogLevel.None
+            };
+            
+            var provider = new LoggerProvider(loggerConfiguration, configurations, systemWrapper);
+            var logger = provider.CreateLogger(loggerName);
+
+            logger.LogError(
+                error, 
+                "Something went wrong and we logged an exception itself with an inner exception. This is a param {arg}",
+                12345);
+
+            // Assert
+            systemWrapper.Received(1).LogLine(Arg.Is<string>(s =>
+                s.Contains("\"exception\":{\"type\":\"" + error.GetType().FullName + "\",\"message\":\"" +
+                           error.Message + "\"")
+            ));
+            
+            systemWrapper.Received(1).LogLine(Arg.Is<string>(s =>
+                s.Contains("\"level\":\"Error\",\"service\":\"" + service+ "\",\"name\":\"" + loggerName + "\",\"message\":\"Something went wrong and we logged an exception itself with an inner exception. This is a param 12345\",\"exception\":{\"type\":\"System.InvalidOperationException\",\"message\":\"Parent exception message\",\"inner_exception\":{\"type\":\"System.ArgumentNullException\",\"message\":\"Very important inner exception message (Parameter 'service')\"}}}")
+            ));
+        }
+        
+        [Fact]
+        public void Log_Nested_Inner_Exception()
+        {
+            // Arrange
+            var loggerName = Guid.NewGuid().ToString();
+            var service = Guid.NewGuid().ToString();
+            var error = new InvalidOperationException("Parent exception message",
+                new ArgumentNullException(nameof(service),
+                    new Exception("Very important nested inner exception message")));
+            
+            var logLevel = LogLevel.Information;
+            var randomSampleRate = 0.5;
+
+            var configurations = Substitute.For<IPowertoolsConfigurations>();
+            configurations.Service.Returns(service);
+            configurations.LogLevel.Returns(logLevel.ToString());
+
+            var systemWrapper = Substitute.For<ISystemWrapper>();
+            systemWrapper.GetRandom().Returns(randomSampleRate);
+
+            var loggerConfiguration = new LoggerConfiguration
+            {
+                Service = null,
+                MinimumLevel = LogLevel.None
+            };
+            
+            var provider = new LoggerProvider(loggerConfiguration, configurations, systemWrapper);
+            var logger = provider.CreateLogger(loggerName);
+            
+
+            logger.LogError(
+                error, 
+                "Something went wrong and we logged an exception itself with an inner exception. This is a param {arg}",
+                12345);
+
+            // Assert
+            systemWrapper.Received(1).LogLine(Arg.Is<string>(s =>
+                s.Contains("\"message\":\"Something went wrong and we logged an exception itself with an inner exception. This is a param 12345\",\"exception\":{\"type\":\"System.InvalidOperationException\",\"message\":\"Parent exception message\",\"inner_exception\":{\"type\":\"System.ArgumentNullException\",\"message\":\"service\",\"inner_exception\":{\"type\":\"System.Exception\",\"message\":\"Very important nested inner exception message\"}}}}")
+            ));
+        }
 
         [Fact]
         public void Log_WhenNestedException_LogsExceptionDetails()


### PR DESCRIPTION
> Please provide the issue number

Issue number: #680 

## Summary

### Changes

This pull request focuses on enhancing the logging functionality by improving how exceptions, particularly inner exceptions, are handled and logged. The key changes include refactoring the exception writing logic, updating the property extraction to include inner exceptions, and adding new tests to verify these changes.

### Enhancements to exception handling and logging:

* [`libraries/src/AWS.Lambda.Powertools.Logging/Internal/Converters/ExceptionConverter.cs`](diffhunk://#diff-a21277a5724c3b17bfa08a604fa9eaedd7d7aacae6178e0e574e7d276332f111L60-R63): Refactored the `Write` method to include a nested `WriteException` method, which recursively writes inner exceptions if they exist. [[1]](diffhunk://#diff-a21277a5724c3b17bfa08a604fa9eaedd7d7aacae6178e0e574e7d276332f111L60-R63) [[2]](diffhunk://#diff-a21277a5724c3b17bfa08a604fa9eaedd7d7aacae6178e0e574e7d276332f111L70-R103)

* [`libraries/src/AWS.Lambda.Powertools.Logging/Internal/Converters/ExceptionPropertyExtractor.cs`](diffhunk://#diff-ea39747a3b81717c650de4e6005c0867a8ec25fda393fbd788c710e452e504d1R43): Updated the `GetBaseExceptionProperties` method to include the `InnerException` property in the extracted properties.

### Tests for improved exception logging:

* [`libraries/tests/AWS.Lambda.Powertools.Logging.Tests/PowertoolsLoggerTest.cs`](diffhunk://#diff-cbe4825d66808994c709a5cc492d0adb8130ebf385d28e5382634ecf1ad257e6R1094-R1177): Added new tests `Log_Inner_Exception` and `Log_Nested_Inner_Exception` to verify that inner exceptions are correctly logged, ensuring the new functionality works as expected.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
