### PR TITLE
chore: Only run on libraries folder changes

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -13,6 +13,8 @@ name: E2E Tests
 on:
   workflow_dispatch:
   push:
+    paths:
+      - "libraries/**"
     branches:
       - develop
       


### PR DESCRIPTION
> Please provide the issue number

Issue number: #719

## Summary

### Changes

This pull request includes a small change to the `.github/workflows/e2e-tests.yml` file. The change specifies that the end-to-end tests should be triggered on pushes to the `libraries` directory.

* [`.github/workflows/e2e-tests.yml`](diffhunk://#diff-194218c48b9a0cdd03974145733804c2d992ca818529fe2fa69a501d8b5b1cc3R16-R17): Added a path filter to trigger the workflow on pushes to the `libraries` directory.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [ ] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
