### PR TITLE
chore: Add support for custom key prefixes in Idempotency utility

### DIFF
--- a/libraries/src/AWS.Lambda.Powertools.Idempotency/IdempotentAttribute.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Idempotency/IdempotentAttribute.cs
@@ -64,6 +64,11 @@ namespace AWS.Lambda.Powertools.Idempotency;
 public class IdempotentAttribute : UniversalWrapperAttribute
 {
     /// <summary>
+    /// Custom prefix for idempotency key: key_prefix#hash
+    /// </summary>
+    public string KeyPrefix { get; set; }
+    
+    /// <summary>
     ///     Wraps as a synchronous operation, simply throws IdempotencyConfigurationException
     /// </summary>
     /// <typeparam name="T"></typeparam>
@@ -90,7 +95,7 @@ public class IdempotentAttribute : UniversalWrapperAttribute
 
         Task<T> ResultDelegate() => Task.FromResult(target(args));
 
-        var idempotencyHandler = new IdempotencyAspectHandler<T>(ResultDelegate, eventArgs.Method.Name, payload,GetContext(eventArgs));
+        var idempotencyHandler = new IdempotencyAspectHandler<T>(ResultDelegate, eventArgs.Method.Name, KeyPrefix, payload,GetContext(eventArgs));
         if (idempotencyHandler == null)
         {
             throw new Exception("Failed to create an instance of IdempotencyAspectHandler");
@@ -128,7 +133,7 @@ public class IdempotentAttribute : UniversalWrapperAttribute
         
         Task<T> ResultDelegate() => target(args);
         
-        var idempotencyHandler = new IdempotencyAspectHandler<T>(ResultDelegate, eventArgs.Method.Name, payload, GetContext(eventArgs));
+        var idempotencyHandler = new IdempotencyAspectHandler<T>(ResultDelegate, eventArgs.Method.Name, KeyPrefix, payload, GetContext(eventArgs));
         if (idempotencyHandler == null)
         {
             throw new Exception("Failed to create an instance of IdempotencyAspectHandler");

--- a/libraries/src/AWS.Lambda.Powertools.Idempotency/Internal/IdempotencyAspectHandler.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Idempotency/Internal/IdempotencyAspectHandler.cs
@@ -50,11 +50,13 @@ internal class IdempotencyAspectHandler<T>
     /// </summary>
     /// <param name="target"></param>
     /// <param name="functionName"></param>
+    /// <param name="keyPrefix"></param>
     /// <param name="payload"></param>
     /// <param name="lambdaContext"></param>
     public IdempotencyAspectHandler(
         Func<Task<T>> target,
         string functionName,
+        string keyPrefix,
         JsonDocument payload,
         ILambdaContext lambdaContext)
     {
@@ -62,7 +64,7 @@ internal class IdempotencyAspectHandler<T>
         _data = payload;
         _lambdaContext = lambdaContext;
         _persistenceStore = Idempotency.Instance.PersistenceStore;
-        _persistenceStore.Configure(Idempotency.Instance.IdempotencyOptions, functionName);
+        _persistenceStore.Configure(Idempotency.Instance.IdempotencyOptions, functionName, keyPrefix);
     }
 
     /// <summary>

--- a/libraries/src/AWS.Lambda.Powertools.Idempotency/Persistence/BasePersistenceStore.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Idempotency/Persistence/BasePersistenceStore.cs
@@ -1,12 +1,12 @@
 /*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
@@ -37,16 +37,17 @@ public abstract class BasePersistenceStore : IPersistenceStore
     /// Idempotency Options
     /// </summary>
     private IdempotencyOptions _idempotencyOptions = null!;
-    
+
     /// <summary>
     /// Function name
     /// </summary>
     private string _functionName;
+
     /// <summary>
     /// Boolean to indicate whether or not payload validation is enabled
     /// </summary>
     protected bool PayloadValidationEnabled;
-    
+
     /// <summary>
     /// LRUCache
     /// </summary>
@@ -57,34 +58,45 @@ public abstract class BasePersistenceStore : IPersistenceStore
     /// </summary>
     /// <param name="idempotencyOptions">Idempotency configuration settings</param>
     /// <param name="functionName">The name of the function being decorated</param>
-    public void Configure(IdempotencyOptions idempotencyOptions, string functionName)
+    /// <param name="keyPrefix"></param>
+    public void Configure(IdempotencyOptions idempotencyOptions, string functionName, string keyPrefix)
     {
-        var funcEnv = Environment.GetEnvironmentVariable(Constants.LambdaFunctionNameEnv);
-        _functionName = funcEnv ?? "testFunction";
-        if (!string.IsNullOrWhiteSpace(functionName))
+        if (!string.IsNullOrEmpty(keyPrefix))
         {
-            _functionName += "." + functionName;
+            _functionName = keyPrefix;
         }
+        else
+        {
+            var funcEnv = Environment.GetEnvironmentVariable(Constants.LambdaFunctionNameEnv);
+
+            _functionName = funcEnv ?? "testFunction";
+            if (!string.IsNullOrWhiteSpace(functionName))
+            {
+                _functionName += "." + functionName;
+            }
+        }
+
         _idempotencyOptions = idempotencyOptions;
-        
+
         if (!string.IsNullOrWhiteSpace(_idempotencyOptions.PayloadValidationJmesPath))
         {
             PayloadValidationEnabled = true;
         }
-        
+
         var useLocalCache = _idempotencyOptions.UseLocalCache;
         if (useLocalCache)
         {
             _cache = new LRUCache<string, DataRecord>(_idempotencyOptions.LocalCacheMaxItems);
         }
     }
-    
+
     /// <summary>
     /// For test purpose only (adding a cache to mock)
     /// </summary>
-    internal void Configure(IdempotencyOptions options, string functionName, LRUCache<string, DataRecord> cache)
+    internal void Configure(IdempotencyOptions options, string functionName, string keyPrefix,
+        LRUCache<string, DataRecord> cache)
     {
-        Configure(options, functionName);
+        Configure(options, functionName, keyPrefix);
         _cache = cache;
     }
 
@@ -118,12 +130,12 @@ public abstract class BasePersistenceStore : IPersistenceStore
     public virtual async Task SaveInProgress(JsonDocument data, DateTimeOffset now, double? remainingTimeInMs)
     {
         var idempotencyKey = GetHashedIdempotencyKey(data);
-        
+
         if (RetrieveFromCache(idempotencyKey, now) != null)
         {
             throw new IdempotencyItemAlreadyExistsException();
         }
-        
+
         long? inProgressExpirationMsTimestamp = null;
         if (remainingTimeInMs.HasValue)
         {
@@ -137,11 +149,10 @@ public abstract class BasePersistenceStore : IPersistenceStore
             null,
             GetHashedPayload(data),
             inProgressExpirationMsTimestamp
-            
         );
         await PutRecord(record, now);
     }
-    
+
     /// <summary>
     /// Delete record from the persistence store
     /// </summary>
@@ -152,14 +163,14 @@ public abstract class BasePersistenceStore : IPersistenceStore
         var idemPotencyKey = GetHashedIdempotencyKey(data);
 
         Console.WriteLine("Function raised an exception {0}. " +
-                  "Clearing in progress record in persistence store for idempotency key: {1}",
+                          "Clearing in progress record in persistence store for idempotency key: {1}",
             throwable.GetType().Name,
             idemPotencyKey);
 
         await DeleteRecord(idemPotencyKey);
         DeleteFromCache(idemPotencyKey);
     }
-    
+
     /// <summary>
     /// Retrieve idempotency key for data provided, fetch from persistence store, and convert to DataRecord.
     /// </summary>
@@ -182,7 +193,7 @@ public abstract class BasePersistenceStore : IPersistenceStore
         ValidatePayload(data, record);
         return record;
     }
-    
+
     /// <summary>
     /// Save data_record to local cache except when status is "INPROGRESS"
     /// NOTE: We can't cache "INPROGRESS" records as we have no way to reflect updates that can happen outside of the
@@ -198,7 +209,7 @@ public abstract class BasePersistenceStore : IPersistenceStore
 
         _cache.Set(dataRecord.IdempotencyKey, dataRecord);
     }
-    
+
     /// <summary>
     /// Validate that the hashed payload matches data provided and stored data record
     /// </summary>
@@ -215,7 +226,7 @@ public abstract class BasePersistenceStore : IPersistenceStore
             throw new IdempotencyValidationException("Payload does not match stored record for this event key");
         }
     }
-    
+
     /// <summary>
     /// Retrieve data record from cache
     /// </summary>
@@ -228,14 +239,15 @@ public abstract class BasePersistenceStore : IPersistenceStore
             return null;
 
         if (!_cache.TryGet(idempotencyKey, out var record) || record == null) return null;
-        if (!record.IsExpired(now)) 
+        if (!record.IsExpired(now))
         {
             return record;
         }
+
         DeleteFromCache(idempotencyKey);
         return null;
     }
-    
+
     /// <summary>
     /// Deletes item from cache
     /// </summary>
@@ -244,10 +256,10 @@ public abstract class BasePersistenceStore : IPersistenceStore
     {
         if (!_idempotencyOptions.UseLocalCache)
             return;
-        
+
         _cache.Delete(idempotencyKey);
     }
-    
+
     /// <summary>
     /// Extract payload using validation key jmespath and return a hashed representation
     /// </summary>
@@ -259,12 +271,12 @@ public abstract class BasePersistenceStore : IPersistenceStore
         {
             return "";
         }
-        
+
         var transformer = JsonTransformer.Parse(_idempotencyOptions.PayloadValidationJmesPath);
         var result = transformer.Transform(data.RootElement);
         return GenerateHash(result.RootElement);
     }
-    
+
     /// <summary>
     /// Calculate unix timestamp of expiry date for idempotency record
     /// </summary>
@@ -285,7 +297,7 @@ public abstract class BasePersistenceStore : IPersistenceStore
     {
         var node = data.RootElement;
         var eventKeyJmesPath = _idempotencyOptions.EventKeyJmesPath;
-        if (eventKeyJmesPath != null) 
+        if (eventKeyJmesPath != null)
         {
             var transformer = JsonTransformer.Parse(eventKeyJmesPath);
             var result = transformer.Transform(node);
@@ -298,7 +310,9 @@ public abstract class BasePersistenceStore : IPersistenceStore
             {
                 throw new IdempotencyKeyException("No data found to create a hashed idempotency key");
             }
-            Console.WriteLine("No data found to create a hashed idempotency key. JMESPath: {0}", _idempotencyOptions.EventKeyJmesPath ?? string.Empty);
+
+            Console.WriteLine("No data found to create a hashed idempotency key. JMESPath: {0}",
+                _idempotencyOptions.EventKeyJmesPath ?? string.Empty);
         }
 
         var hash = GenerateHash(node);
@@ -313,9 +327,10 @@ public abstract class BasePersistenceStore : IPersistenceStore
     private static bool IsMissingIdempotencyKey(JsonElement data)
     {
         return data.ValueKind == JsonValueKind.Null || data.ValueKind == JsonValueKind.Undefined
-            || (data.ValueKind == JsonValueKind.String && data.ToString() == string.Empty);
+                                                    || (data.ValueKind == JsonValueKind.String &&
+                                                        data.ToString() == string.Empty);
     }
-    
+
     /// <summary>
     /// Generate a hash value from the provided data
     /// </summary>
@@ -328,16 +343,16 @@ public abstract class BasePersistenceStore : IPersistenceStore
         // starting .NET 8 no option to change hash algorithm
         using var hashAlgorithm = MD5.Create();
 #else
-
         using var hashAlgorithm = HashAlgorithm.Create(_idempotencyOptions.HashFunction);
 #endif
         if (hashAlgorithm == null)
         {
             throw new ArgumentException("Invalid HashAlgorithm");
         }
+
         var stringToHash = data.ToString();
         var hash = GetHash(hashAlgorithm, stringToHash);
-        
+
         return hash;
     }
 
@@ -351,18 +366,18 @@ public abstract class BasePersistenceStore : IPersistenceStore
     {
         // Convert the input string to a byte array and compute the hash.
         var data = hashAlgorithm.ComputeHash(Encoding.UTF8.GetBytes(input));
-        
+
         // Create a new Stringbuilder to collect the bytes
         // and create a string.
         var sBuilder = new StringBuilder();
-        
+
         // Loop through each byte of the hashed data
         // and format each one as a hexadecimal string.
         for (var i = 0; i < data.Length; i++)
         {
             sBuilder.Append(data[i].ToString("x2"));
         }
-        
+
         // Return the hexadecimal string.
         return sBuilder.ToString();
     }

--- a/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Handlers/IdempotencyAttributeWithCustomKeyPrefix.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Handlers/IdempotencyAttributeWithCustomKeyPrefix.cs
@@ -1,0 +1,21 @@
+using System;
+using Amazon.Lambda.Core;
+
+namespace AWS.Lambda.Powertools.Idempotency.Tests.Handlers;
+
+/// <summary>
+/// Simple Lambda function with Idempotent attribute on a sub method with a custom prefix key
+/// </summary>
+public class IdempotencyAttributeWithCustomKeyPrefix
+{
+    public string HandleRequest(string input, ILambdaContext context) 
+    {
+        return ReturnGuid(input);
+    }
+
+    [Idempotent(KeyPrefix = "MyMethod")]
+    private string ReturnGuid(string p)
+    {
+        return Guid.NewGuid().ToString();
+    }
+}

--- a/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Handlers/IdempotencyFunctionMethodDecorated.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Handlers/IdempotencyFunctionMethodDecorated.cs
@@ -13,7 +13,6 @@
  * permissions and limitations under the License.
  */
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
@@ -22,7 +21,6 @@ using System.Threading.Tasks;
 using Amazon.DynamoDBv2;
 using Amazon.Lambda.APIGatewayEvents;
 using Amazon.Lambda.Core;
-using AWS.Lambda.Powertools.Idempotency.Tests.Model;
 
 namespace AWS.Lambda.Powertools.Idempotency.Tests.Handlers;
 
@@ -34,9 +32,6 @@ public class IdempotencyFunctionMethodDecorated
     {
         Idempotency.Configure(builder =>
             builder
-#if NET8_0_OR_GREATER
-                .WithJsonSerializationContext(TestJsonSerializerContext.Default)
-#endif
                 .UseDynamoDb(storeBuilder =>
                     storeBuilder
                         .WithTableName("idempotency_table")

--- a/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Handlers/IdempotencyHandlerWithCustomKeyPrefix.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Handlers/IdempotencyHandlerWithCustomKeyPrefix.cs
@@ -1,0 +1,16 @@
+using System;
+using Amazon.Lambda.Core;
+
+namespace AWS.Lambda.Powertools.Idempotency.Tests.Handlers;
+
+/// <summary>
+/// Simple Lambda function with Idempotent on handler with a custom prefix key
+/// </summary>
+public class IdempotencyHandlerWithCustomKeyPrefix
+{
+    [Idempotent(KeyPrefix = "MyHandler")]
+    public string HandleRequest(string input, ILambdaContext context)
+    {
+        return Guid.NewGuid().ToString();
+    }
+}

--- a/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Internal/IdempotentAspectTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Internal/IdempotentAspectTests.cs
@@ -353,7 +353,7 @@ public class IdempotentAspectTests : IDisposable
     }
 
     [Fact]
-    public void Handle_WhenIdempotencyOnSubMethodAnnotated_AndKeyJMESPath_ShouldPutInStoreWithKey()
+    public async Task Handle_WhenIdempotencyOnSubMethodAnnotated_AndKeyJMESPath_ShouldPutInStoreWithKey()
     {
         // Arrange
         var store = new InMemoryPersistenceStore();
@@ -373,7 +373,46 @@ public class IdempotentAspectTests : IDisposable
 
         // Assert
         // a1d0c6e83f027327d8461063f4ac58a6 = MD5(42)
-        store.GetRecord("testFunction.createBasket#a1d0c6e83f027327d8461063f4ac58a6").Should().NotBeNull();
+        var record = await store.GetRecord("testFunction.CreateBasket#a1d0c6e83f027327d8461063f4ac58a6");
+        Assert.NotNull(record);
+    }
+    
+    [Fact]
+    public async Task WhenIdempotency_Custom_Prefix_Key_Handler()
+    {
+        // Arrange
+        var store = new InMemoryPersistenceStore();
+        Idempotency.Configure(builder =>
+            builder
+                .WithPersistenceStore(store));
+
+        // Act
+        var function = new IdempotencyHandlerWithCustomKeyPrefix();
+        function.HandleRequest("42", new TestLambdaContext());
+
+        // Assert
+        // a1d0c6e83f027327d8461063f4ac58a6 = MD5(42)
+        var record = await store.GetRecord("MyHandler#a1d0c6e83f027327d8461063f4ac58a6");
+        Assert.NotNull(record);
+    }
+    
+    [Fact]
+    public async Task WhenIdempotency_Custom_Prefix_Key_Method()
+    {
+        // Arrange
+        var store = new InMemoryPersistenceStore();
+        Idempotency.Configure(builder =>
+            builder
+                .WithPersistenceStore(store));
+
+        // Act
+        var function = new IdempotencyAttributeWithCustomKeyPrefix();
+        function.HandleRequest("42", new TestLambdaContext());
+
+        // Assert
+        // a1d0c6e83f027327d8461063f4ac58a6 = MD5(42)
+        var record = await store.GetRecord("MyMethod#a1d0c6e83f027327d8461063f4ac58a6");
+        Assert.NotNull(record);
     }
 
     [Fact]

--- a/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Persistence/BasePersistenceStoreTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Persistence/BasePersistenceStoreTests.cs
@@ -78,7 +78,7 @@ public class BasePersistenceStoreTests
         var persistenceStore = new InMemoryPersistenceStore();
         var request = LoadApiGatewayProxyRequest();
 
-        persistenceStore.Configure(new IdempotencyOptionsBuilder().Build(), null);
+        persistenceStore.Configure(new IdempotencyOptionsBuilder().Build(), null, null);
 
         var now = DateTimeOffset.UtcNow;
 
@@ -102,7 +102,7 @@ public class BasePersistenceStoreTests
         var persistenceStore = new InMemoryPersistenceStore();
         var request = LoadApiGatewayProxyRequest();
 
-        persistenceStore.Configure(new IdempotencyOptionsBuilder().Build(), null);
+        persistenceStore.Configure(new IdempotencyOptionsBuilder().Build(), null, null);
 
         var now = DateTimeOffset.UtcNow;
         var lambdaTimeoutMs = 30000;
@@ -130,7 +130,7 @@ public class BasePersistenceStoreTests
 
         persistenceStore.Configure(new IdempotencyOptionsBuilder()
             .WithEventKeyJmesPath("powertools_json(Body).id")
-            .Build(), "myfunc");
+            .Build(), "myfunc", null);
 
         var now = DateTimeOffset.UtcNow;
 
@@ -157,7 +157,7 @@ public class BasePersistenceStoreTests
 
         persistenceStore.Configure(new IdempotencyOptionsBuilder()
             .WithEventKeyJmesPath("powertools_json(Body).[id, message]") //[43876123454654,"Lambda rocks"]
-            .Build(), "myfunc");
+            .Build(), "myfunc", null);
 
         var now = DateTimeOffset.UtcNow;
 
@@ -185,7 +185,7 @@ public class BasePersistenceStoreTests
         persistenceStore.Configure(new IdempotencyOptionsBuilder()
             .WithEventKeyJmesPath("unavailable")
             .WithThrowOnNoIdempotencyKey(true) // should throw
-            .Build(), "");
+            .Build(), "", null);
         var now = DateTimeOffset.UtcNow;
 
         // Act
@@ -209,7 +209,7 @@ public class BasePersistenceStoreTests
 
         persistenceStore.Configure(new IdempotencyOptionsBuilder()
             .WithEventKeyJmesPath("unavailable")
-            .Build(), "");
+            .Build(), "", null);
 
         var now = DateTimeOffset.UtcNow;
 
@@ -233,7 +233,7 @@ public class BasePersistenceStoreTests
         persistenceStore.Configure(new IdempotencyOptionsBuilder()
             .WithUseLocalCache(true)
             .WithEventKeyJmesPath("powertools_json(Body).id")
-            .Build(), null, cache);
+            .Build(), null, null, cache);
 
         var now = DateTimeOffset.UtcNow;
         cache.Set("testFunction#2fef178cc82be5ce3da6c5e0466a6182",
@@ -266,7 +266,7 @@ public class BasePersistenceStoreTests
             .WithEventKeyJmesPath("powertools_json(Body).id")
             .WithUseLocalCache(true)
             .WithExpiration(TimeSpan.FromSeconds(2))
-            .Build(), null, cache);
+            .Build(), null, null, cache);
 
         var now = DateTimeOffset.UtcNow;
         cache.Set("testFunction#2fef178cc82be5ce3da6c5e0466a6182",
@@ -296,7 +296,7 @@ public class BasePersistenceStoreTests
         var persistenceStore = new InMemoryPersistenceStore();
         var request = LoadApiGatewayProxyRequest();
         LRUCache<string, DataRecord> cache = new(2);
-        persistenceStore.Configure(new IdempotencyOptionsBuilder().Build(), null, cache);
+        persistenceStore.Configure(new IdempotencyOptionsBuilder().Build(), null, null, cache);
 
         var product = new Product(34543, "product", 42);
 
@@ -325,7 +325,7 @@ public class BasePersistenceStoreTests
         LRUCache<string, DataRecord> cache = new(2);
 
         persistenceStore.Configure(new IdempotencyOptionsBuilder()
-            .WithUseLocalCache(true).Build(), null, cache);
+            .WithUseLocalCache(true).Build(), null, null, cache);
 
         var product = new Product(34543, "product", 42);
         var now = DateTimeOffset.UtcNow;
@@ -355,7 +355,7 @@ public class BasePersistenceStoreTests
         var request = LoadApiGatewayProxyRequest();
 
         LRUCache<string, DataRecord> cache = new(2);
-        persistenceStore.Configure(new IdempotencyOptionsBuilder().Build(), "myfunc", cache);
+        persistenceStore.Configure(new IdempotencyOptionsBuilder().Build(), "myfunc", null, cache);
 
         var now = DateTimeOffset.UtcNow;
 
@@ -378,7 +378,7 @@ public class BasePersistenceStoreTests
         LRUCache<string, DataRecord> cache = new(2);
 
         persistenceStore.Configure(new IdempotencyOptionsBuilder()
-            .WithUseLocalCache(true).Build(), "myfunc", cache);
+            .WithUseLocalCache(true).Build(), "myfunc", null, cache);
 
         var now = DateTimeOffset.UtcNow;
         var dr = new DataRecord(
@@ -407,7 +407,7 @@ public class BasePersistenceStoreTests
         var request = LoadApiGatewayProxyRequest();
         LRUCache<string, DataRecord> cache = new(2);
         persistenceStore.Configure(new IdempotencyOptionsBuilder()
-            .WithUseLocalCache(true).Build(), "myfunc", cache);
+            .WithUseLocalCache(true).Build(), "myfunc", null, cache);
 
         var now = DateTimeOffset.UtcNow;
         var dr = new DataRecord(
@@ -440,7 +440,7 @@ public class BasePersistenceStoreTests
                 .WithEventKeyJmesPath("powertools_json(Body).id")
                 .WithPayloadValidationJmesPath("powertools_json(Body).message")
                 .Build(),
-            "myfunc");
+            "myfunc", null);
 
         var now = DateTimeOffset.UtcNow;
 
@@ -459,7 +459,7 @@ public class BasePersistenceStoreTests
         var persistenceStore = new InMemoryPersistenceStore();
         var request = LoadApiGatewayProxyRequest();
 
-        persistenceStore.Configure(new IdempotencyOptionsBuilder().Build(), null);
+        persistenceStore.Configure(new IdempotencyOptionsBuilder().Build(), null, null);
 
         // Act
         await persistenceStore.DeleteRecord(JsonSerializer.SerializeToDocument(request)!, new ArithmeticException());
@@ -476,7 +476,7 @@ public class BasePersistenceStoreTests
         var request = LoadApiGatewayProxyRequest();
         LRUCache<string, DataRecord> cache = new(2);
         persistenceStore.Configure(new IdempotencyOptionsBuilder()
-            .WithUseLocalCache(true).Build(), null, cache);
+            .WithUseLocalCache(true).Build(), null, null, cache);
 
         cache.Set("testFunction#5eff007a9ed2789a9f9f6bc182fc6ae6",
             new DataRecord("testFunction#5eff007a9ed2789a9f9f6bc182fc6ae6",
@@ -497,7 +497,7 @@ public class BasePersistenceStoreTests
     {
         // Arrange
         var persistenceStore = new InMemoryPersistenceStore();
-        persistenceStore.Configure(new IdempotencyOptionsBuilder().Build(), null);
+        persistenceStore.Configure(new IdempotencyOptionsBuilder().Build(), null, null);
         var expectedHash = "70c24d88041893f7fbab4105b76fd9e1"; // MD5(Lambda rocks)
 
         // Act
@@ -513,7 +513,7 @@ public class BasePersistenceStoreTests
     {
         // Arrange
         var persistenceStore = new InMemoryPersistenceStore();
-        persistenceStore.Configure(new IdempotencyOptionsBuilder().Build(), null);
+        persistenceStore.Configure(new IdempotencyOptionsBuilder().Build(), null, null);
         var product = new Product(42, "Product", 12);
         var expectedHash = "c83e720b399b3b4898c8734af177c53a"; // MD5({"Id":42,"Name":"Product","Price":12})
 
@@ -530,7 +530,7 @@ public class BasePersistenceStoreTests
     {
         // Arrange
         var persistenceStore = new InMemoryPersistenceStore();
-        persistenceStore.Configure(new IdempotencyOptionsBuilder().Build(), null);
+        persistenceStore.Configure(new IdempotencyOptionsBuilder().Build(), null, null);
         var expectedHash = "bb84c94278119c8838649706df4db42b"; // MD5(256.42)
 
         // Act
@@ -538,6 +538,27 @@ public class BasePersistenceStoreTests
 
         // Assert
         generatedHash.Should().Be(expectedHash);
+    }
+    
+    [Fact]
+    public async Task When_Key_Prefix_Set_Should_Create_With_Prefix()
+    {
+        // Arrange
+        var persistenceStore = new InMemoryPersistenceStore();
+        var request = LoadApiGatewayProxyRequest();
+
+        persistenceStore.Configure(new IdempotencyOptionsBuilder()
+            .WithEventKeyJmesPath("powertools_json(Body).id")
+            .Build(), "myfunc", "MyCustomPrefixKey");
+
+        var now = DateTimeOffset.UtcNow;
+
+        // Act
+        await persistenceStore.SaveInProgress(JsonSerializer.SerializeToDocument(request)!, now, null);
+
+        // Assert
+        var dr = persistenceStore.DataRecord;
+        dr.IdempotencyKey.Should().Be("MyCustomPrefixKey#2fef178cc82be5ce3da6c5e0466a6182");
     }
 
     private static APIGatewayProxyRequest LoadApiGatewayProxyRequest()

--- a/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Persistence/DynamoDBPersistenceStoreTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Persistence/DynamoDBPersistenceStoreTests.cs
@@ -42,7 +42,7 @@ public class DynamoDbPersistenceStoreTests : IClassFixture<DynamoDbFixture>
             .WithTableName(_tableName)
             .WithDynamoDBClient(_client)
             .Build();
-        _dynamoDbPersistenceStore.Configure(new IdempotencyOptionsBuilder().Build(),functionName: null);
+        _dynamoDbPersistenceStore.Configure(new IdempotencyOptionsBuilder().Build(),functionName: null, keyPrefix: null);
     }
     
     //putRecord
@@ -281,7 +281,7 @@ public class DynamoDbPersistenceStoreTests : IClassFixture<DynamoDbFixture>
         });
         // enable payload validation
         _dynamoDbPersistenceStore.Configure(new IdempotencyOptionsBuilder().WithPayloadValidationJmesPath("path").Build(),
-            null);
+            null, null);
 
         // Act
         expiry = now.AddSeconds(3600).ToUnixTimeSeconds();
@@ -367,7 +367,7 @@ public class DynamoDbPersistenceStoreTests : IClassFixture<DynamoDbFixture>
                 .WithStatusAttr("state")
                 .WithValidationAttr("valid")
                 .Build();
-            persistenceStore.Configure(new IdempotencyOptionsBuilder().Build(),functionName: null);
+            persistenceStore.Configure(new IdempotencyOptionsBuilder().Build(),functionName: null, keyPrefix: null);
 
             var now = DateTimeOffset.UtcNow;
             var record = new DataRecord(

--- a/libraries/tests/e2e/functions/idempotency/Function/src/Function/Function.cs
+++ b/libraries/tests/e2e/functions/idempotency/Function/src/Function/Function.cs
@@ -71,3 +71,21 @@ namespace IdempotencyPayloadSubsetTest
         }
     }
 }
+
+namespace CustomKeyPrefixTest
+{
+    public class Function
+    {
+        public Function()
+        {
+            var tableName = Environment.GetEnvironmentVariable("IDEMPOTENCY_TABLE_NAME");
+            Idempotency.Configure(builder => builder.UseDynamoDb(tableName));
+        }
+    
+        [Idempotent(KeyPrefix = "MyCustomKeyPrefix")]
+        public APIGatewayProxyResponse FunctionHandler(APIGatewayProxyRequest apigwProxyEvent, ILambdaContext context)
+        {
+            return TestHelper.TestMethod(apigwProxyEvent);
+        }
+    }
+}


### PR DESCRIPTION
> Please provide the issue number

Issue number: #703 

## Summary

### Changes

This pull request introduces a new feature to allow custom prefixes for idempotency keys in the Idempotency utility. The changes include updates to the `IdempotentAttribute` class, the `IdempotencyAspectHandler` class, and various test cases to support and validate the new feature (including E2E tests).

### New Feature: Custom Prefix for Idempotency Key

* [`libraries/src/AWS.Lambda.Powertools.Idempotency/IdempotentAttribute.cs`](diffhunk://#diff-1002d76904dc2293f745444219cc63cf11a6168b1196193c23a64300d56ec192R66-R70): Added a `KeyPrefix` property to the `IdempotentAttribute` class to allow custom prefixes for idempotency keys. Updated the `WrapSync` and `WrapAsync` methods to pass the `KeyPrefix` to the `IdempotencyAspectHandler`. [[1]](diffhunk://#diff-1002d76904dc2293f745444219cc63cf11a6168b1196193c23a64300d56ec192R66-R70) [[2]](diffhunk://#diff-1002d76904dc2293f745444219cc63cf11a6168b1196193c23a64300d56ec192L93-R98) [[3]](diffhunk://#diff-1002d76904dc2293f745444219cc63cf11a6168b1196193c23a64300d56ec192L131-R136)

* [`libraries/src/AWS.Lambda.Powertools.Idempotency/Internal/IdempotencyAspectHandler.cs`](diffhunk://#diff-9e6a57c4e3678d11fe15ba636f5f9a1ea4c599e20f4e1c1fa52679deca8f7db3R53-R67): Modified the constructor of `IdempotencyAspectHandler` to accept a `keyPrefix` parameter and updated the `Configure` method of the persistence store to use the `keyPrefix` if provided.

### Persistence Store Configuration

* [`libraries/src/AWS.Lambda.Powertools.Idempotency/Persistence/BasePersistenceStore.cs`](diffhunk://#diff-0943fa12a0a4f3d46bca7882bb2252ef4ea4ea9c83c739144d84b2c3fc7dfeffL60-R78): Updated the `Configure` method to handle the new `keyPrefix` parameter. If the `keyPrefix` is provided, it is used as the function name; otherwise, the environment variable or default value is used. [[1]](diffhunk://#diff-0943fa12a0a4f3d46bca7882bb2252ef4ea4ea9c83c739144d84b2c3fc7dfeffL60-R78) [[2]](diffhunk://#diff-0943fa12a0a4f3d46bca7882bb2252ef4ea4ea9c83c739144d84b2c3fc7dfeffL85-R99)

### Test Cases

* Added new test cases to validate the custom prefix functionality:
  * [`libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Handlers/IdempotencyAttributeWithCustomKeyPrefix.cs`](diffhunk://#diff-f9bf990a9f472f8e49e2b45b35d984156dd0d1574168da4bf056be066d21f43aR1-R21): Added a new handler to test idempotency with a custom key prefix on a method.
  * [`libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Handlers/IdempotencyHandlerWithCustomKeyPrefix.cs`](diffhunk://#diff-ee9e1a656e94578efddfe20878c43d402a334d8d48dc46b5488289b36d822396R1-R16): Added a new handler to test idempotency with a custom key prefix on a handler.
  * [`libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Internal/IdempotentAspectTests.cs`](diffhunk://#diff-4fac1d17624c4b9c420eabb554a0f6a7f756097df105fab54ca1bb2b01122088L376-R415): Added new test methods to validate the custom prefix key functionality for both handlers and methods.

* Updated existing test cases to include the `keyPrefix` parameter where necessary:
  * [`libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Persistence/BasePersistenceStoreTests.cs`](diffhunk://#diff-3cc9f8409b53bd3d9878f2bb5d6a49ec56f41e81ad1ccc35b9d93e1bdb6f9417L81-R81): Updated various test methods to pass the `keyPrefix` parameter to the `Configure` method. [[1]](diffhunk://#diff-3cc9f8409b53bd3d9878f2bb5d6a49ec56f41e81ad1ccc35b9d93e1bdb6f9417L81-R81) [[2]](diffhunk://#diff-3cc9f8409b53bd3d9878f2bb5d6a49ec56f41e81ad1ccc35b9d93e1bdb6f9417L105-R105) [[3]](diffhunk://#diff-3cc9f8409b53bd3d9878f2bb5d6a49ec56f41e81ad1ccc35b9d93e1bdb6f9417L133-R133) [[4]](diffhunk://#diff-3cc9f8409b53bd3d9878f2bb5d6a49ec56f41e81ad1ccc35b9d93e1bdb6f9417L160-R160) [[5]](diffhunk://#diff-3cc9f8409b53bd3d9878f2bb5d6a49ec56f41e81ad1ccc35b9d93e1bdb6f9417L188-R188) [[6]](diffhunk://#diff-3cc9f8409b53bd3d9878f2bb5d6a49ec56f41e81ad1ccc35b9d93e1bdb6f9417L212-R212) [[7]](diffhunk://#diff-3cc9f8409b53bd3d9878f2bb5d6a49ec56f41e81ad1ccc35b9d93e1bdb6f9417L236-R236) [[8]](diffhunk://#diff-3cc9f8409b53bd3d9878f2bb5d6a49ec56f41e81ad1ccc35b9d93e1bdb6f9417L269-R269) [[9]](diffhunk://#diff-3cc9f8409b53bd3d9878f2bb5d6a49ec56f41e81ad1ccc35b9d93e1bdb6f9417L299-R299)

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [ ] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
