### PR TITLE
chore: Fix execution env verion and ConsoleWrapper for test mode

### DIFF
--- a/.github/workflows/publish-artifacts-examples-tests.yml
+++ b/.github/workflows/publish-artifacts-examples-tests.yml
@@ -79,6 +79,7 @@ jobs:
 
       # Ensure we preserve access to NuGet.org
       - name: Configure NuGet.org source
+        continue-on-error: true
         run: |
           dotnet nuget add source https://api.nuget.org/v3/index.json --name nuget.org
 

--- a/libraries/src/AWS.Lambda.Powertools.Common/Core/ConsoleWrapper.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Common/Core/ConsoleWrapper.cs
@@ -22,41 +22,77 @@ namespace AWS.Lambda.Powertools.Common;
 public class ConsoleWrapper : IConsoleWrapper
 {
     private static bool _override;
+    private static TextWriter _testOutputStream;
+    private static bool _outputResetPerformed = false;
+    private static bool _inTestMode = false;
 
     /// <inheritdoc />
     public void WriteLine(string message)
     {
-        OverrideLambdaLogger();
-        Console.WriteLine(message);
+        if (_inTestMode && _testOutputStream != null)
+        {
+            _testOutputStream.WriteLine(message);
+        }
+        else
+        {
+            EnsureConsoleOutputOnce();
+            Console.WriteLine(message);
+        }
     }
 
     /// <inheritdoc />
     public void Debug(string message)
     {
-        OverrideLambdaLogger();
-        System.Diagnostics.Debug.WriteLine(message);
+        if (_inTestMode && _testOutputStream != null)
+        {
+            _testOutputStream.WriteLine(message);
+        }
+        else
+        {
+            EnsureConsoleOutputOnce();
+            System.Diagnostics.Debug.WriteLine(message);
+        }
     }
 
     /// <inheritdoc />
     public void Error(string message)
     {
-        if (!_override)
+        if (_inTestMode && _testOutputStream != null)
         {
-            var errordOutput = new StreamWriter(Console.OpenStandardError());
-            errordOutput.AutoFlush = true;
-            Console.SetError(errordOutput);
+            _testOutputStream.WriteLine(message);
         }
-
-        Console.Error.WriteLine(message);
+        else
+        {
+            if (!_override)
+            {
+                var errordOutput = new StreamWriter(Console.OpenStandardError());
+                errordOutput.AutoFlush = true;
+                Console.SetError(errordOutput);
+            }
+            Console.Error.WriteLine(message);
+        }
     }
 
-    internal static void SetOut(StringWriter consoleOut)
+    /// <summary>
+    ///     Set the ConsoleWrapper to use a different TextWriter
+    ///     This is useful for unit tests where you want to capture the output
+    /// </summary>
+    public static void SetOut(TextWriter consoleOut)
     {
+        _testOutputStream = consoleOut;
+        _inTestMode = true;
         _override = true;
         Console.SetOut(consoleOut);
     }
     
-    private void OverrideLambdaLogger()
+    private static void EnsureConsoleOutputOnce()
+    {
+        if (_outputResetPerformed) return;
+        OverrideLambdaLogger();
+        _outputResetPerformed = true;
+    }
+    
+    private static void OverrideLambdaLogger()
     {
         if (_override)
         {
@@ -73,8 +109,22 @@ public class ConsoleWrapper : IConsoleWrapper
         Console.WriteLine($"{DateTime.UtcNow:yyyy-MM-ddTHH:mm:ss.fffZ}\t{logLevel}\t{message}");
     }
 
+    /// <summary>
+    ///     Reset the ConsoleWrapper to its original state
+    /// </summary>
     public static void ResetForTest()
     {
         _override = false;
+        _inTestMode = false;
+        _testOutputStream = null;
+        _outputResetPerformed = false;
+    }
+    
+    /// <summary>
+    ///     Clear the output reset flag
+    /// </summary>
+    public static void ClearOutputResetFlag()
+    {
+        _outputResetPerformed = false;
     }
 }

--- a/libraries/tests/AWS.Lambda.Powertools.BatchProcessing.Tests/Internal/BatchProcessingInternalTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.BatchProcessing.Tests/Internal/BatchProcessingInternalTests.cs
@@ -35,7 +35,7 @@ public class BatchProcessingInternalTests
         var sqsBatchProcessor = new SqsBatchProcessor(conf);
 
         // Assert
-        Assert.Equal($"{Constants.FeatureContextIdentifier}/BatchProcessing/1.0.0",
+        Assert.Equal($"{Constants.FeatureContextIdentifier}/BatchProcessing/{env.GetAssemblyVersion(this)}",
             env.GetEnvironmentVariable("AWS_EXECUTION_ENV"));
         
         Assert.NotNull(sqsBatchProcessor);
@@ -52,7 +52,7 @@ public class BatchProcessingInternalTests
         var KinesisEventBatchProcessor = new KinesisEventBatchProcessor(conf);
 
         // Assert
-        Assert.Equal($"{Constants.FeatureContextIdentifier}/BatchProcessing/1.0.0",
+        Assert.Equal($"{Constants.FeatureContextIdentifier}/BatchProcessing/{env.GetAssemblyVersion(this)}",
             env.GetEnvironmentVariable("AWS_EXECUTION_ENV"));
         
         Assert.NotNull(KinesisEventBatchProcessor);
@@ -69,7 +69,7 @@ public class BatchProcessingInternalTests
         var dynamoDbStreamBatchProcessor = new DynamoDbStreamBatchProcessor(conf);
 
         // Assert
-        Assert.Equal($"{Constants.FeatureContextIdentifier}/BatchProcessing/1.0.0",
+        Assert.Equal($"{Constants.FeatureContextIdentifier}/BatchProcessing/{env.GetAssemblyVersion(this)}",
             env.GetEnvironmentVariable("AWS_EXECUTION_ENV"));
         
         Assert.NotNull(dynamoDbStreamBatchProcessor);

--- a/libraries/tests/AWS.Lambda.Powertools.Common.Tests/ConsoleWrapperTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Common.Tests/ConsoleWrapperTests.cs
@@ -6,19 +6,28 @@ namespace AWS.Lambda.Powertools.Common.Tests;
 
 public class ConsoleWrapperTests : IDisposable
 {
+    private StringWriter _writer;
+
+    public ConsoleWrapperTests()
+    {
+        // Setup a new StringWriter for each test
+        _writer = new StringWriter();
+        // Reset static state for clean testing
+        ConsoleWrapper.ResetForTest();
+    }
+
     [Fact]
     public void WriteLine_Should_Write_To_Console()
     {
         // Arrange
         var consoleWrapper = new ConsoleWrapper();
-        var writer = new StringWriter();
-        ConsoleWrapper.SetOut(writer);
+        ConsoleWrapper.SetOut(_writer);
 
         // Act
         consoleWrapper.WriteLine("test message");
 
         // Assert
-        Assert.Equal($"test message{Environment.NewLine}", writer.ToString());
+        Assert.Equal($"test message{Environment.NewLine}", _writer.ToString());
     }
 
     [Fact]
@@ -26,16 +35,15 @@ public class ConsoleWrapperTests : IDisposable
     {
         // Arrange
         var consoleWrapper = new ConsoleWrapper();
-        var writer = new StringWriter();
-        ConsoleWrapper.SetOut(writer);
-        Console.SetError(writer);
+        ConsoleWrapper.SetOut(_writer);
+        Console.SetError(_writer);
 
         // Act
         consoleWrapper.Error("error message");
-        writer.Flush();
+        _writer.Flush();
 
         // Assert
-        Assert.Equal($"error message{Environment.NewLine}", writer.ToString());
+        Assert.Equal($"error message{Environment.NewLine}", _writer.ToString());
     }
 
     [Fact]
@@ -43,122 +51,91 @@ public class ConsoleWrapperTests : IDisposable
     {
         // Arrange
         var consoleWrapper = new ConsoleWrapper();
-        var writer = new StringWriter();
-        ConsoleWrapper.SetOut(writer);
+        ConsoleWrapper.SetOut(_writer);
 
         // Act
         consoleWrapper.WriteLine("test message");
 
         // Assert
-        Assert.Equal($"test message{Environment.NewLine}", writer.ToString());
+        Assert.Equal($"test message{Environment.NewLine}", _writer.ToString());
     }
 
     [Fact]
     public void OverrideLambdaLogger_Should_Override_Console_Out()
     {
-// Arrange
-        var originalOut = Console.Out;
-        try
-        {
-            var consoleWrapper = new ConsoleWrapper();
-            
-            // Act - create a custom StringWriter and set it after constructor 
-            // but before WriteLine (which triggers OverrideLambdaLogger)
-            var writer = new StringWriter();
-            ConsoleWrapper.SetOut(writer);
+        // Arrange
+        var consoleWrapper = new ConsoleWrapper();
+        ConsoleWrapper.SetOut(_writer);
 
-            consoleWrapper.WriteLine("test message");
+        // Act
+        consoleWrapper.WriteLine("test message");
 
-            // Assert
-            Assert.Equal($"test message{Environment.NewLine}", writer.ToString());
-        }
-        finally
-        {
-            // Restore original console out
-            ConsoleWrapper.ResetForTest();
-        }
+        // Assert
+        Assert.Equal($"test message{Environment.NewLine}", _writer.ToString());
     }
-    
-    [Fact]
-        public void WriteLine_WritesMessageToConsole()
-        {
-            // Arrange
-            var consoleWrapper = new ConsoleWrapper();
-            var originalOutput = Console.Out;
-            using var stringWriter = new StringWriter();
-            ConsoleWrapper.SetOut(stringWriter);
-            
-            try
-            {
-                // Act
-                consoleWrapper.WriteLine("Test message");
-                
-                // Assert
-                var output = stringWriter.ToString();
-                Assert.Contains("Test message", output);
-            }
-            finally
-            {
-                // Restore original output
-                ConsoleWrapper.ResetForTest();
-            }
-        }
-        
-        [Fact]
-        public void SetOut_OverridesConsoleOutput()
-        {
-            // Arrange
-            var originalOutput = Console.Out;
-            using var stringWriter = new StringWriter();
-            
-            try
-            {
-                // Act
-                typeof(ConsoleWrapper)
-                    .GetMethod("SetOut", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)
-                    ?.Invoke(null, new object[] { stringWriter });
-                
-                Console.WriteLine("Test override");
-                
-                // Assert
-                var output = stringWriter.ToString();
-                Assert.Contains("Test override", output);
-            }
-            finally
-            {
-                // Restore original output
-                ConsoleWrapper.ResetForTest();
-            }
-        }
-        
-        [Fact]
-        public void StaticWriteLine_FormatsLogMessageCorrectly()
-        {
-            // Arrange
-            var originalOutput = Console.Out;
-            using var stringWriter = new StringWriter();
-            ConsoleWrapper.SetOut(stringWriter);
-            
-            try
-            {
-                // Act
-                typeof(ConsoleWrapper)
-                    .GetMethod("WriteLine", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static, null, new[] { typeof(string), typeof(string) }, null)
-                    ?.Invoke(null, new object[] { "INFO", "Test log message" });
-                
-                // Assert
-                var output = stringWriter.ToString();
-                Assert.Matches(@"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\tINFO\tTest log message", output);
-            }
-            finally
-            {
-                // Restore original output
-                ConsoleWrapper.ResetForTest();
-            }
-        }
 
-        public void Dispose()
-        {
-            ConsoleWrapper.ResetForTest();
-        }
+    [Fact]
+    public void WriteLine_WritesMessageToConsole()
+    {
+        // Arrange
+        var consoleWrapper = new ConsoleWrapper();
+        ConsoleWrapper.SetOut(_writer);
+
+        // Act
+        consoleWrapper.WriteLine("Test message");
+
+        // Assert
+        var output = _writer.ToString();
+        Assert.Contains("Test message", output);
+    }
+
+    [Fact]
+    public void SetOut_OverridesConsoleOutput()
+    {
+        // Act
+        ConsoleWrapper.SetOut(_writer);
+        Console.WriteLine("Test override");
+
+        // Assert
+        var output = _writer.ToString();
+        Assert.Contains("Test override", output);
+    }
+
+    [Fact]
+    public void StaticWriteLine_FormatsLogMessageCorrectly()
+    {
+        // Arrange
+        ConsoleWrapper.SetOut(_writer);
+
+        // Act - Using reflection to call internal static method
+        typeof(ConsoleWrapper)
+            .GetMethod("WriteLine", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static, null, new[] { typeof(string), typeof(string) }, null)
+            ?.Invoke(null, new object[] { "INFO", "Test log message" });
+
+        // Assert
+        var output = _writer.ToString();
+        Assert.Matches(@"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\tINFO\tTest log message", output);
+    }
+
+    [Fact]
+    public void ClearOutputResetFlag_ResetsFlag()
+    {
+        // Arrange
+        var consoleWrapper = new ConsoleWrapper();
+        ConsoleWrapper.SetOut(_writer);
+        
+        // Act
+        consoleWrapper.WriteLine("First message"); // Should set the reset flag
+        ConsoleWrapper.ClearOutputResetFlag();
+        consoleWrapper.WriteLine("Second message"); // Should set it again
+        
+        // Assert
+        Assert.Equal($"First message{Environment.NewLine}Second message{Environment.NewLine}", _writer.ToString());
+    }
+
+    public void Dispose()
+    {
+        ConsoleWrapper.ResetForTest();
+        _writer?.Dispose();
+    }
 }

--- a/libraries/tests/AWS.Lambda.Powertools.Common.Tests/ConsoleWrapperTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Common.Tests/ConsoleWrapperTests.cs
@@ -109,7 +109,8 @@ public class ConsoleWrapperTests : IDisposable
 
         // Act - Using reflection to call internal static method
         typeof(ConsoleWrapper)
-            .GetMethod("WriteLine", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static, null, new[] { typeof(string), typeof(string) }, null)
+            .GetMethod("WriteLine", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static,
+                null, new[] { typeof(string), typeof(string) }, null)
             ?.Invoke(null, new object[] { "INFO", "Test log message" });
 
         // Assert
@@ -123,14 +124,71 @@ public class ConsoleWrapperTests : IDisposable
         // Arrange
         var consoleWrapper = new ConsoleWrapper();
         ConsoleWrapper.SetOut(_writer);
-        
+
         // Act
         consoleWrapper.WriteLine("First message"); // Should set the reset flag
         ConsoleWrapper.ClearOutputResetFlag();
         consoleWrapper.WriteLine("Second message"); // Should set it again
-        
+
         // Assert
         Assert.Equal($"First message{Environment.NewLine}Second message{Environment.NewLine}", _writer.ToString());
+    }
+
+    [Fact]
+    public void Debug_InTestMode_WritesToTestOutputStream()
+    {
+        // Arrange
+        var consoleWrapper = new ConsoleWrapper();
+        ConsoleWrapper.SetOut(_writer);
+
+        // Act
+        consoleWrapper.Debug("debug message");
+
+        // Assert
+        Assert.Equal($"debug message{Environment.NewLine}", _writer.ToString());
+    }
+
+    [Fact]
+    public void Debug_NotInTestMode_WritesToDebugConsole()
+    {
+        // Since capturing Debug output is difficult in a unit test
+        // We'll use a mock or just verify the path doesn't throw
+    
+        // Arrange
+        var consoleWrapper = new ConsoleWrapper();
+        ConsoleWrapper.ResetForTest(); // Ensure we're not in test mode
+
+        // Act & Assert - Just verify it doesn't throw
+        var exception = Record.Exception(() => consoleWrapper.Debug("debug message"));
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void Error_DoesNotThrowWhenNotOverridden()
+    {
+        // Arrange
+        var consoleWrapper = new ConsoleWrapper();
+        ConsoleWrapper.ResetForTest(); // Reset to ensure _override is false
+    
+        // Act & Assert - Just verify it doesn't throw
+        var exception = Record.Exception(() => consoleWrapper.Error("error without override"));
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void Error_UsesTestOutputStreamWhenInTestMode()
+    {
+        // Arrange
+        var consoleWrapper = new ConsoleWrapper();
+    
+        // Set test mode
+        ConsoleWrapper.SetOut(_writer);
+    
+        // Act
+        consoleWrapper.Error("error in test mode");
+
+        // Assert
+        Assert.Contains("error in test mode", _writer.ToString());
     }
 
     public void Dispose()

--- a/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Internal/IdempotentAspectTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Internal/IdempotentAspectTests.cs
@@ -272,7 +272,7 @@ public class IdempotentAspectTests : IDisposable
         var xRayRecorder = new Idempotency(conf);
 
         // Assert
-        Assert.Equal($"{Constants.FeatureContextIdentifier}/Idempotency/1.0.0",
+        Assert.Equal($"{Constants.FeatureContextIdentifier}/Idempotency/{env.GetAssemblyVersion(this)}",
             env.GetEnvironmentVariable("AWS_EXECUTION_ENV"));
 
         Assert.NotNull(xRayRecorder);

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/PowertoolsLoggerTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/PowertoolsLoggerTest.cs
@@ -1369,7 +1369,7 @@ namespace AWS.Lambda.Powertools.Logging.Tests
             logger.LogInformation("Test");
 
             // Assert
-            Assert.Equal($"{Constants.FeatureContextIdentifier}/Logging/1.0.0",
+            Assert.Equal($"{Constants.FeatureContextIdentifier}/Logging/{env.GetAssemblyVersion(this)}",
                 env.GetEnvironmentVariable("AWS_EXECUTION_ENV"));
         }
 

--- a/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/MetricsTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/MetricsTests.cs
@@ -24,7 +24,7 @@ public class MetricsTests
         _ = new Metrics(conf);
 
         // Assert
-        Assert.Equal($"{Constants.FeatureContextIdentifier}/Metrics/1.0.0",
+        Assert.Equal($"{Constants.FeatureContextIdentifier}/Metrics/{env.GetAssemblyVersion(this)}",
             env.GetEnvironmentVariable("AWS_EXECUTION_ENV"));
     }
 

--- a/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/XRayRecorderTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/XRayRecorderTests.cs
@@ -40,7 +40,7 @@ public class XRayRecorderTests
         var xRayRecorder = new XRayRecorder(awsXray, conf);
 
         // Assert
-        Assert.Equal($"{Constants.FeatureContextIdentifier}/Tracing/1.0.0",
+        Assert.Equal($"{Constants.FeatureContextIdentifier}/Tracing/{env.GetAssemblyVersion(this)}",
             env.GetEnvironmentVariable("AWS_EXECUTION_ENV"));
 
         Assert.NotNull(xRayRecorder);


### PR DESCRIPTION
> Please provide the issue number

Issue number: #839 

## Summary

### Changes

This pull request includes several changes to improve testing and logging functionality in the AWS Lambda Powertools library. The most important changes include enhancements to the `ConsoleWrapper` class for better testability, updates to unit tests to reflect these changes, and modifications to ensure the correct version is set in the execution environment context.
Updates to execution environment version for tests

### Enhancements to `ConsoleWrapper`:

* Added `_testOutputStream`, `_outputResetPerformed`, and `_inTestMode` fields to support test mode and ensure console output is correctly overridden during tests.
* Introduced the `SetOut` method to set a custom `TextWriter` for capturing output during tests.
* Added `ResetForTest` and `ClearOutputResetFlag` methods to reset the `ConsoleWrapper` state after tests.

### Unit test improvements:

* Updated `ConsoleWrapperTests` to use a `StringWriter` for capturing console output and reset the `ConsoleWrapper` state before each test.
* Modified tests to assert the correct version in the execution environment context for various components, including BatchProcessing, Idempotency, Logging, Metrics, and Tracing. [[1]](diffhunk://#diff-c8251f4208f8711a7fbd8fe56128556eb266c35f32f91bc8851191d2ce2e3be4L38-R38) [[2]](diffhunk://#diff-c8251f4208f8711a7fbd8fe56128556eb266c35f32f91bc8851191d2ce2e3be4L55-R55) [[3]](diffhunk://#diff-c8251f4208f8711a7fbd8fe56128556eb266c35f32f91bc8851191d2ce2e3be4L72-R72) [[4]](diffhunk://#diff-4fac1d17624c4b9c420eabb554a0f6a7f756097df105fab54ca1bb2b01122088L275-R275) [[5]](diffhunk://#diff-cbe4825d66808994c709a5cc492d0adb8130ebf385d28e5382634ecf1ad257e6L1372-R1372) [[6]](diffhunk://#diff-700853ede748ad6d6f561c20464ee061d53a1ef6a5e99c1980c9128fa9e7a7a8L27-R27) [[7]](diffhunk://#diff-f90f81a2d6c1b1286e2c3cf79138059ac686f1af4cbff524a911d7d0a3f40436L43-R43)

### Workflow configuration:

* Updated `.github/workflows/publish-artifacts-examples-tests.yml` to continue on error when configuring the NuGet.org source.
### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [ ] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
