### PR TITLE
chore: Fix arm e2e aot

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Deploy AOT Stack
         run: |
           cd libraries/tests/e2e/infra-aot
-          cdk deploy -c architecture={{ matrix.arch }} --require-approval never
+          cdk deploy -c architecture=${{ matrix.arch }} --require-approval never
 
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -140,14 +140,38 @@ jobs:
         run: |
           cd libraries/tests/e2e/infra
           cdk destroy --force
-          
-      - name: Destroy x86_64 AOT Core Stack
-        run: |
-          cd libraries/tests/e2e/infra-aot
-          cdk destroy -c architecture=x86_64 --force
+
+  destroy-aot-stack:
+    strategy:
+      matrix:
+        os: [ubuntu-24.04-arm, ubuntu-latest]
+        include:
+          - os: ubuntu-24.04-arm
+            arch: arm64
+          - os: ubuntu-latest
+            arch: x86_64
+    runs-on: ${{ matrix.os }}
+    needs: run-tests
+    if: always()
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
+        with:
+          role-to-assume: ${{ secrets.E2E_DEPLOY_ROLE }}
+          aws-region: us-east-1
+          mask-aws-account-id: true
+
+      - name: Install CDK
+        run: npm install -g aws-cdk
+        
+      - name: Install AWS Lambda .NET CLI Tools
+        run: dotnet tool install -g Amazon.Lambda.Tools
 
       - name: Destroy arm64 AOT Core Stack
         run: |
           cd libraries/tests/e2e/infra-aot
-          cdk destroy -c architecture=arm64 --force
+          cdk destroy -c architecture=${{ matrix.arch }} --force
       

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -51,7 +51,15 @@ jobs:
           cdk deploy --require-approval never
 
   deploy-aot-stack:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-24.04-arm, ubuntu-latest]
+        include:
+          - os: ubuntu-24.04-arm
+            arch: arm64
+          - os: ubuntu-latest
+            arch: x86_64
+    runs-on: ${{ matrix.arch }}
     steps:
       - name: Checkout code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -73,10 +81,10 @@ jobs:
       - name: Install AWS Lambda .NET CLI Tools
         run: dotnet tool install -g Amazon.Lambda.Tools
 
-      - name: Deploy AOT Stack x86_64
+      - name: Deploy AOT Stack
         run: |
           cd libraries/tests/e2e/infra-aot
-          cdk deploy -c architecture=x86_64 --require-approval never
+          cdk deploy -c architecture={{ matrix.arch }} --require-approval never
 
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -59,7 +59,7 @@ jobs:
             arch: arm64
           - os: ubuntu-latest
             arch: x86_64
-    runs-on: ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -141,7 +141,13 @@ jobs:
           cd libraries/tests/e2e/infra
           cdk destroy --force
           
-      - name: Destroy AOT Core Stack
+      - name: Destroy x86_64 AOT Core Stack
         run: |
           cd libraries/tests/e2e/infra-aot
           cdk destroy -c architecture=x86_64 --force
+
+      - name: Destroy arm64 AOT Core Stack
+        run: |
+          cd libraries/tests/e2e/infra-aot
+          cdk destroy -c architecture=arm64 --force
+      

--- a/libraries/tests/e2e/infra-aot/Program.cs
+++ b/libraries/tests/e2e/infra-aot/Program.cs
@@ -19,7 +19,13 @@ namespace InfraAot
                 throw new System.ArgumentException("architecture context must be either arm64 or x86_64");
             }
 
-            _ = new CoreAotStack(app, $"CoreAotStack-{architecture}", new AotStackProps
+            var id = "CoreAotStack";
+            if(architecture == "arm64")
+            {
+                id = $"CoreAotStack-{architecture}";
+            }
+
+            _ = new CoreAotStack(app, id, new AotStackProps
             {
                 Architecture = architecture
             });

--- a/libraries/tests/e2e/infra-aot/Program.cs
+++ b/libraries/tests/e2e/infra-aot/Program.cs
@@ -19,7 +19,7 @@ namespace InfraAot
                 throw new System.ArgumentException("architecture context must be either arm64 or x86_64");
             }
 
-            _ = new CoreAotStack(app, "CoreAotStack", new AotStackProps
+            _ = new CoreAotStack(app, $"CoreAotStack-{architecture}", new AotStackProps
             {
                 Architecture = architecture
             });


### PR DESCRIPTION
> Please provide the issue number

Issue number: #683

## Summary

### Changes

Add GitHub actions strategy to deploy to arm and x86 architecture for AOT end to end tests
Use new GitHub arm runner
Split Cloud Formation AOT stack by architecture (arm, x86)

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
