### PR TITLE
chore: Tracing Sanitize SegmentName to avoid unsupported characters

### DIFF
--- a/libraries/src/AWS.Lambda.Powertools.Tracing/Internal/Helpers.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Tracing/Internal/Helpers.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.RegularExpressions;
 
 namespace AWS.Lambda.Powertools.Tracing.Internal;
@@ -17,7 +18,7 @@ public static class Helpers
         // Define a regular expression pattern to match allowed characters
         var pattern = @"[^a-zA-Z0-9\s_\.\:/%&#=+\-@]";
 
-        // Replace any character that does not match the pattern with an empty string
-        return Regex.Replace(input, pattern, string.Empty);
+        // Replace any character that does not match the pattern with an empty string, with a timeout
+        return Regex.Replace(input, pattern, string.Empty, RegexOptions.None, TimeSpan.FromMilliseconds(100));
     }
 }

--- a/libraries/src/AWS.Lambda.Powertools.Tracing/Internal/Helpers.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Tracing/Internal/Helpers.cs
@@ -1,0 +1,23 @@
+using System.Text.RegularExpressions;
+
+namespace AWS.Lambda.Powertools.Tracing.Internal;
+
+/// <summary>
+///    Helper class
+/// </summary>
+public static class Helpers
+{
+    /// <summary>
+    /// Sanitize a string by removing any characters that are not alphanumeric, whitespace, or one of the following: _ . : / % & # = + - @
+    /// </summary>
+    /// <param name="input"></param>
+    /// <returns></returns>
+    public static string SanitizeString(string input)
+    {
+        // Define a regular expression pattern to match allowed characters
+        var pattern = @"[^a-zA-Z0-9\s_\.\:/%&#=+\-@]";
+
+        // Replace any character that does not match the pattern with an empty string
+        return Regex.Replace(input, pattern, string.Empty);
+    }
+}

--- a/libraries/src/AWS.Lambda.Powertools.Tracing/Internal/XRayRecorder.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Tracing/Internal/XRayRecorder.cs
@@ -78,7 +78,9 @@ internal class XRayRecorder : IXRayRecorder
     public void BeginSubsegment(string name)
     {
         if (_isLambda)
-            _awsxRayRecorder.BeginSubsegment(name);
+        {
+            _awsxRayRecorder.BeginSubsegment(Helpers.SanitizeString(name));
+        }
     }
 
     /// <summary>

--- a/libraries/src/AWS.Lambda.Powertools.Tracing/TracingAttribute.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Tracing/TracingAttribute.cs
@@ -15,7 +15,6 @@
 
 using System;
 using AspectInjector.Broker;
-using AWS.Lambda.Powertools.Common;
 using AWS.Lambda.Powertools.Tracing.Internal;
 
 namespace AWS.Lambda.Powertools.Tracing;
@@ -114,8 +113,10 @@ public class TracingAttribute : Attribute
     /// <summary>
     ///     Set custom segment name for the operation.
     ///     The default is '## {MethodName}'.
+    ///
+    ///     The logical name of the service that handled the request, up to 200 characters. 
+    ///     Names can contain Unicode letters, numbers, and whitespace, and the following symbols: \_, ., :, /, %, &amp;, #, =, +, \\, -, @
     /// </summary>
-    /// <value>The name of the segment.</value>
     public string SegmentName { get; set; } = "";
 
     /// <summary>

--- a/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/Handlers/Handlers.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/Handlers/Handlers.cs
@@ -31,6 +31,18 @@ public class HandlerFunctions
         
     }
     
+    [Tracing(SegmentName = "## <<Main>$>g__Handler|0_0")]
+    public void HandleWithInvalidSegmentName()
+    {
+        MethodWithInvalidSegmentName();
+    }
+    
+    [Tracing(SegmentName = "Inval$#id | <Segment>")]
+    private void MethodWithInvalidSegmentName()
+    {
+        
+    }
+    
     [Tracing(Namespace = "Namespace Defined")]
     public void HandleWithNamespace()
     {

--- a/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/TracingAttributeTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/TracingAttributeTest.cs
@@ -256,6 +256,28 @@ namespace AWS.Lambda.Powertools.Tracing.Tests
             Assert.Single(segment.Subsegments);
             Assert.Equal("SegmentName", subSegment.Name);
         }
+        
+        [Fact]
+        public void OnEntry_WhenSegmentName_Is_Unsupported()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("LAMBDA_TASK_ROOT", "AWS");
+            Environment.SetEnvironmentVariable("POWERTOOLS_SERVICE_NAME", "POWERTOOLS");
+
+            // Act
+            var segment = AWSXRayRecorder.Instance.TraceContext.GetEntity();
+            _handler.HandleWithInvalidSegmentName();
+            var subSegment = segment.Subsegments[0];
+            var childSegment = subSegment.Subsegments[0];
+            
+            // Assert
+            Assert.True(segment.IsSubsegmentsAdded);
+            Assert.True(subSegment.IsSubsegmentsAdded);
+            Assert.Single(segment.Subsegments);
+            Assert.Single(subSegment.Subsegments);
+            Assert.Equal("## Maing__Handler0_0", subSegment.Name);
+            Assert.Equal("Inval#id  Segment", childSegment.Name);
+        }
 
         [Fact]
         public void OnEntry_WhenNamespaceIsNull_SetNamespaceWithService()


### PR DESCRIPTION
> Please provide the issue number

Issue number: #740 

## Summary

### Changes

1. Sanitize SegmentName 
2. Show accepted chars in the SegmentName

This pull request introduces several changes to the AWS Lambda Powertools Tracing library, primarily focusing on sanitizing segment names and updating related tests. The most important changes include the addition of a helper method for sanitizing strings, modifications to the `XRayRecorder` and `TracingAttribute` classes to use this sanitization, and the addition of new test cases to ensure the changes work correctly.

### Sanitization of Segment Names:

* [`libraries/src/AWS.Lambda.Powertools.Tracing/Internal/Helpers.cs`](diffhunk://#diff-a96509cd7948029c474a5db7716e3ae984dc6c68d4221d0070f6357a1947c7c2R1-R23): Added a new static `Helpers` class with a `SanitizeString` method to remove any characters that are not alphanumeric, whitespace, or one of the following: `_ . : / % & # = + - @`.
* [`libraries/src/AWS.Lambda.Powertools.Tracing/Internal/XRayRecorder.cs`](diffhunk://#diff-c91b42b9c9dbcd00f81cbe615a175d61f7f7e26f3d9abaabeb3a84574da10c7dL81-R83): Updated the `BeginSubsegment` method to use `Helpers.SanitizeString` for sanitizing the segment name.

### Documentation and Attribute Updates:

* [`libraries/src/AWS.Lambda.Powertools.Tracing/TracingAttribute.cs`](diffhunk://#diff-872838290b616d522c8d4e2fa4311a37801b6318aeef67a08ebfbb9b9ccf17efR116-L118): Updated the documentation for the `SegmentName` property to specify the allowed characters in segment names.

### Test Enhancements:

* [`libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/Handlers/Handlers.cs`](diffhunk://#diff-3ae63201b4ebb4412f61c6dc334d0e8adce7729955614d1e6ef49ef4b15ea4a5R34-R45): Added new methods `HandleWithInvalidSegmentName` and `MethodWithInvalidSegmentName` to test the handling of invalid segment names.
* [`libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/TracingAttributeTest.cs`](diffhunk://#diff-5437ae33fcf10367ae435706416d1d95212bee698c37d2ebbbb496da3827ce1bR260-R281): Added a new test `OnEntry_WhenSegmentName_Is_Unsupported` to verify that the segment names are sanitized correctly.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
