### PR TITLE
chore: Fix Service override on decorator

### DIFF
--- a/libraries/src/AWS.Lambda.Powertools.Logging/Internal/LoggingAspect.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Internal/LoggingAspect.cs
@@ -138,7 +138,7 @@ public class LoggingAspect
             _correlationIdPath = trigger.CorrelationIdPath;
             _clearState = trigger.ClearState;
 
-            Logger.LoggerProvider ??= new LoggerProvider(_config, _powertoolsConfigurations, _systemWrapper);
+            Logger.LoggerProvider = new LoggerProvider(_config, _powertoolsConfigurations, _systemWrapper);
 
             if (!_initializeContext)
                 return;

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Handlers/TestHandlers.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Handlers/TestHandlers.cs
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 
+using System;
 using System.Text.Json.Serialization;
 using Amazon.Lambda.APIGatewayEvents;
 using Amazon.Lambda.ApplicationLoadBalancerEvents;
@@ -40,12 +41,13 @@ class TestHandlers
     public void LogEventNoArgs()
     {
     }
-    
-    [Logging(LogEvent = true, LoggerOutputCase = LoggerOutputCase.PascalCase, CorrelationIdPath = "/Headers/MyRequestIdHeader")]
+
+    [Logging(LogEvent = true, LoggerOutputCase = LoggerOutputCase.PascalCase,
+        CorrelationIdPath = "/Headers/MyRequestIdHeader")]
     public void LogEvent(TestObject testObject, ILambdaContext context)
     {
     }
-    
+
     [Logging(LogEvent = false)]
     public void LogEventFalse(ILambdaContext context)
     {
@@ -81,104 +83,129 @@ class TestHandlers
     public void CorrelationIdFromString(TestObject testObject)
     {
     }
-        
+
     [Logging(CorrelationIdPath = "/headers/my_request_id_header")]
     public void CorrelationIdFromStringSnake(TestObject testObject)
     {
     }
-        
+
     [Logging(CorrelationIdPath = "/Headers/MyRequestIdHeader", LoggerOutputCase = LoggerOutputCase.PascalCase)]
     public void CorrelationIdFromStringPascal(TestObject testObject)
     {
     }
-        
+
     [Logging(CorrelationIdPath = "/headers/myRequestIdHeader", LoggerOutputCase = LoggerOutputCase.CamelCase)]
     public void CorrelationIdFromStringCamel(TestObject testObject)
     {
     }
-        
+
     [Logging(CorrelationIdPath = "/headers/my_request_id_header")]
     public void CorrelationIdFromStringSnakeEnv(TestObject testObject)
     {
     }
-        
+
     [Logging(CorrelationIdPath = "/Headers/MyRequestIdHeader")]
     public void CorrelationIdFromStringPascalEnv(TestObject testObject)
     {
     }
-        
+
     [Logging(CorrelationIdPath = "/headers/myRequestIdHeader")]
     public void CorrelationIdFromStringCamelEnv(TestObject testObject)
     {
     }
-        
+
     [Logging(Service = "test", LoggerOutputCase = LoggerOutputCase.CamelCase)]
     public void HandlerService()
     {
         Logger.LogInformation("test");
     }
-        
+
     [Logging(SamplingRate = 0.5, LoggerOutputCase = LoggerOutputCase.CamelCase, LogLevel = LogLevel.Information)]
     public void HandlerSamplingRate()
     {
         Logger.LogInformation("test");
     }
-    
+
     [Logging(LogLevel = LogLevel.Critical)]
     public void TestLogLevelCritical()
     {
         Logger.LogCritical("test");
     }
-    
+
     [Logging(LogLevel = LogLevel.Critical, LogEvent = true)]
     public void TestLogLevelCriticalLogEvent(ILambdaContext context)
     {
     }
-    
+
     [Logging(LogLevel = LogLevel.Debug, LogEvent = true)]
     public void TestLogEventWithoutContext()
     {
     }
-    
+
     [Logging(LogEvent = true, SamplingRate = 0.2, Service = "my_service")]
     public void TestCustomFormatterWithDecorator(string input, ILambdaContext context)
     {
     }
-    
+
     [Logging(LogEvent = true, SamplingRate = 0.2, Service = "my_service")]
     public void TestCustomFormatterWithDecoratorNoContext(string input)
     {
     }
-    
+
     public void TestCustomFormatterNoDecorator(string input, ILambdaContext context)
     {
         Logger.LogInformation(input);
     }
-    
+
     public void TestLogNoDecorator()
     {
         Logger.LogInformation("test");
     }
-    
+
     [Logging(Service = "test", LoggerOutputCase = LoggerOutputCase.SnakeCase)]
     public void TestEnums(string input, ILambdaContext context)
     {
         Logger.LogInformation(Pet.Dog);
         Logger.LogInformation(Thing.Five);
     }
-    
+
     public enum Thing
     {
         One = 1,
         Three = 3,
         Five = 5
     }
-    
+
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public enum Pet
     {
         Cat = 1,
         Dog = 3,
         Lizard = 5
+    }
+}
+
+public class TestServiceHandler
+{
+    public void LogWithEnv()
+    {
+        Environment.SetEnvironmentVariable("POWERTOOLS_SERVICE_NAME", "Environment Service");
+        
+        Logger.LogInformation("Service: Environment Service");
+    }
+    
+    public void LogWithAndWithoutEnv()
+    {
+        Logger.LogInformation("Service: service_undefined");
+        
+        Environment.SetEnvironmentVariable("POWERTOOLS_SERVICE_NAME", "Environment Service");
+        
+        Logger.LogInformation("Service: service_undefined");
+    }
+
+    [Logging(Service = "Attribute Service")]
+    public void Handler()
+    {
+        Logger.LogInformation("Service: Attribute Service");
     }
 }

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/PowertoolsLoggerTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/PowertoolsLoggerTest.cs
@@ -29,7 +29,7 @@ using Xunit;
 
 namespace AWS.Lambda.Powertools.Logging.Tests
 {
-    [Collection("Sequential")]
+    [Collection("X Sequential")]
     public class PowertoolsLoggerTest : IDisposable
     {
         public PowertoolsLoggerTest()
@@ -1337,6 +1337,8 @@ namespace AWS.Lambda.Powertools.Logging.Tests
         [Fact]
         public void Log_Set_Execution_Environment_Context()
         {
+            var _originalValue = Environment.GetEnvironmentVariable("POWERTOOLS_SERVICE_NAME");
+            
             // Arrange
             var loggerName = Guid.NewGuid().ToString();
             var assemblyName = "AWS.Lambda.Powertools.Logger";
@@ -1707,6 +1709,7 @@ namespace AWS.Lambda.Powertools.Logging.Tests
         public void Dispose()
         {
             PowertoolsLoggingSerializer.ClearOptions();
+            LoggingAspect.ResetForTest();
         }
     }
 }

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/TestSetup.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/TestSetup.cs
@@ -13,6 +13,21 @@
  * permissions and limitations under the License.
  */
 
+using System.Collections.Generic;
+using System.Linq;
 using Xunit;
+using Xunit.Abstractions;
 
+[assembly: TestCollectionOrderer("AWS.Lambda.Powertools.Logging.Tests.DisplayNameOrderer", "AWS.Lambda.Powertools.Logging.Tests")]
 [assembly: CollectionBehavior(DisableTestParallelization = true)]
+
+
+namespace AWS.Lambda.Powertools.Logging.Tests;
+
+public class DisplayNameOrderer : ITestCollectionOrderer
+{
+    public IEnumerable<ITestCollection> OrderTestCollections(IEnumerable<ITestCollection> testCollections)
+    {
+        return testCollections.OrderBy(collection => collection.DisplayName);
+    }
+}

--- a/libraries/tests/e2e/functions/core/logging/Function/test/Function.Tests/FunctionTests.cs
+++ b/libraries/tests/e2e/functions/core/logging/Function/test/Function.Tests/FunctionTests.cs
@@ -23,7 +23,7 @@ public class FunctionTests
     [Trait("Category", "AOT")]
     [Theory]
     [InlineData("E2ETestLambda_X64_AOT_NET8_logging")]
-    // [InlineData("E2ETestLambda_ARM_AOT_NET8_metrics")]
+    [InlineData("E2ETestLambda_ARM_AOT_NET8_logging")]
     public async Task AotFunctionTest(string functionName)
     {
         await TestFunction(functionName);


### PR DESCRIPTION
> Please provide the issue number

Issue number: #702 

## Summary

### Changes

Modified the logger provider initialization, adding new test classes and methods, and updating test setups for better organization and functionality.

### Logger provider initialization:
* [`libraries/src/AWS.Lambda.Powertools.Logging/Internal/LoggingAspect.cs`](diffhunk://#diff-28773729ae13b16a2bea1c09c17e6d653fceee05b81d2c6ad5d003f9ba5165a1L141-R141): Changed the logger provider initialization to always create a new instance of `LoggerProvider`.

### Test enhancements:
* [`libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Attributes/LoggingAttributeTest.cs`](diffhunk://#diff-4103eca0455fc07cb8b4b5a66eadfd3cdd4c918a00867632ca8833647a5ce716R478-R539): Added new test class `ServiceTests` to verify service name overrides and included additional environment variable cleanup in `Dispose` methods.
* [`libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Handlers/TestHandlers.cs`](diffhunk://#diff-0ca6d66a2227086e400c8c9779e40eb6c0a398ebc5ba2164017ef9d095e3a3dcR187-R211): Introduced `TestServiceHandler` class with methods to log service names based on environment variables and attributes.
* [`libraries/tests/AWS.Lambda.Powertools.Logging.Tests/PowertoolsLoggerTest.cs`](diffhunk://#diff-cbe4825d66808994c709a5cc492d0adb8130ebf385d28e5382634ecf1ad257e6L32-R32): Added environment variable preservation and reset in tests, and updated collection attribute for sequential test execution. [[1]](diffhunk://#diff-cbe4825d66808994c709a5cc492d0adb8130ebf385d28e5382634ecf1ad257e6L32-R32) [[2]](diffhunk://#diff-cbe4825d66808994c709a5cc492d0adb8130ebf385d28e5382634ecf1ad257e6R1340-R1341) [[3]](diffhunk://#diff-cbe4825d66808994c709a5cc492d0adb8130ebf385d28e5382634ecf1ad257e6R1712)

### Test setup improvements:
* [`libraries/tests/AWS.Lambda.Powertools.Logging.Tests/TestSetup.cs`](diffhunk://#diff-7fff0cbc8618badf5b000e62c3b6500f10e638ad92fca532ba26f11ba698b70fR16-R33): Added `DisplayNameOrderer` class to order test collections by display name and included necessary using directives.

### Minor updates:
* [`libraries/tests/e2e/functions/core/logging/Function/test/Function.Tests/FunctionTests.cs`](diffhunk://#diff-b8451340c71fcaa8a2a846eb3c6f613b3af3721581cb0976bfb339ee9a5ef775L26-R26): Enabled an additional inline data test for ARM architecture in AOT function tests.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
