### PR TITLE
chore: Metrics v2 always set namespace and service

### DIFF
--- a/libraries/src/AWS.Lambda.Powertools.Metrics/Metrics.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/Metrics.cs
@@ -180,8 +180,9 @@ public class Metrics : IMetrics, IDisposable
         Instance = this;
         _powertoolsConfigurations.SetExecutionEnvironment(this);
 
-        if (!string.IsNullOrEmpty(nameSpace)) SetNamespace(nameSpace);
-        if (!string.IsNullOrEmpty(service)) SetService(service);
+        // set namespace and service always
+        SetNamespace(nameSpace);
+        SetService(service);
     }
 
     /// <inheritdoc />
@@ -364,7 +365,19 @@ public class Metrics : IMetrics, IDisposable
 
         var context = new MetricsContext();
         context.SetNamespace(nameSpace ?? GetNamespace());
-        context.SetService(service ?? _context.GetService());
+        
+        var parsedService = !string.IsNullOrWhiteSpace(service)
+            ? service
+            : _powertoolsConfigurations.Service == "service_undefined"
+                ? null
+                : _powertoolsConfigurations.Service;
+        
+        // var serviceTodAdd = parsedService ?? _context.GetService();
+        if (!string.IsNullOrWhiteSpace(parsedService))
+        {
+            context.SetService(parsedService);
+            context.AddDimension("Service", parsedService);
+        }
 
         if (dimensions != null)
         {

--- a/libraries/src/AWS.Lambda.Powertools.Metrics/Metrics.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/Metrics.cs
@@ -372,7 +372,6 @@ public class Metrics : IMetrics, IDisposable
                 ? null
                 : _powertoolsConfigurations.Service;
         
-        // var serviceTodAdd = parsedService ?? _context.GetService();
         if (!string.IsNullOrWhiteSpace(parsedService))
         {
             context.SetService(parsedService);

--- a/libraries/tests/AWS.Lambda.Powertools.Metrics.AspNetCore.Tests/MetricsEndpointExtensionsTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Metrics.AspNetCore.Tests/MetricsEndpointExtensionsTests.cs
@@ -20,8 +20,7 @@ public class MetricsEndpointExtensionsTests : IDisposable
         var options = new MetricsOptions
         {
             CaptureColdStart = true,
-            Namespace = "TestNamespace",
-            Service = "TestService"
+            Namespace = "TestNamespace"
         };
         
         var conf = Substitute.For<IPowertoolsConfigurations>();
@@ -61,7 +60,6 @@ public class MetricsEndpointExtensionsTests : IDisposable
         {
             CaptureColdStart = true,
             Namespace = "TestNamespace",
-            Service = "TestService"
         };
         
         var conf = Substitute.For<IPowertoolsConfigurations>();
@@ -111,7 +109,6 @@ public class MetricsEndpointExtensionsTests : IDisposable
         {
             CaptureColdStart = true,
             Namespace = "TestNamespace",
-            Service = "TestService",
             DefaultDimensions = new Dictionary<string, string>
             {
                 { "Environment", "Prod" }

--- a/libraries/tests/AWS.Lambda.Powertools.Metrics.AspNetCore.Tests/MetricsMiddlewareExtensionsTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Metrics.AspNetCore.Tests/MetricsMiddlewareExtensionsTests.cs
@@ -21,7 +21,6 @@ public class MetricsMiddlewareExtensionsTests : IDisposable
         {
             CaptureColdStart = true,
             Namespace = "TestNamespace",
-            Service = "TestService"
         };
         
         var conf = Substitute.For<IPowertoolsConfigurations>();
@@ -59,7 +58,6 @@ public class MetricsMiddlewareExtensionsTests : IDisposable
         {
             CaptureColdStart = true,
             Namespace = "TestNamespace",
-            Service = "TestService"
         };
         
         var conf = Substitute.For<IPowertoolsConfigurations>();

--- a/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/EMFValidationTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/EMFValidationTests.cs
@@ -216,6 +216,12 @@ namespace AWS.Lambda.Powertools.Metrics.Tests
 
             // Assert
             Assert.Contains("\"CloudWatchMetrics\":[{\"Namespace\":\"EnvNamespace\",\"Metrics\":[{\"Name\":\"SingleMetric\",\"Unit\":\"Count\",\"StorageResolution\":1}],\"Dimensions\":[[\"Default\"]]}]},\"Default\":\"SingleMetric\",\"SingleMetric\":1}", metricsOutput);
+            
+            // assert with different service name
+            Assert.Contains("\"CloudWatchMetrics\":[{\"Namespace\":\"EnvNamespace\",\"Metrics\":[{\"Name\":\"SingleMetric2\",\"Unit\":\"Count\",\"StorageResolution\":1}],\"Dimensions\":[[\"Service\",\"Default\"]]}]},\"Service\":\"service1\",\"Default\":\"SingleMetric\",\"SingleMetric2\":1}", metricsOutput);
+            
+            // assert with different service name
+            Assert.Contains("\"CloudWatchMetrics\":[{\"Namespace\":\"EnvNamespace\",\"Metrics\":[{\"Name\":\"SingleMetric3\",\"Unit\":\"Count\",\"StorageResolution\":1}],\"Dimensions\":[[\"Service\",\"Default\"]]}]},\"Service\":\"service2\",\"Default\":\"SingleMetric\",\"SingleMetric3\":1}", metricsOutput);
         }
 
         [Trait("Category", "MetricsImplementation")]

--- a/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/Handlers/FunctionHandler.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/Handlers/FunctionHandler.cs
@@ -86,6 +86,18 @@ public class FunctionHandler
             dimensions: new Dictionary<string, string> {
                 { "Default", "SingleMetric" }
             });
+        
+        Metrics.PushSingleMetric("SingleMetric2", 1, MetricUnit.Count, resolution: MetricResolution.High,
+            service: "service1",
+            dimensions: new Dictionary<string, string> {
+                { "Default", "SingleMetric" }
+            });
+
+        Metrics.PushSingleMetric("SingleMetric3", 1, MetricUnit.Count, resolution: MetricResolution.High,
+            service: "service2",
+            dimensions: new Dictionary<string, string> {
+                { "Default", "SingleMetric" }
+            });
     }
 
     [Metrics(Namespace = "dotnet-powertools-test", Service = "testService")]

--- a/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/MetricsTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/MetricsTests.cs
@@ -234,7 +234,6 @@ public class MetricsTests
         {
             CaptureColdStart = true,
             Namespace = "dotnet-powertools-test",
-            Service = "testService",
             DefaultDimensions = new Dictionary<string, string>
             {
                 { "Environment", "Test" },
@@ -268,7 +267,6 @@ public class MetricsTests
         {
             CaptureColdStart = true,
             Namespace = "dotnet-powertools-test",
-            Service = "testService",
             DefaultDimensions = null
         };
 

--- a/libraries/tests/e2e/functions/core/metrics/Function/test/Function.Tests/FunctionTests.cs
+++ b/libraries/tests/e2e/functions/core/metrics/Function/test/Function.Tests/FunctionTests.cs
@@ -270,10 +270,14 @@ public class FunctionTests
         Assert.Equal("Count", unitElement.GetString());
 
         Assert.True(cloudWatchMetricsElement[0].TryGetProperty("Dimensions", out JsonElement dimensionsElement));
-        Assert.Equal("FunctionName", dimensionsElement[0][0].GetString());
+        Assert.Equal("Service", dimensionsElement[0][0].GetString());
+        Assert.Equal("FunctionName", dimensionsElement[0][1].GetString());
 
         Assert.True(root.TryGetProperty("FunctionName", out JsonElement functionNameElement));
         Assert.Equal(_functionName, functionNameElement.GetString());
+
+        Assert.True(root.TryGetProperty("Service", out JsonElement serviceElement));
+        Assert.Equal("Test", serviceElement.GetString());
 
         Assert.True(root.TryGetProperty("SingleMetric", out JsonElement singleMetricElement));
         Assert.Equal(1, singleMetricElement.GetInt32());


### PR DESCRIPTION
> Please provide the issue number

Issue number: #806 

## Summary

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [ ] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
