### PR TITLE
chore: add Logging Service property priority to docs

### DIFF
--- a/docs/core/logging.md
+++ b/docs/core/logging.md
@@ -36,6 +36,14 @@ Setting | Description | Environment variable | Attribute parameter
 **Service** | Sets **Service** key that will be present across all log statements | `POWERTOOLS_SERVICE_NAME` | `Service`
 **Logging level** | Sets how verbose Logger should be (Information, by default) |  `POWERTOOLS_LOG_LEVEL` | `LogLevel`
 
+### Service Property Priority Resolution
+
+The root level Service property now correctly follows this priority order:
+
+1. LoggingAttribute.Service (property value set in the decorator)
+2. POWERTOOLS_SERVICE_NAME (environment variable)
+
+
 ### Example using AWS Serverless Application Model (AWS SAM)
 
 You can override log level by setting **`POWERTOOLS_LOG_LEVEL`** environment variable in the AWS SAM template.


### PR DESCRIPTION
> Please provide the issue number

Issue number: #702 

## Summary

### Changes

Add Logging Service property priority to docs

Service Property Priority Resolution

The root level Service property now correctly follows this priority order:

1. LoggingAttribute.Service (property value set in the decorator)
2. POWERTOOLS_SERVICE_NAME (environment variable)


### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [ ] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
