### PR TITLE
chore: update Kafka deserialization to use alias for ConsumerRecords

### DIFF
--- a/libraries/tests/AWS.Lambda.Powertools.Kafka.Tests/Avro/HandlerTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Kafka.Tests/Avro/HandlerTests.cs
@@ -5,6 +5,12 @@ using Avro.IO;
 using Avro.Specific;
 using AWS.Lambda.Powertools.Kafka.Avro;
 
+#if DEBUG
+using KafkaAlias = AWS.Lambda.Powertools.Kafka;
+#else
+using KafkaAlias = AWS.Lambda.Powertools.Kafka.Avro;
+#endif
+
 namespace AWS.Lambda.Powertools.Kafka.Tests.Avro;
 
 public class KafkaHandlerTests
@@ -21,7 +27,7 @@ public class KafkaHandlerTests
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(kafkaJson));
 
         // Act - Deserialize and process
-        var kafkaEvent = serializer.Deserialize<ConsumerRecords<int, AvroProduct>>(stream);
+        var kafkaEvent = serializer.Deserialize<KafkaAlias.ConsumerRecords<int, AvroProduct>>(stream);
         var response = await Handler(kafkaEvent, mockContext);
 
         // Assert
@@ -69,7 +75,7 @@ public class KafkaHandlerTests
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(kafkaJson));
 
         // Act - Deserialize and process
-        var kafkaEvent = serializer.Deserialize<ConsumerRecords<int, string>>(stream);
+        var kafkaEvent = serializer.Deserialize<KafkaAlias.ConsumerRecords<int, string>>(stream);
         var response = await HandlerSimple(kafkaEvent, mockContext);
 
         // Assert
@@ -240,7 +246,7 @@ public class KafkaHandlerTests
     }
 
     // Define the test handler method
-    private async Task<string> Handler(ConsumerRecords<int, AvroProduct> records, ILambdaContext context)
+    private async Task<string> Handler(KafkaAlias.ConsumerRecords<int, AvroProduct> records, ILambdaContext context)
     {
         foreach (var record in records)
         {
@@ -251,7 +257,7 @@ public class KafkaHandlerTests
         return "Successfully processed Kafka events";
     }
     
-    private async Task<string> HandlerSimple(ConsumerRecords<int, string> records, ILambdaContext context)
+    private async Task<string> HandlerSimple(KafkaAlias.ConsumerRecords<int, string> records, ILambdaContext context)
     {
         foreach (var record in records)
         {
@@ -274,7 +280,7 @@ public class KafkaHandlerTests
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(kafkaJson));
 
         // Act - Deserialize and process
-        var kafkaEvent = serializer.Deserialize<ConsumerRecords<AvroKey, AvroProduct>>(stream);
+        var kafkaEvent = serializer.Deserialize<KafkaAlias.ConsumerRecords<AvroKey, AvroProduct>>(stream);
         var response = await HandlerWithAvroKeys(kafkaEvent, mockContext);
 
         // Assert
@@ -394,7 +400,7 @@ public class KafkaHandlerTests
         return Convert.ToBase64String(stream.ToArray());
     }
 
-    private async Task<string> HandlerWithAvroKeys(ConsumerRecords<AvroKey, AvroProduct> records,
+    private async Task<string> HandlerWithAvroKeys(KafkaAlias.ConsumerRecords<AvroKey, AvroProduct> records,
         ILambdaContext context)
     {
         foreach (var record in records)

--- a/libraries/tests/AWS.Lambda.Powertools.Kafka.Tests/Avro/PowertoolsKafkaAvroSerializerTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Kafka.Tests/Avro/PowertoolsKafkaAvroSerializerTests.cs
@@ -2,6 +2,12 @@ using System.Runtime.Serialization;
 using System.Text;
 using AWS.Lambda.Powertools.Kafka.Avro;
 
+#if DEBUG
+using KafkaAlias = AWS.Lambda.Powertools.Kafka;
+#else
+using KafkaAlias = AWS.Lambda.Powertools.Kafka.Avro;
+#endif
+
 namespace AWS.Lambda.Powertools.Kafka.Tests.Avro;
 
 public class PowertoolsKafkaAvroSerializerTests
@@ -15,7 +21,7 @@ public class PowertoolsKafkaAvroSerializerTests
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(kafkaEventJson));
 
         // Act
-        var result = serializer.Deserialize<ConsumerRecords<int, AvroProduct>>(stream);
+        var result = serializer.Deserialize<KafkaAlias.ConsumerRecords<int, AvroProduct>>(stream);
 
         // Assert
         Assert.NotNull(result);
@@ -54,7 +60,7 @@ public class PowertoolsKafkaAvroSerializerTests
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(kafkaEventJson));
 
         // Act
-        var result = serializer.Deserialize<ConsumerRecords<int, AvroProduct>>(stream);
+        var result = serializer.Deserialize<KafkaAlias.ConsumerRecords<int, AvroProduct>>(stream);
 
         // Assert - Test enumeration
         int count = 0;
@@ -91,7 +97,7 @@ public class PowertoolsKafkaAvroSerializerTests
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(kafkaEventJson));
 
         // Act
-        var result = serializer.Deserialize<ConsumerRecords<string, string>>(stream);
+        var result = serializer.Deserialize<KafkaAlias.ConsumerRecords<string, string>>(stream);
         var firstRecord = result.First();
         Assert.Equal("Myvalue", firstRecord.Value);
         Assert.Equal("MyKey", firstRecord.Key);
@@ -113,7 +119,7 @@ public class PowertoolsKafkaAvroSerializerTests
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(kafkaEventJson));
 
         Assert.Throws<SerializationException>(() => 
-            serializer.Deserialize<ConsumerRecords<TestModel, string>>(stream));
+            serializer.Deserialize<KafkaAlias.ConsumerRecords<TestModel, string>>(stream));
     }
     
     private string CreateKafkaEvent(string keyValue, string valueValue)

--- a/libraries/tests/AWS.Lambda.Powertools.Kafka.Tests/AvroErrorHandlingTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Kafka.Tests/AvroErrorHandlingTests.cs
@@ -2,6 +2,12 @@ using System.Runtime.Serialization;
 using System.Text;
 using AWS.Lambda.Powertools.Kafka.Avro;
 
+#if DEBUG
+using KafkaAlias = AWS.Lambda.Powertools.Kafka;
+#else
+using KafkaAlias = AWS.Lambda.Powertools.Kafka.Avro;
+#endif
+
 namespace AWS.Lambda.Powertools.Kafka.Tests;
 
 public class AvroErrorHandlingTests
@@ -22,7 +28,7 @@ public class AvroErrorHandlingTests
 
         // Act & Assert
         var ex = Assert.Throws<SerializationException>(() =>
-            serializer.Deserialize<ConsumerRecords<TestModel, string>>(stream));
+            serializer.Deserialize<KafkaAlias.ConsumerRecords<TestModel, string>>(stream));
 
         Assert.Contains("Failed to deserialize key data", ex.Message);
     }
@@ -43,7 +49,7 @@ public class AvroErrorHandlingTests
 
         // Act & Assert
         var ex = Assert.Throws<SerializationException>(() =>
-            serializer.Deserialize<ConsumerRecords<string, TestModel>>(stream));
+            serializer.Deserialize<KafkaAlias.ConsumerRecords<string, TestModel>>(stream));
 
         Assert.Contains("Failed to deserialize value data", ex.Message);
     }

--- a/libraries/tests/AWS.Lambda.Powertools.Kafka.Tests/Json/PowertoolsKafkaJsonSerializerTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Kafka.Tests/Json/PowertoolsKafkaJsonSerializerTests.cs
@@ -3,6 +3,12 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using AWS.Lambda.Powertools.Kafka.Json;
 
+#if DEBUG
+using KafkaAlias = AWS.Lambda.Powertools.Kafka;
+#else
+using KafkaAlias = AWS.Lambda.Powertools.Kafka.Json;
+#endif
+
 namespace AWS.Lambda.Powertools.Kafka.Tests.Json;
 
 public class PowertoolsKafkaJsonSerializerTests
@@ -20,7 +26,7 @@ public class PowertoolsKafkaJsonSerializerTests
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(kafkaEventJson));
 
         // Act
-        var result = serializer.Deserialize<ConsumerRecords<int, TestModel>>(stream);
+        var result = serializer.Deserialize<KafkaAlias.ConsumerRecords<int, TestModel>>(stream);
 
         // Assert
         Assert.NotNull(result);
@@ -39,7 +45,7 @@ public class PowertoolsKafkaJsonSerializerTests
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(kafkaEventJson));
 
         // Act
-        var result = serializer.Deserialize<ConsumerRecords<string, JsonProduct>>(stream);
+        var result = serializer.Deserialize<KafkaAlias.ConsumerRecords<string, JsonProduct>>(stream);
 
         // Assert - Test enumeration
         int count = 0;
@@ -74,7 +80,7 @@ public class PowertoolsKafkaJsonSerializerTests
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(kafkaEventJson));
 
         // Act
-        var result = serializer.Deserialize<ConsumerRecords<string, string>>(stream);
+        var result = serializer.Deserialize<KafkaAlias.ConsumerRecords<string, string>>(stream);
         var firstRecord = result.First();
         Assert.Equal("Myvalue", firstRecord.Value);
         Assert.Equal("MyKey", firstRecord.Key);
@@ -96,7 +102,7 @@ public class PowertoolsKafkaJsonSerializerTests
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(kafkaEventJson));
 
         // Act
-        var result = serializer.Deserialize<ConsumerRecords<Dictionary<string, object>, string>>(stream);
+        var result = serializer.Deserialize<KafkaAlias.ConsumerRecords<Dictionary<string, object>, string>>(stream);
 
         // Assert
         var record = result.First();
@@ -126,7 +132,7 @@ public class PowertoolsKafkaJsonSerializerTests
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(kafkaEventJson));
 
         // Act
-        var result = serializer.Deserialize<ConsumerRecords<TestModel, string>>(stream);
+        var result = serializer.Deserialize<KafkaAlias.ConsumerRecords<TestModel, string>>(stream);
 
         // Assert
         var record = result.First();
@@ -155,7 +161,7 @@ public class PowertoolsKafkaJsonSerializerTests
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(kafkaEventJson));
 
         // Act
-        var result = serializer.Deserialize<ConsumerRecords<string, TestModel>>(stream);
+        var result = serializer.Deserialize<KafkaAlias.ConsumerRecords<string, TestModel>>(stream);
 
         // Assert
         var record = result.First();
@@ -187,7 +193,7 @@ public class PowertoolsKafkaJsonSerializerTests
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(kafkaEventJson));
 
         // Act
-        var result = serializer.Deserialize<ConsumerRecords<string, JsonProduct>>(stream);
+        var result = serializer.Deserialize<KafkaAlias.ConsumerRecords<string, JsonProduct>>(stream);
 
         // Assert
         var record = result.First();
@@ -212,7 +218,7 @@ public class PowertoolsKafkaJsonSerializerTests
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(kafkaEventJson));
 
         // Act
-        var result = serializer.Deserialize<ConsumerRecords<string, JsonProduct>>(stream);
+        var result = serializer.Deserialize<KafkaAlias.ConsumerRecords<string, JsonProduct>>(stream);
 
         // Assert
         var record = result.First();
@@ -243,7 +249,7 @@ public class PowertoolsKafkaJsonSerializerTests
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(kafkaEventJson));
 
         // Act
-        var result = serializer.Deserialize<ConsumerRecords<string, TestModel>>(stream);
+        var result = serializer.Deserialize<KafkaAlias.ConsumerRecords<string, TestModel>>(stream);
 
         // Assert
         var record = result.First();

--- a/libraries/tests/AWS.Lambda.Powertools.Kafka.Tests/JsonErrorHandlingTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Kafka.Tests/JsonErrorHandlingTests.cs
@@ -2,6 +2,12 @@ using System.Runtime.Serialization;
 using System.Text;
 using AWS.Lambda.Powertools.Kafka.Json;
 
+#if DEBUG
+using KafkaAlias = AWS.Lambda.Powertools.Kafka;
+#else
+using KafkaAlias = AWS.Lambda.Powertools.Kafka.Json;
+#endif
+
 namespace AWS.Lambda.Powertools.Kafka.Tests;
 
 public class JsonErrorHandlingTests
@@ -22,7 +28,7 @@ public class JsonErrorHandlingTests
 
         // Act & Assert
         var ex = Assert.Throws<SerializationException>(() =>
-            serializer.Deserialize<ConsumerRecords<Json.TestModel, string>>(stream));
+            serializer.Deserialize<KafkaAlias.ConsumerRecords<Json.TestModel, string>>(stream));
 
         Assert.Contains("Failed to deserialize key data", ex.Message);
     }
@@ -43,7 +49,7 @@ public class JsonErrorHandlingTests
 
         // Act & Assert
         var ex = Assert.Throws<SerializationException>(() =>
-            serializer.Deserialize<ConsumerRecords<string, Json.TestModel>>(stream));
+            serializer.Deserialize<KafkaAlias.ConsumerRecords<string, Json.TestModel>>(stream));
 
         Assert.Contains("Failed to deserialize value data", ex.Message);
     }

--- a/libraries/tests/AWS.Lambda.Powertools.Kafka.Tests/JsonTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Kafka.Tests/JsonTests.cs
@@ -3,6 +3,12 @@ using Amazon.Lambda.Core;
 using Amazon.Lambda.TestUtilities;
 using AWS.Lambda.Powertools.Kafka.Json;
 
+#if DEBUG
+using KafkaAlias = AWS.Lambda.Powertools.Kafka;
+#else
+using KafkaAlias = AWS.Lambda.Powertools.Kafka.Json;
+#endif
+
 namespace AWS.Lambda.Powertools.Kafka.Tests;
 
 public class JsonTests
@@ -31,7 +37,7 @@ public class JsonTests
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
         
         // When
-        var result = serializer.Deserialize<ConsumerRecords<string, JsonProduct>>(stream);
+        var result = serializer.Deserialize<KafkaAlias.ConsumerRecords<string, JsonProduct>>(stream);
         
         // Then
         Assert.Equal("aws:kafka", result.EventSource);
@@ -47,7 +53,7 @@ public class JsonTests
     public void Given_RawUtf8Data_When_ProcessedWithDefaultHandler_Then_DeserializesToStrings()
     {
         // Given
-        string Handler(ConsumerRecords<string, string> records, ILambdaContext context)
+        string Handler(KafkaAlias.ConsumerRecords<string, string> records, ILambdaContext context)
         {
             foreach (var record in records)
             {
@@ -82,7 +88,7 @@ public class JsonTests
         
         // Use the default serializer which handles base64 → UTF-8 conversion
         var serializer = new PowertoolsKafkaJsonSerializer();
-        var records = serializer.Deserialize<ConsumerRecords<string, string>>(stream);
+        var records = serializer.Deserialize<KafkaAlias.ConsumerRecords<string, string>>(stream);
         
         // When
         var result = Handler(records, mockContext);

--- a/libraries/tests/AWS.Lambda.Powertools.Kafka.Tests/KafkaHandlerFunctionalTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Kafka.Tests/KafkaHandlerFunctionalTests.cs
@@ -2,8 +2,18 @@ using System.Runtime.Serialization;
 using System.Text;
 using Amazon.Lambda.Core;
 using Amazon.Lambda.TestUtilities;
-using AWS.Lambda.Powertools.Kafka.Avro;
+using AWS.Lambda.Powertools.Kafka.Json;
 using TestKafka;
+
+#if DEBUG
+using KafkaAvro = AWS.Lambda.Powertools.Kafka;
+using KafkaProto = AWS.Lambda.Powertools.Kafka;
+using KafkaJson = AWS.Lambda.Powertools.Kafka;
+#else
+using KafkaAvro = AWS.Lambda.Powertools.Kafka.Avro;
+using KafkaProto = AWS.Lambda.Powertools.Kafka.Protobuf;
+using KafkaJson = AWS.Lambda.Powertools.Kafka.Json;
+#endif
 
 namespace AWS.Lambda.Powertools.Kafka.Tests;
 
@@ -15,7 +25,7 @@ public class KafkaHandlerFunctionalTests
     public void Given_SingleJsonRecord_When_ProcessedWithHandler_Then_SuccessfullyDeserializedAndProcessed()
     {
         // Given
-        string Handler(ConsumerRecords<string, JsonProduct> records, ILambdaContext context)
+        string Handler(KafkaJson.ConsumerRecords<string, JsonProduct> records, ILambdaContext context)
         {
             foreach (var record in records)
             {
@@ -28,11 +38,11 @@ public class KafkaHandlerFunctionalTests
         var mockContext = new TestLambdaContext { Logger = mockLogger };
         
         // Create a single record
-        var records = new ConsumerRecords<string, JsonProduct>
+        var records = new KafkaJson.ConsumerRecords<string, JsonProduct>
         {
-            Records = new Dictionary<string, List<ConsumerRecord<string, JsonProduct>>>
+            Records = new Dictionary<string, List<KafkaJson.ConsumerRecord<string, JsonProduct>>>
             {
-                { "mytopic-0", new List<ConsumerRecord<string, JsonProduct>>
+                { "mytopic-0", new List<KafkaJson.ConsumerRecord<string, JsonProduct>>
                     {
                         new()
                         {
@@ -66,7 +76,7 @@ public class KafkaHandlerFunctionalTests
     {
         // Given
         int processedCount = 0;
-        string Handler(ConsumerRecords<string, JsonProduct> records, ILambdaContext context)
+        string Handler(KafkaJson.ConsumerRecords<string, JsonProduct> records, ILambdaContext context)
         {
             foreach (var record in records)
             {
@@ -80,11 +90,11 @@ public class KafkaHandlerFunctionalTests
         var mockContext = new TestLambdaContext { Logger = mockLogger };
         
         // Create multiple records
-        var records = new ConsumerRecords<string, JsonProduct>
+        var records = new KafkaJson.ConsumerRecords<string, JsonProduct>
         {
-            Records = new Dictionary<string, List<ConsumerRecord<string, JsonProduct>>>
+            Records = new Dictionary<string, List<KafkaJson.ConsumerRecord<string, JsonProduct>>>
             {
-                { "mytopic-0", new List<ConsumerRecord<string, JsonProduct>>
+                { "mytopic-0", new List<KafkaJson.ConsumerRecord<string, JsonProduct>>
                     {
                         new() { Topic = "mytopic", Value = new JsonProduct { Name = "Laptop" } },
                         new() { Topic = "mytopic", Value = new JsonProduct { Name = "Phone" } },
@@ -108,7 +118,7 @@ public class KafkaHandlerFunctionalTests
     public void Given_JsonRecordWithMetadata_When_ProcessedWithHandler_Then_MetadataIsAccessible()
     {
         // Given
-        string Handler(ConsumerRecords<string, JsonProduct> records, ILambdaContext context)
+        string Handler(KafkaJson.ConsumerRecords<string, JsonProduct> records, ILambdaContext context)
         {
             var record = records.First();
             context.Logger.LogInformation($"Topic: {record.Topic}, Partition: {record.Partition}, Offset: {record.Offset}, Time: {record.Timestamp}");
@@ -118,11 +128,11 @@ public class KafkaHandlerFunctionalTests
         var mockLogger = new TestLambdaLogger();
         var mockContext = new TestLambdaContext { Logger = mockLogger };
         
-        var records = new ConsumerRecords<string, JsonProduct>
+        var records = new KafkaJson.ConsumerRecords<string, JsonProduct>
         {
-            Records = new Dictionary<string, List<ConsumerRecord<string, JsonProduct>>>
+            Records = new Dictionary<string, List<KafkaJson.ConsumerRecord<string, JsonProduct>>>
             {
-                { "mytopic-0", new List<ConsumerRecord<string, JsonProduct>>
+                { "mytopic-0", new List<KafkaJson.ConsumerRecord<string, JsonProduct>>
                     {
                         new()
                         {
@@ -150,7 +160,7 @@ public class KafkaHandlerFunctionalTests
     public void Given_JsonRecordWithHeaders_When_ProcessedWithHandler_Then_HeadersAreAccessible()
     {
         // Given
-        string Handler(ConsumerRecords<string, JsonProduct> records, ILambdaContext context)
+        string Handler(KafkaJson.ConsumerRecords<string, JsonProduct> records, ILambdaContext context)
         {
             var record = records.First();
             var source = record.Headers["source"].DecodedValue();
@@ -162,11 +172,11 @@ public class KafkaHandlerFunctionalTests
         var mockLogger = new TestLambdaLogger();
         var mockContext = new TestLambdaContext { Logger = mockLogger };
         
-        var records = new ConsumerRecords<string, JsonProduct>
+        var records = new KafkaJson.ConsumerRecords<string, JsonProduct>
         {
-            Records = new Dictionary<string, List<ConsumerRecord<string, JsonProduct>>>
+            Records = new Dictionary<string, List<KafkaJson.ConsumerRecord<string, JsonProduct>>>
             {
-                { "mytopic-0", new List<ConsumerRecord<string, JsonProduct>>
+                { "mytopic-0", new List<KafkaJson.ConsumerRecord<string, JsonProduct>>
                     {
                         new()
                         {
@@ -198,7 +208,7 @@ public class KafkaHandlerFunctionalTests
     public void Given_SingleAvroRecord_When_ProcessedWithHandler_Then_SuccessfullyDeserializedAndProcessed()
     {
         // Given
-        string Handler(ConsumerRecords<string, AvroProduct> records, ILambdaContext context)
+        string Handler(KafkaAvro.ConsumerRecords<string, AvroProduct> records, ILambdaContext context)
         {
             foreach (var record in records)
             {
@@ -211,11 +221,11 @@ public class KafkaHandlerFunctionalTests
         var mockContext = new TestLambdaContext { Logger = mockLogger };
         
         // Create a single record
-        var records = new ConsumerRecords<string, AvroProduct>
+        var records = new KafkaAvro.ConsumerRecords<string, AvroProduct>
         {
-            Records = new Dictionary<string, List<ConsumerRecord<string, AvroProduct>>>
+            Records = new Dictionary<string, List<KafkaAvro.ConsumerRecord<string, AvroProduct>>>
             {
-                { "mytopic-0", new List<ConsumerRecord<string, AvroProduct>>
+                { "mytopic-0", new List<KafkaAvro.ConsumerRecord<string, AvroProduct>>
                     {
                         new()
                         {
@@ -242,7 +252,7 @@ public class KafkaHandlerFunctionalTests
     public void Given_ComplexAvroKey_When_ProcessedWithHandler_Then_KeyIsCorrectlyDeserialized()
     {
         // Given
-        string Handler(ConsumerRecords<AvroKey, AvroProduct> records, ILambdaContext context)
+        string Handler(KafkaAvro.ConsumerRecords<AvroKey, AvroProduct> records, ILambdaContext context)
         {
             var record = records.First();
             context.Logger.LogInformation($"Processing product with key ID: {record.Key.id}, color: {record.Key.color}");
@@ -252,11 +262,11 @@ public class KafkaHandlerFunctionalTests
         var mockLogger = new TestLambdaLogger();
         var mockContext = new TestLambdaContext { Logger = mockLogger };
         
-        var records = new ConsumerRecords<AvroKey, AvroProduct>
+        var records = new KafkaAvro.ConsumerRecords<AvroKey, AvroProduct>
         {
-            Records = new Dictionary<string, List<ConsumerRecord<AvroKey, AvroProduct>>>
+            Records = new Dictionary<string, List<KafkaAvro.ConsumerRecord<AvroKey, AvroProduct>>>
             {
-                { "mytopic-0", new List<ConsumerRecord<AvroKey, AvroProduct>>
+                { "mytopic-0", new List<KafkaAvro.ConsumerRecord<AvroKey, AvroProduct>>
                     {
                         new()
                         {
@@ -280,7 +290,7 @@ public class KafkaHandlerFunctionalTests
     public void Given_MissingAvroSchema_When_DeserializedWithAvroSerializer_Then_ReturnsException()
     {
         // Arrange
-        var serializer = new PowertoolsKafkaAvroSerializer();
+        var serializer = new AWS.Lambda.Powertools.Kafka.Avro.PowertoolsKafkaAvroSerializer();
 
         // Create data that looks like Avro but without schema
         byte[] invalidAvroData = { 0x01, 0x02, 0x03, 0x04 }; // Just some random bytes
@@ -303,7 +313,7 @@ public class KafkaHandlerFunctionalTests
 
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(kafkaEventJson));
         Assert.Throws<SerializationException>(() => 
-            serializer.Deserialize<ConsumerRecords<string, AvroProduct>>(stream));
+            serializer.Deserialize<KafkaAvro.ConsumerRecords<string, AvroProduct>>(stream));
     }
     
     #endregion
@@ -314,7 +324,7 @@ public class KafkaHandlerFunctionalTests
     public void Given_SingleProtobufRecord_When_ProcessedWithHandler_Then_SuccessfullyDeserializedAndProcessed()
     {
         // Given
-        string Handler(ConsumerRecords<int, ProtobufProduct> records, ILambdaContext context)
+        string Handler(KafkaProto.ConsumerRecords<int, ProtobufProduct> records, ILambdaContext context)
         {
             foreach (var record in records)
             {
@@ -327,11 +337,11 @@ public class KafkaHandlerFunctionalTests
         var mockContext = new TestLambdaContext { Logger = mockLogger };
         
         // Create a single record
-        var records = new ConsumerRecords<int, ProtobufProduct>
+        var records = new KafkaProto.ConsumerRecords<int, ProtobufProduct>
         {
-            Records = new Dictionary<string, List<ConsumerRecord<int, ProtobufProduct>>>
+            Records = new Dictionary<string, List<KafkaProto.ConsumerRecord<int, ProtobufProduct>>>
             {
-                { "mytopic-0", new List<ConsumerRecord<int, ProtobufProduct>>
+                { "mytopic-0", new List<KafkaProto.ConsumerRecord<int, ProtobufProduct>>
                     {
                         new()
                         {
@@ -358,7 +368,7 @@ public class KafkaHandlerFunctionalTests
     public void Given_NullKeyOrValue_When_ProcessedWithHandler_Then_HandlesNullsCorrectly()
     {
         // Given
-        string Handler(ConsumerRecords<int?, ProtobufProduct> records, ILambdaContext context)
+        string Handler(KafkaProto.ConsumerRecords<int?, ProtobufProduct> records, ILambdaContext context)
         {
             foreach (var record in records)
             {
@@ -372,11 +382,11 @@ public class KafkaHandlerFunctionalTests
         var mockLogger = new TestLambdaLogger();
         var mockContext = new TestLambdaContext { Logger = mockLogger };
         
-        var records = new ConsumerRecords<int?, ProtobufProduct>
+        var records = new KafkaProto.ConsumerRecords<int?, ProtobufProduct>
         {
-            Records = new Dictionary<string, List<ConsumerRecord<int?, ProtobufProduct>>>
+            Records = new Dictionary<string, List<KafkaProto.ConsumerRecord<int?, ProtobufProduct>>>
             {
-                { "mytopic-0", new List<ConsumerRecord<int?, ProtobufProduct>>
+                { "mytopic-0", new List<KafkaProto.ConsumerRecord<int?, ProtobufProduct>>
                     {
                         new() { Key = 1, Value = new ProtobufProduct { Name = "Valid Product" } },
                         new() { Key = null, Value = new ProtobufProduct { Name = "No Key" } },

--- a/libraries/tests/AWS.Lambda.Powertools.Kafka.Tests/Protobuf/HandlerTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Kafka.Tests/Protobuf/HandlerTests.cs
@@ -5,6 +5,12 @@ using AWS.Lambda.Powertools.Kafka.Protobuf;
 using Google.Protobuf;
 using TestKafka;
 
+#if DEBUG
+using KafkaAlias = AWS.Lambda.Powertools.Kafka;
+#else
+using KafkaAlias = AWS.Lambda.Powertools.Kafka.Protobuf;
+#endif
+
 namespace AWS.Lambda.Powertools.Kafka.Tests.Protobuf;
 
 public class ProtobufHandlerTests
@@ -21,7 +27,7 @@ public class ProtobufHandlerTests
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(kafkaJson));
 
         // Act - Deserialize and process
-        var kafkaEvent = serializer.Deserialize<ConsumerRecords<int, ProtobufProduct>>(stream);
+        var kafkaEvent = serializer.Deserialize<KafkaAlias.ConsumerRecords<int, ProtobufProduct>>(stream);
         var response = await Handler(kafkaEvent, mockContext);
 
         // Assert
@@ -69,7 +75,7 @@ public class ProtobufHandlerTests
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(kafkaJson));
 
         // Act - Deserialize and process
-        var kafkaEvent = serializer.Deserialize<ConsumerRecords<ProtobufKey, ProtobufProduct>>(stream);
+        var kafkaEvent = serializer.Deserialize<KafkaAlias.ConsumerRecords<ProtobufKey, ProtobufProduct>>(stream);
         var response = await HandlerWithProtobufKeys(kafkaEvent, mockContext);
 
         // Assert
@@ -275,7 +281,7 @@ public class ProtobufHandlerTests
     }
 
     // Define the test handler method
-    private async Task<string> Handler(ConsumerRecords<int, ProtobufProduct> records, ILambdaContext context)
+    private async Task<string> Handler(KafkaAlias.ConsumerRecords<int, ProtobufProduct> records, ILambdaContext context)
     {
         foreach (var record in records)
         {
@@ -286,7 +292,7 @@ public class ProtobufHandlerTests
         return "Successfully processed Protobuf Kafka events";
     }
 
-    private async Task<string> HandlerWithProtobufKeys(ConsumerRecords<ProtobufKey, ProtobufProduct> records,
+    private async Task<string> HandlerWithProtobufKeys(KafkaAlias.ConsumerRecords<ProtobufKey, ProtobufProduct> records,
         ILambdaContext context)
     {
         foreach (var record in records)
@@ -302,7 +308,7 @@ public class ProtobufHandlerTests
     [Fact]
     public void SimpleHandlerTest()
     {
-        string Handler(ConsumerRecords<int, ProtobufProduct> records, ILambdaContext context)
+        string Handler(KafkaAlias.ConsumerRecords<int, ProtobufProduct> records, ILambdaContext context)
         {
             foreach (var record in records)
             {
@@ -319,11 +325,11 @@ public class ProtobufHandlerTests
             Logger = mockLogger
         };
 
-        var records = new ConsumerRecords<int, ProtobufProduct>
+        var records = new KafkaAlias.ConsumerRecords<int, ProtobufProduct>
         {
-            Records = new Dictionary<string, List<ConsumerRecord<int, ProtobufProduct>>>
+            Records = new Dictionary<string, List<KafkaAlias.ConsumerRecord<int, ProtobufProduct>>>
             {
-                { "mytopic-0", new List<ConsumerRecord<int, ProtobufProduct>>
+                { "mytopic-0", new List<KafkaAlias.ConsumerRecord<int, ProtobufProduct>>
                     {
                         new()
                         {

--- a/libraries/tests/AWS.Lambda.Powertools.Kafka.Tests/Protobuf/PowertoolsKafkaProtobufSerializerTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Kafka.Tests/Protobuf/PowertoolsKafkaProtobufSerializerTests.cs
@@ -4,6 +4,12 @@ using AWS.Lambda.Powertools.Kafka.Protobuf;
 using Com.Example.Protobuf;
 using TestKafka;
 
+#if DEBUG
+using KafkaAlias = AWS.Lambda.Powertools.Kafka;
+#else
+using KafkaAlias = AWS.Lambda.Powertools.Kafka.Protobuf;
+#endif
+
 namespace AWS.Lambda.Powertools.Kafka.Tests.Protobuf;
 
 public class PowertoolsKafkaProtobufSerializerTests
@@ -17,7 +23,7 @@ public class PowertoolsKafkaProtobufSerializerTests
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(kafkaEventJson));
 
         // Act
-        var result = serializer.Deserialize<ConsumerRecords<int, ProtobufProduct>>(stream);
+        var result = serializer.Deserialize<KafkaAlias.ConsumerRecords<int, ProtobufProduct>>(stream);
 
         // Assert
         Assert.NotNull(result);
@@ -65,7 +71,7 @@ public class PowertoolsKafkaProtobufSerializerTests
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(kafkaEventJson));
 
         // Act
-        var result = serializer.Deserialize<ConsumerRecords<int, ProtobufProduct>>(stream);
+        var result = serializer.Deserialize<KafkaAlias.ConsumerRecords<int, ProtobufProduct>>(stream);
 
         // Assert - Test enumeration
         int count = 0;
@@ -103,7 +109,7 @@ public class PowertoolsKafkaProtobufSerializerTests
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(kafkaEventJson));
 
         // Act
-        var result = serializer.Deserialize<ConsumerRecords<string, string>>(stream);
+        var result = serializer.Deserialize<KafkaAlias.ConsumerRecords<string, string>>(stream);
         var firstRecord = result.First();
         Assert.Equal("Myvalue", firstRecord.Value);
         Assert.Equal("MyKey", firstRecord.Key);
@@ -127,7 +133,7 @@ public class PowertoolsKafkaProtobufSerializerTests
         // Act
         var message =
             Assert.Throws<SerializationException>(() =>
-                serializer.Deserialize<ConsumerRecords<TestModel, string>>(stream));
+                serializer.Deserialize<KafkaAlias.ConsumerRecords<TestModel, string>>(stream));
         Assert.Contains("Failed to deserialize key data: Unsupported", message.Message);
     }
 
@@ -140,7 +146,7 @@ public class PowertoolsKafkaProtobufSerializerTests
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(kafkaEventJson));
 
         // Act
-        var result = serializer.Deserialize<ConsumerRecords<int, UserProfile>>(stream);
+        var result = serializer.Deserialize<KafkaAlias.ConsumerRecords<int, UserProfile>>(stream);
 
         // Assert
         Assert.NotNull(result);
@@ -179,7 +185,7 @@ public class PowertoolsKafkaProtobufSerializerTests
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(kafkaEventJson));
 
         // Act
-        var result = serializer.Deserialize<ConsumerRecords<int, UserProfile>>(stream);
+        var result = serializer.Deserialize<KafkaAlias.ConsumerRecords<int, UserProfile>>(stream);
 
         // Assert
         Assert.NotNull(result);
@@ -220,7 +226,7 @@ public class PowertoolsKafkaProtobufSerializerTests
 
         // Act & Assert
         var ex = Assert.Throws<SerializationException>(() =>
-            serializer.Deserialize<ConsumerRecords<int, ProtobufProduct>>(stream));
+            serializer.Deserialize<KafkaAlias.ConsumerRecords<int, ProtobufProduct>>(stream));
 
         // Verify the exception message contains useful information
         Assert.Contains("Failed to deserialize value data:", ex.Message);
@@ -253,7 +259,7 @@ public class PowertoolsKafkaProtobufSerializerTests
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(kafkaEventJson));
 
         // Act
-        var result = serializer.Deserialize<ConsumerRecords<int, UserProfile>>(stream);
+        var result = serializer.Deserialize<KafkaAlias.ConsumerRecords<int, UserProfile>>(stream);
 
         // Assert
         var record = result.First();

--- a/libraries/tests/AWS.Lambda.Powertools.Kafka.Tests/ProtobufErrorHandlingTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Kafka.Tests/ProtobufErrorHandlingTests.cs
@@ -2,6 +2,12 @@ using System.Runtime.Serialization;
 using System.Text;
 using AWS.Lambda.Powertools.Kafka.Protobuf;
 
+#if DEBUG
+using KafkaAlias = AWS.Lambda.Powertools.Kafka;
+#else
+using KafkaAlias = AWS.Lambda.Powertools.Kafka.Protobuf;
+#endif
+
 namespace AWS.Lambda.Powertools.Kafka.Tests;
 
 public class ProtobufErrorHandlingTests
@@ -22,7 +28,7 @@ public class ProtobufErrorHandlingTests
 
         // Act & Assert
         var ex = Assert.Throws<SerializationException>(() =>
-            serializer.Deserialize<ConsumerRecords<TestModel, string>>(stream));
+            serializer.Deserialize<KafkaAlias.ConsumerRecords<TestModel, string>>(stream));
 
         Assert.Contains("Failed to deserialize key data", ex.Message);
     }
@@ -43,7 +49,7 @@ public class ProtobufErrorHandlingTests
 
         // Act & Assert
         var ex = Assert.Throws<SerializationException>(() =>
-            serializer.Deserialize<ConsumerRecords<string, TestModel>>(stream));
+            serializer.Deserialize<KafkaAlias.ConsumerRecords<string, TestModel>>(stream));
 
         Assert.Contains("Failed to deserialize value data", ex.Message);
     }


### PR DESCRIPTION
> Please provide the issue number

Issue number: #912 

## Summary

### Changes

Fix --no-restore tests
Transient dependencies not being used properly when using package cache

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [ ] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
