### PR TITLE
fix: pin FluentAssertions NuGet version to prevent license issues

### DIFF
--- a/libraries/tests/Directory.Packages.props
+++ b/libraries/tests/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageVersion Include="Amazon.Lambda.Core" Version="2.3.0" />
     <PackageVersion Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.0" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
+    <PackageVersion Include="FluentAssertions" Version="[6.12.0]" />
     <PackageVersion Include="Amazon.Lambda.ApplicationLoadBalancerEvents" Version="2.2.0" />
     <PackageVersion Include="Amazon.Lambda.DynamoDBEvents" Version="3.1.0" />
     <PackageVersion Include="Amazon.Lambda.KinesisEvents" Version="2.2.0" />


### PR DESCRIPTION
… changes

Issue Number : [697](https://github.com/aws-powertools/powertools-lambda-dotnet/issues/697)

## Summary

### Changes

The commit updates the Directory.Packages.props file to pin the FluentAssertions NuGet package version by surrounding the version number with square brackets to prevent unintentional upgrades.

### User experience

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [ ] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
