### PR TITLE
chore: Add Aot e2e tests for x86

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Deploy AOT Stack
         run: |
-          dotnet-lambda package -pl libraries/tests/e2e/functions/core/logging/AOT-Function/src/AOT-Function -cmd ../../../ -o libraries/tests/e2e/functions/core/logging/AOT-Function/dist -f net8.0 -farch x86_64 -cifb public.ecr.aws/sam/build-dotnet8
+          dotnet-lambda package -pl libraries/tests/e2e/functions/core/logging/AOT-Function/src/AOT-Function -cmd ../../../ -o libraries/tests/e2e/functions/core/logging/AOT-Function/dist -f net8.0 -farch arm64 -cifb public.ecr.aws/sam/build-dotnet8:latest-arm64
 
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -62,11 +62,6 @@ jobs:
           role-to-assume: ${{ secrets.E2E_DEPLOY_ROLE }}
           aws-region: us-east-1
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@53851d14592bedcffcf25ea515637cff71ef929a
-        with:
-          platforms: arm64
-            
       - name: Set up .NET
         uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3
         with:
@@ -78,17 +73,10 @@ jobs:
       - name: Install AWS Lambda .NET CLI Tools
         run: dotnet tool install -g Amazon.Lambda.Tools
 
-      - name: Set up Docker Buildx
-        id: builder
-        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
-        with:
-          install: true
-          driver: docker
-          platforms: linux/amd64,linux/arm64
-
-      - name: Deploy AOT Stack
+      - name: Deploy AOT Stack x86_64
         run: |
-          dotnet-lambda package -pl libraries/tests/e2e/functions/core/logging/AOT-Function/src/AOT-Function -cmd ../../../ -o libraries/tests/e2e/functions/core/logging/AOT-Function/dist -f net8.0 -farch arm64 -cifb public.ecr.aws/sam/build-dotnet8:latest-arm64
+          cd libraries/tests/e2e/infra-aot
+          cdk deploy -c architecture=x86_64 --require-approval never
 
   run-tests:
     runs-on: ubuntu-latest
@@ -112,7 +100,12 @@ jobs:
       - name: Run Core Tests
         run: |
           cd libraries/tests/e2e/functions/core
-          dotnet test
+          dotnet test --Filter Category!=AOT
+          
+      - name: Run Core AOT Tests
+        run: |
+          cd libraries/tests/e2e/functions/core
+          dotnet test --Filter Category=AOT
 
   destroy-stack:
     runs-on: ubuntu-latest
@@ -140,45 +133,7 @@ jobs:
           cd libraries/tests/e2e/infra
           cdk destroy --force
           
-#  destroy-aot-stack:
-#    runs-on: ubuntu-latest
-#    needs: run-tests
-#    if: always()
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        architecture: [ x86_64, arm64 ]
-#    steps:
-#      - name: Checkout code
-#        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-#
-#      - name: Configure AWS credentials
-#        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
-#        with:
-#          role-to-assume: ${{ secrets.E2E_DEPLOY_ROLE }}
-#          aws-region: us-east-1
-#          mask-aws-account-id: true
-#
-#      - name: Install CDK
-#        run: npm install -g aws-cdk
-#
-#      - name: Install AWS Lambda .NET CLI Tools
-#        run: dotnet tool install -g Amazon.Lambda.Tools
-#
-#      - name: Set up QEMU
-#        uses: docker/setup-qemu-action@53851d14592bedcffcf25ea515637cff71ef929a
-#        with:
-#          platforms: ${{ matrix.architecture }}
-#
-#      - name: Set up Docker Buildx
-#        id: builder
-#        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
-#        with:
-#          install: true
-#          driver: docker
-#          platforms: linux/amd64,linux/arm64
-#
-#      - name: Destroy Core AOT Stack
-#        run: |
-#          cd libraries/tests/e2e/infra-aot
-#          cdk destroy -c architecture=${{ matrix.architecture }} --force
+      - name: Destroy AOT Core Stack
+        run: |
+          cd libraries/tests/e2e/infra-aot
+          cdk destroy -c architecture=x86_64 --force

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -57,7 +57,7 @@ jobs:
         include:
           - os: ubuntu-latest
             arch: x86_64
-          - os: ubuntu-22.04-arm
+          - os: macos-latest
             arch: arm64
     steps:
       - name: Checkout code

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -51,14 +51,7 @@ jobs:
           cdk deploy --require-approval never
 
   deploy-aot-stack:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-latest
-            arch: x86_64
-          - os: macos-latest
-            arch: arm64
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -69,6 +62,11 @@ jobs:
           role-to-assume: ${{ secrets.E2E_DEPLOY_ROLE }}
           aws-region: us-east-1
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@53851d14592bedcffcf25ea515637cff71ef929a
+        with:
+          platforms: arm64
+            
       - name: Set up .NET
         uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3
         with:
@@ -80,23 +78,18 @@ jobs:
       - name: Install AWS Lambda .NET CLI Tools
         run: dotnet tool install -g Amazon.Lambda.Tools
 
-#      - name: Set up QEMU
-#        uses: docker/setup-qemu-action@53851d14592bedcffcf25ea515637cff71ef929a
-#        with:
-#          platforms: ${{ matrix.arch }}
-#
-#      - name: Set up Docker Buildx
-#        id: builder
-#        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
-#        with:
-#          install: true
-#          driver: docker
-#          platforms: linux/amd64,linux/arm64
+      - name: Set up Docker Buildx
+        id: builder
+        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
+        with:
+          install: true
+          driver: docker
+          platforms: linux/arm64
 
       - name: Deploy AOT Stack
         run: |
           cd libraries/tests/e2e/infra-aot
-          cdk deploy -c architecture=${{ matrix.arch }} --require-approval never
+          cdk deploy -c architecture=arm64 --require-approval never
 
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -84,7 +84,7 @@ jobs:
         with:
           install: true
           driver: docker
-          platforms: linux/arm64
+          platforms: linux/amd64,linux/arm64
 
       - name: Deploy AOT Stack
         run: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -80,7 +80,7 @@ jobs:
 
   run-tests:
     runs-on: ubuntu-latest
-    needs: deploy-stack
+    needs: [deploy-stack,deploy-aot-stack]
     steps:
       - name: Checkout code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -100,12 +100,12 @@ jobs:
       - name: Run Core Tests
         run: |
           cd libraries/tests/e2e/functions/core
-          dotnet test --Filter Category!=AOT
+          dotnet test --filter Category!=AOT
           
       - name: Run Core AOT Tests
         run: |
           cd libraries/tests/e2e/functions/core
-          dotnet test --Filter Category=AOT
+          dotnet test --filter Category=AOT
 
   destroy-stack:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -56,7 +56,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            arch: amd64
+            arch: x86_64
           - os: ubuntu-22.04-arm
             arch: arm64
     steps:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Deploy AOT Stack
         run: |
-          dotnet-lambda package -pl libraries/tests/e2e/functions/core/logging/AOT-Function/src/AOT-Function -cmd ../../../ -o libraries/tests/e2e/functions/core/logging/AOT-Function/dist -f net8.0 -farch arm64 -cifb public.ecr.aws/sam/build-dotnet8
+          dotnet-lambda package -pl libraries/tests/e2e/functions/core/logging/AOT-Function/src/AOT-Function -cmd ../../../ -o libraries/tests/e2e/functions/core/logging/AOT-Function/dist -f net8.0 -farch x86_64 -cifb public.ecr.aws/sam/build-dotnet8
 
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -88,8 +88,7 @@ jobs:
 
       - name: Deploy AOT Stack
         run: |
-          cd libraries/tests/e2e/infra-aot
-          cdk deploy -c architecture=arm64 --require-approval never
+          dotnet-lambda package -pl libraries/tests/e2e/functions/core/logging/AOT-Function/src/AOT-Function -cmd ../../../ -o libraries/tests/e2e/functions/core/logging/AOT-Function/dist -f net8.0 -farch arm64 -cifb public.ecr.aws/sam/build-dotnet8
 
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -50,38 +50,41 @@ jobs:
           cd libraries/tests/e2e/infra
           cdk deploy --require-approval never
 
-#  deploy-aot-stack:
-#    runs-on: ubuntu-latest
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        architecture: [ x86_64, arm64 ]
-#    steps:
-#      - name: Checkout code
-#        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-#
-#      - name: Configure AWS credentials
-#        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
-#        with:
-#          role-to-assume: ${{ secrets.E2E_DEPLOY_ROLE }}
-#          aws-region: us-east-1
-#
-#      - name: Set up .NET
-#        uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3
-#        with:
-#          dotnet-version: '8.x'
-#
-#      - name: Install CDK
-#        run: npm install -g aws-cdk
-#        
-#      - name: Install AWS Lambda .NET CLI Tools
-#        run: dotnet tool install -g Amazon.Lambda.Tools
-#        
+  deploy-aot-stack:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            arch: amd64
+          - os: ubuntu-22.04-arm
+            arch: arm64
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
+        with:
+          role-to-assume: ${{ secrets.E2E_DEPLOY_ROLE }}
+          aws-region: us-east-1
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3
+        with:
+          dotnet-version: '8.x'
+
+      - name: Install CDK
+        run: npm install -g aws-cdk
+
+      - name: Install AWS Lambda .NET CLI Tools
+        run: dotnet tool install -g Amazon.Lambda.Tools
+
 #      - name: Set up QEMU
 #        uses: docker/setup-qemu-action@53851d14592bedcffcf25ea515637cff71ef929a
 #        with:
-#          platforms: ${{ matrix.architecture }}
-#          
+#          platforms: ${{ matrix.arch }}
+#
 #      - name: Set up Docker Buildx
 #        id: builder
 #        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
@@ -89,11 +92,11 @@ jobs:
 #          install: true
 #          driver: docker
 #          platforms: linux/amd64,linux/arm64
-#
-#      - name: Deploy AOT Stack
-#        run: |
-#          cd libraries/tests/e2e/infra-aot
-#          cdk deploy -c architecture=${{ matrix.architecture }} --require-approval never
+
+      - name: Deploy AOT Stack
+        run: |
+          cd libraries/tests/e2e/infra-aot
+          cdk deploy -c architecture=${{ matrix.arch }} --require-approval never
 
   run-tests:
     runs-on: ubuntu-latest

--- a/libraries/tests/e2e/functions/core/logging/Function/test/Function.Tests/FunctionTests.cs
+++ b/libraries/tests/e2e/functions/core/logging/Function/test/Function.Tests/FunctionTests.cs
@@ -9,15 +9,24 @@ using Xunit.Abstractions;
 namespace Function.Tests;
 
 [Trait("Category", "E2E")]
-public class FunctionTest
+public class FunctionTests
 {
     private readonly ITestOutputHelper _testOutputHelper;
     private readonly AmazonLambdaClient _lambdaClient;
 
-    public FunctionTest(ITestOutputHelper testOutputHelper)
+    public FunctionTests(ITestOutputHelper testOutputHelper)
     {
         _testOutputHelper = testOutputHelper;
         _lambdaClient = new AmazonLambdaClient();
+    }
+    
+    [Trait("Category", "AOT")]
+    [Theory]
+    [InlineData("E2ETestLambda_X64_AOT_NET8_logging")]
+    // [InlineData("E2ETestLambda_ARM_AOT_NET8_metrics")]
+    public async Task AotFunctionTest(string functionName)
+    {
+        await TestFunction(functionName);
     }
 
     [Theory]
@@ -25,8 +34,12 @@ public class FunctionTest
     [InlineData("E2ETestLambda_ARM_NET6_logging")]
     [InlineData("E2ETestLambda_X64_NET8_logging")]
     [InlineData("E2ETestLambda_ARM_NET8_logging")]
-    // [InlineData("E2ETestLambda_ARM_AOT_NET8_logging")]
-    public async Task TestFunction(string functionName)
+    public async Task FunctionTest(string functionName)
+    {
+        await TestFunction(functionName);
+    }
+
+    internal async Task TestFunction(string functionName)
     {
         var request = new InvokeRequest
         {

--- a/libraries/tests/e2e/functions/core/metrics/Function/test/Function.Tests/FunctionTests.cs
+++ b/libraries/tests/e2e/functions/core/metrics/Function/test/Function.Tests/FunctionTests.cs
@@ -9,15 +9,24 @@ using Xunit.Abstractions;
 namespace Function.Tests;
 
 [Trait("Category", "E2E")]
-public class FunctionTest
+public class FunctionTests
 {
     private readonly ITestOutputHelper _testOutputHelper;
     private readonly AmazonLambdaClient _lambdaClient;
 
-    public FunctionTest(ITestOutputHelper testOutputHelper)
+    public FunctionTests(ITestOutputHelper testOutputHelper)
     {
         _testOutputHelper = testOutputHelper;
         _lambdaClient = new AmazonLambdaClient();
+    }
+
+    [Trait("Category", "AOT")]
+    [Theory]
+    [InlineData("E2ETestLambda_X64_AOT_NET8_metrics")]
+    // [InlineData("E2ETestLambda_ARM_AOT_NET8_metrics")]
+    public async Task AotFunctionTest(string functionName)
+    {
+        await TestFunction(functionName);
     }
 
     [Theory]
@@ -25,8 +34,12 @@ public class FunctionTest
     [InlineData("E2ETestLambda_ARM_NET6_metrics")]
     [InlineData("E2ETestLambda_X64_NET8_metrics")]
     [InlineData("E2ETestLambda_ARM_NET8_metrics")]
-    // [InlineData("E2ETestLambda_ARM_AOT_NET8_metrics")]
-    public async Task TestFunction(string functionName)
+    public async Task FunctionTest(string functionName)
+    {
+        await TestFunction(functionName);
+    }
+
+    internal async Task TestFunction(string functionName)
     {
         var request = new InvokeRequest
         {

--- a/libraries/tests/e2e/functions/core/tracing/Function/test/Function.Tests/FunctionTests.cs
+++ b/libraries/tests/e2e/functions/core/tracing/Function/test/Function.Tests/FunctionTests.cs
@@ -9,12 +9,12 @@ using Xunit.Abstractions;
 namespace Function.Tests;
 
 [Trait("Category", "E2E")]
-public class FunctionTest
+public class FunctionTests
 {
     private readonly ITestOutputHelper _testOutputHelper;
     private readonly AmazonLambdaClient _lambdaClient;
 
-    public FunctionTest(ITestOutputHelper testOutputHelper)
+    public FunctionTests(ITestOutputHelper testOutputHelper)
     {
         _testOutputHelper = testOutputHelper;
         _lambdaClient = new AmazonLambdaClient(new AmazonLambdaConfig
@@ -22,14 +22,27 @@ public class FunctionTest
             Timeout = TimeSpan.FromSeconds(7)
         });
     }
+    
+    [Trait("Category", "AOT")]
+    [Theory]
+    [InlineData("E2ETestLambda_X64_AOT_NET8_tracing")]
+    // [InlineData("E2ETestLambda_ARM_AOT_NET8_tracing")]
+    public async Task AotFunctionTest(string functionName)
+    {
+        await TestFunction(functionName);
+    }
 
     [Theory]
     [InlineData("E2ETestLambda_X64_NET6_tracing")]
     [InlineData("E2ETestLambda_ARM_NET6_tracing")]
     [InlineData("E2ETestLambda_X64_NET8_tracing")]
     [InlineData("E2ETestLambda_ARM_NET8_tracing")]
-    // [InlineData("E2ETestLambda_ARM_AOT_NET8_tracing")]
-    public async Task TestToUpperFunction(string functionName)
+    public async Task FunctionTest(string functionName)
+    {
+        await TestFunction(functionName);
+    }
+
+    internal async Task TestFunction(string functionName)
     {
         var request = new InvokeRequest
         {


### PR DESCRIPTION
> Please provide the issue number

Issue number: #683 

## Summary

### Changes

Add E2E tests for AOT x86 only. Currently we do not have support for ARM runners

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
