### PR TITLE
feat(metrics): Added runtime validation for the metric name

### DIFF
--- a/libraries/src/AWS.Lambda.Powertools.Metrics/Metrics.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/Metrics.cs
@@ -182,6 +182,10 @@ public class Metrics : IMetrics, IDisposable
                 throw new ArgumentNullException(
                     nameof(key),
                     "'AddMetric' method requires a valid metrics key. 'Null' or empty values are not allowed.");
+            if (key.Length > 255)
+                throw new ArgumentOutOfRangeException(
+                    nameof(key),
+                    "'AddMetric' method requires a valid metrics key. Key exceeds the allowed length constraint.");
 
             if (value < 0)
             {

--- a/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/MetricsTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/MetricsTests.cs
@@ -156,6 +156,21 @@ public class MetricsTests
     }
 
     [Fact]
+    public void When_AddMetric_With_TooLongKey_Should_ThrowArgumentOutOfRangeException()
+    {
+        // Arrange
+        Substitute.For<IMetrics>();
+        var powertoolsConfigMock = Substitute.For<IPowertoolsConfigurations>();
+        IMetrics metrics = new Metrics(powertoolsConfigMock);
+
+        // Act & Assert
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => metrics.AddMetric("Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem.", 1.0));
+        Assert.Equal("key", exception.ParamName);
+        Assert.Contains("'AddMetric' method requires a valid metrics key. Key exceeds the allowed length constraint.",
+            exception.Message);
+    }
+
+    [Fact]
     public void When_SetDefaultDimensions_With_InvalidKeyOrValue_Should_ThrowArgumentNullException()
     {
         // Arrange


### PR DESCRIPTION
> Please provide the issue number

Issue number: Closes #931 

## Summary

This PR adds runtime validation for the metric name. It ensures that the metric name meets the required length constraints before they are added, providing better error handling and feedback to users. This was done to prevent potential issues that could have come up due to invalid metric name being passed to Cloudwatch.

### Changes

> Please provide a summary of what's being changed

- Added runtime validation for the Metric Name max length: Validated according to the constraints in https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDatum.html
- Added tests for the new validations

### User experience

> Please share what the user experience looks like before and after this change

Before this, for the users who were passing in an invalid metric name (a string of more than 255 characters), the metrics would get silently dropped. But, now the users will get an error.

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [X] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [ ] Changes are documented
* [X] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
