### PR TITLE
chore: Add automatic registration of standard logging services and ILogger

### DIFF
--- a/docs/core/logging.md
+++ b/docs/core/logging.md
@@ -446,7 +446,7 @@ When debugging in non-production environments, you can instruct Logger to log th
 parameter or via `POWERTOOLS_LOGGER_LOG_EVENT` environment variable.
 
 !!! warning
-Log event is disabled by default to prevent sensitive info being logged.
+    Log event is disabled by default to prevent sensitive info being logged.
 
 === "Function.cs"
 
@@ -471,8 +471,8 @@ You can set a Correlation ID using `CorrelationIdPath` parameter by passing
 a [JSON Pointer expression](https://datatracker.ietf.org/doc/html/draft-ietf-appsawg-json-pointer-03){target="_blank"}.
 
 !!! Attention
-The JSON Pointer expression is `case sensitive`. In the bellow example `/headers/my_request_id_header` would work but
-`/Headers/my_request_id_header` would not find the element.
+    The JSON Pointer expression is `case sensitive`. In the bellow example `/headers/my_request_id_header` would work but
+    `/Headers/my_request_id_header` would not find the element.
 
 === "Function.cs"
 
@@ -577,8 +577,8 @@ for known event sources, where either a request ID or X-Ray Trace ID are present
 ## Appending additional keys
 
 !!! info "Custom keys are persisted across warm invocations"
-Always set additional keys as part of your handler to ensure they have the latest value, or explicitly clear them with [
-`ClearState=true`](#clearing-all-state).
+    Always set additional keys as part of your handler to ensure they have the latest value, or explicitly clear them with [
+    `ClearState=true`](#clearing-all-state).
 
 You can append your own keys to your existing logs via `AppendKey`. Typically this value would be passed into the
 function via the event. Appended keys are added to all subsequent log entries in the current execution from the point
@@ -683,7 +683,7 @@ It accepts any dictionary, and all keyword arguments will be added as part of th
 log statement.
 
 !!! info
-Any keyword argument added using extra keys will not be persisted for subsequent messages.
+    Any keyword argument added using extra keys will not be persisted for subsequent messages.
 
 === "Function.cs"
 
@@ -782,8 +782,8 @@ You can dynamically set a percentage of your logs to **DEBUG** level via env var
 via `SamplingRate` parameter on attribute.
 
 !!! info
-Configuration on environment variable is given precedence over sampling rate configuration on attribute, provided it's
-in valid value range.
+    Configuration on environment variable is given precedence over sampling rate configuration on attribute, provided it's
+    in valid value range.
 
 === "Sampling via attribute parameter"
 
@@ -915,8 +915,8 @@ We support the following log levels:
 ### Using AWS Lambda Advanced Logging Controls (ALC)
 
 !!! question "When is it useful?"
-When you want to set a logging policy to drop informational or verbose logs for one or all AWS Lambda functions,
-regardless of runtime and logger used.
+    When you want to set a logging policy to drop informational or verbose logs for one or all AWS Lambda functions,
+    regardless of runtime and logger used.
 
 With [AWS Lambda Advanced Logging Controls (ALC)](https://docs.aws.amazon.com/lambda/latest/dg/monitoring-cloudwatchlogs.html#monitoring-cloudwatchlogs-advanced)
 {target="_blank"}, you can enforce a minimum log level that Lambda will accept from your application code.
@@ -924,9 +924,9 @@ With [AWS Lambda Advanced Logging Controls (ALC)](https://docs.aws.amazon.com/la
 When enabled, you should keep `Logger` and ALC log level in sync to avoid data loss.
 
 !!! warning "When using AWS Lambda Advanced Logging Controls (ALC)"
-- When Powertools Logger output is set to `PascalCase` **`Level`**  property name will be replaced by **`LogLevel`** as
-  a property name.
-- ALC takes precedence over **`POWERTOOLS_LOG_LEVEL`** and when setting it in code using **`[Logging(LogLevel = )]`**
+    - When Powertools Logger output is set to `PascalCase` **`Level`**  property name will be replaced by **`LogLevel`** as
+    a property name.
+    - ALC takes precedence over **`POWERTOOLS_LOG_LEVEL`** and when setting it in code using **`[Logging(LogLevel = )]`**
 
 Here's a sequence diagram to demonstrate how ALC will drop both `Information` and `Debug` logs emitted from `Logger`,
 when ALC log level is stricter than `Logger`.
@@ -985,8 +985,8 @@ customize the serialization of Powertools Logger.
   This is useful when you want to change the casing of the property names or use a different naming convention.
 
 !!! info
-If you want to preserve the original casing of the property names (keys), you can set the `DictionaryKeyPolicy` to
-`null`.
+    If you want to preserve the original casing of the property names (keys), you can set the `DictionaryKeyPolicy` to
+    `null`.
 
 ```csharp
 builder.Logging.AddPowertoolsLogger(options => 
@@ -998,6 +998,19 @@ builder.Logging.AddPowertoolsLogger(options =>
     };
 });
 ```
+
+!!! warning
+    When using `builder.Logging.AddPowertoolsLogger` method it will use any already configured logging providers (file loggers, database loggers, third-party providers).
+    
+    If you want to use Powertools Logger as the only logging provider, you should call `builder.Logging.ClearProviders()` before adding Powertools Logger or the new method override
+    
+    ```csharp
+    builder.Logging.AddPowertoolsLogger(config =>
+        {
+        config.Service = "TestService";
+        config.LoggerOutputCase = LoggerOutputCase.PascalCase;
+        }, clearExistingProviders: true);
+    ```
 
 ### Custom Log formatter (Bring Your Own Formatter)
 

--- a/libraries/src/AWS.Lambda.Powertools.Logging/PowertoolsLoggingBuilderExtensions.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/PowertoolsLoggingBuilderExtensions.cs
@@ -88,9 +88,6 @@ public static class PowertoolsLoggingBuilderExtensions
         }
         
         builder.AddConfiguration();
-
-        // register standard logging services
-        builder.Services.AddLogging();
         
         builder.Services.TryAddSingleton<IPowertoolsEnvironment, PowertoolsEnvironment>();
         builder.Services.TryAddSingleton<IPowertoolsConfigurations>(sp =>

--- a/libraries/src/AWS.Lambda.Powertools.Logging/PowertoolsLoggingBuilderExtensions.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/PowertoolsLoggingBuilderExtensions.cs
@@ -56,6 +56,7 @@ public static class PowertoolsLoggingBuilderExtensions
     ///     Adds the Powertools logger to the logging builder with default configuration.
     /// </summary>
     /// <param name="builder">The logging builder to configure.</param>
+    /// <param name="clearExistingProviders">Opt-in to clear providers for Powertools-only output</param>
     /// <returns>The logging builder for further configuration.</returns>
     /// <remarks>
     ///     This method registers the Powertools logger with default settings. The logger will output 
@@ -78,8 +79,14 @@ public static class PowertoolsLoggingBuilderExtensions
     ///     </code>
     /// </example>
     public static ILoggingBuilder AddPowertoolsLogger(
-        this ILoggingBuilder builder)
+        this ILoggingBuilder builder,
+        bool clearExistingProviders = false)
     {
+        if (clearExistingProviders)
+        {
+            builder.ClearProviders();
+        }
+        
         builder.AddConfiguration();
 
         // register standard logging services
@@ -118,6 +125,7 @@ public static class PowertoolsLoggingBuilderExtensions
     /// </summary>
     /// <param name="builder">The logging builder to configure.</param>
     /// <param name="configure"></param>
+    /// <param name="clearExistingProviders">Opt-in to clear providers for Powertools-only output</param>
     /// <returns>The logging builder for further configuration.</returns>
     /// <remarks>
     ///     This method registers the Powertools logger with default settings. The logger will output 
@@ -162,10 +170,11 @@ public static class PowertoolsLoggingBuilderExtensions
     /// </example>
     public static ILoggingBuilder AddPowertoolsLogger(
         this ILoggingBuilder builder,
-        Action<PowertoolsLoggerConfiguration> configure)
+        Action<PowertoolsLoggerConfiguration> configure,
+        bool clearExistingProviders = false)
     {
         // Add configuration
-        builder.AddPowertoolsLogger();
+        builder.AddPowertoolsLogger(clearExistingProviders);
 
         // Create initial configuration
         var options = new PowertoolsLoggerConfiguration();

--- a/libraries/src/AWS.Lambda.Powertools.Logging/PowertoolsLoggingBuilderExtensions.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/PowertoolsLoggingBuilderExtensions.cs
@@ -82,9 +82,16 @@ public static class PowertoolsLoggingBuilderExtensions
     {
         builder.AddConfiguration();
 
+        // register standard logging services
+        builder.Services.AddLogging();
+        
         builder.Services.TryAddSingleton<IPowertoolsEnvironment, PowertoolsEnvironment>();
         builder.Services.TryAddSingleton<IPowertoolsConfigurations>(sp =>
             new PowertoolsConfigurations(sp.GetRequiredService<IPowertoolsEnvironment>()));
+
+        // automatically register ILogger
+        builder.Services.TryAddSingleton<ILogger>(provider =>
+            provider.GetRequiredService<ILoggerFactory>().CreatePowertoolsLogger());
 
         builder.Services.TryAddEnumerable(
             ServiceDescriptor.Singleton<ILoggerProvider, PowertoolsLoggerProvider>(provider =>

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/PowertoolsLoggerExtensionsTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/PowertoolsLoggerExtensionsTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Linq;
+using AWS.Lambda.Powertools.Logging.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace AWS.Lambda.Powertools.Logging.Tests;
+
+public class PowertoolsLoggerExtensionsTests
+{
+    [Fact]
+    public void AddPowertoolsLogger_WithClearExistingProviders_False_KeepsExistingProviders()
+    {
+        // Arrange
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddLogging(builder =>
+        {
+            // Add a mock existing provider first
+            builder.Services.AddSingleton<ILoggerProvider, MockLoggerProvider>();
+        
+            // Act
+            builder.AddPowertoolsLogger(clearExistingProviders: false);
+        });
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+        var loggerProviders = serviceProvider.GetServices<ILoggerProvider>();
+
+        // Assert
+        var collection = loggerProviders as ILoggerProvider[] ?? loggerProviders.ToArray();
+        Assert.Contains(collection, p => p is MockLoggerProvider);
+        Assert.Contains(collection, p => p is PowertoolsLoggerProvider);
+        Assert.True(collection.Count() >= 2); // Should have both providers
+    }
+
+    [Fact]
+    public void AddPowertoolsLogger_WithClearExistingProviders_True_RemovesExistingProviders()
+    {
+        // Arrange
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddLogging(builder =>
+        {
+            // Add a mock existing provider first
+            builder.Services.AddSingleton<ILoggerProvider, MockLoggerProvider>();
+        
+            // Act
+            builder.AddPowertoolsLogger(clearExistingProviders: true);
+        });
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+        var loggerProviders = serviceProvider.GetServices<ILoggerProvider>();
+
+        // Assert
+        var collection = loggerProviders as ILoggerProvider[] ?? loggerProviders.ToArray();
+        Assert.DoesNotContain(collection, p => p is MockLoggerProvider);
+        Assert.Contains(collection, p => p is PowertoolsLoggerProvider);
+        Assert.Single(collection); // Should only have Powertools provider
+    }
+    
+    private class MockLoggerProvider : ILoggerProvider
+    {
+        public ILogger CreateLogger(string categoryName) => new MockLogger();
+        public void Dispose() { }
+    }
+
+    private class MockLogger : ILogger
+    {
+        public IDisposable BeginScope<TState>(TState state) => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter) { }
+    }
+}


### PR DESCRIPTION


> Please provide the issue number

Issue number: #937 

## Summary

### Changes

This pull request enhances the `AddPowertoolsLogger` method in `AWS.Lambda.Powertools.Logging` to improve service registration and logging functionality. The most notable changes include adding standard logging services and automatically registering the `ILogger` interface.

### Improvements to service registration:

* [`libraries/src/AWS.Lambda.Powertools.Logging/PowertoolsLoggingBuilderExtensions.cs`](diffhunk://#diff-8a7a823ac8266eeacc74402160c3533065823fa6fca4e28d541576545d8a20acR85-R95): Added `builder.Services.AddLogging()` to register standard logging services.

### Enhancements to logging functionality:

* [`libraries/src/AWS.Lambda.Powertools.Logging/PowertoolsLoggingBuilderExtensions.cs`](diffhunk://#diff-8a7a823ac8266eeacc74402160c3533065823fa6fca4e28d541576545d8a20acR85-R95): Automatically registered the `ILogger` interface by adding a singleton service that retrieves and creates a `PowertoolsLogger` instance from the `ILoggerFactory`.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [ ] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
