### PR TITLE
chore: Add AOT support Parameters utility

### DIFF
--- a/libraries/src/AWS.Lambda.Powertools.Parameters/Internal/Transform/JsonTransformer.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Parameters/Internal/Transform/JsonTransformer.cs
@@ -23,12 +23,31 @@ namespace AWS.Lambda.Powertools.Parameters.Internal.Transform;
 /// </summary>
 internal class JsonTransformer : ITransformer
 {
+    private readonly JsonSerializerOptions _options;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JsonTransformer"/> class.
+    /// </summary>
+    public JsonTransformer()
+    {
+        _options = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        };
+    }
+
     /// <summary>
     /// Deserialize a JSON value from a JSON string.
     /// </summary>
     /// <param name="value">JSON string.</param>
     /// <typeparam name="T">JSON value type.</typeparam>
     /// <returns>JSON value.</returns>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+        Justification = "Types are expected to be known at compile time")]
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+        Justification = "Types are expected to be preserved")]
+#endif
     public T? Transform<T>(string value)
     {
         if (typeof(T) == typeof(string))
@@ -37,6 +56,6 @@ internal class JsonTransformer : ITransformer
         if (string.IsNullOrWhiteSpace(value))
             return default;
 
-        return JsonSerializer.Deserialize<T>(value);
+        return JsonSerializer.Deserialize<T>(value, _options);
     }
 }

--- a/libraries/tests/AWS.Lambda.Powertools.Parameters.Tests/AppConfig/AppConfigProviderTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Parameters.Tests/AppConfig/AppConfigProviderTest.cs
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -32,6 +33,7 @@ using Xunit;
 
 namespace AWS.Lambda.Powertools.Parameters.Tests.AppConfig;
 
+[SuppressMessage("Usage", "xUnit1030:Do not call ConfigureAwait(false) in test method")]
 public class AppConfigProviderTest
 {
     [Fact]


### PR DESCRIPTION
> Please provide the issue number

Issue number: #878 

## Summary

### Changes

This pull request introduces enhancements to the `JsonTransformer` class to support case-insensitive JSON deserialization and updates related tests. The most important changes include adding a `JsonSerializerOptions` instance with case-insensitivity enabled, modifying the `Transform<T>` method to use these options, and suppressing specific warnings in both the implementation and test files.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [ ] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
