### PR TITLE
chore: Remove version check from execution environment

### DIFF
--- a/libraries/tests/AWS.Lambda.Powertools.BatchProcessing.Tests/Internal/BatchProcessingInternalTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.BatchProcessing.Tests/Internal/BatchProcessingInternalTests.cs
@@ -35,7 +35,7 @@ public class BatchProcessingInternalTests
         var sqsBatchProcessor = new SqsBatchProcessor(conf);
 
         // Assert
-        Assert.Equal($"{Constants.FeatureContextIdentifier}/BatchProcessing/{env.GetAssemblyVersion(this)}",
+        Assert.Contains($"{Constants.FeatureContextIdentifier}/BatchProcessing/",
             env.GetEnvironmentVariable("AWS_EXECUTION_ENV"));
         
         Assert.NotNull(sqsBatchProcessor);
@@ -52,7 +52,7 @@ public class BatchProcessingInternalTests
         var KinesisEventBatchProcessor = new KinesisEventBatchProcessor(conf);
 
         // Assert
-        Assert.Equal($"{Constants.FeatureContextIdentifier}/BatchProcessing/{env.GetAssemblyVersion(this)}",
+        Assert.Contains($"{Constants.FeatureContextIdentifier}/BatchProcessing/",
             env.GetEnvironmentVariable("AWS_EXECUTION_ENV"));
         
         Assert.NotNull(KinesisEventBatchProcessor);
@@ -69,7 +69,7 @@ public class BatchProcessingInternalTests
         var dynamoDbStreamBatchProcessor = new DynamoDbStreamBatchProcessor(conf);
 
         // Assert
-        Assert.Equal($"{Constants.FeatureContextIdentifier}/BatchProcessing/{env.GetAssemblyVersion(this)}",
+        Assert.Contains($"{Constants.FeatureContextIdentifier}/BatchProcessing/",
             env.GetEnvironmentVariable("AWS_EXECUTION_ENV"));
         
         Assert.NotNull(dynamoDbStreamBatchProcessor);

--- a/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Internal/IdempotentAspectTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Internal/IdempotentAspectTests.cs
@@ -272,7 +272,7 @@ public class IdempotentAspectTests : IDisposable
         var xRayRecorder = new Idempotency(conf);
 
         // Assert
-        Assert.Equal($"{Constants.FeatureContextIdentifier}/Idempotency/{env.GetAssemblyVersion(this)}",
+        Assert.Contains($"{Constants.FeatureContextIdentifier}/Idempotency/",
             env.GetEnvironmentVariable("AWS_EXECUTION_ENV"));
 
         Assert.NotNull(xRayRecorder);

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/PowertoolsLoggerTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/PowertoolsLoggerTest.cs
@@ -1369,7 +1369,7 @@ namespace AWS.Lambda.Powertools.Logging.Tests
             logger.LogInformation("Test");
 
             // Assert
-            Assert.Equal($"{Constants.FeatureContextIdentifier}/Logging/{env.GetAssemblyVersion(this)}",
+            Assert.Contains($"{Constants.FeatureContextIdentifier}/Logging/",
                 env.GetEnvironmentVariable("AWS_EXECUTION_ENV"));
         }
 

--- a/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/MetricsTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/MetricsTests.cs
@@ -24,7 +24,7 @@ public class MetricsTests
         _ = new Metrics(conf);
 
         // Assert
-        Assert.Equal($"{Constants.FeatureContextIdentifier}/Metrics/{env.GetAssemblyVersion(this)}",
+        Assert.Contains($"{Constants.FeatureContextIdentifier}/Metrics/",
             env.GetEnvironmentVariable("AWS_EXECUTION_ENV"));
     }
 

--- a/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/XRayRecorderTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/XRayRecorderTests.cs
@@ -40,7 +40,7 @@ public class XRayRecorderTests
         var xRayRecorder = new XRayRecorder(awsXray, conf);
 
         // Assert
-        Assert.Equal($"{Constants.FeatureContextIdentifier}/Tracing/{env.GetAssemblyVersion(this)}",
+        Assert.Contains($"{Constants.FeatureContextIdentifier}/Tracing/",
             env.GetEnvironmentVariable("AWS_EXECUTION_ENV"));
 
         Assert.NotNull(xRayRecorder);


### PR DESCRIPTION
> Please provide the issue number

Issue number: #839 

## Summary

### Changes

Remove version check and do assert instead of equal

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [ ] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
