### PR TITLE
feat(tracing): add Subsegment wrapper to prevent exposing Amazon.XRayRecorder.Core.Internal

### DIFF
--- a/libraries/src/AWS.Lambda.Powertools.Tracing/Internal/TracingSubsegment.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Tracing/Internal/TracingSubsegment.cs
@@ -1,0 +1,18 @@
+using Amazon.XRay.Recorder.Core.Internal.Entities;
+using System.Collections.Generic;
+
+namespace AWS.Lambda.Powertools.Tracing.Internal;
+
+/// <summary>
+///     Class TracingSubsegment.
+///     It's a wrapper for Subsegment from Amazon.XRay.Recorder.Core.Internal.
+/// </summary>
+/// <seealso cref="Subsegment" />
+public class TracingSubsegment : Subsegment
+{
+    /// <summary>
+    /// Wrapper constructor
+    /// </summary>
+    /// <param name="name"></param>
+    public TracingSubsegment(string name) : base(name) { }
+}

--- a/libraries/src/AWS.Lambda.Powertools.Tracing/Internal/TracingSubsegment.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Tracing/Internal/TracingSubsegment.cs
@@ -1,0 +1,17 @@
+using Amazon.XRay.Recorder.Core.Internal.Entities;
+
+namespace AWS.Lambda.Powertools.Tracing.Internal;
+
+/// <summary>
+///     Class TracingSubsegment.
+///     It's a wrapper for Subsegment from Amazon.XRay.Recorder.Core.Internal.
+/// </summary>
+/// <seealso cref="Subsegment" />
+public class TracingSubsegment : Subsegment
+{
+    /// <summary>
+    /// Wrapper constructor
+    /// </summary>
+    /// <param name="name"></param> 
+    public TracingSubsegment(string name) : base(name) { }
+}

--- a/libraries/src/AWS.Lambda.Powertools.Tracing/Tracing.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Tracing/Tracing.cs
@@ -130,7 +130,7 @@ public static class Tracing
     /// <param name="name">The name of the subsegment.</param>
     /// <param name="subsegment">The AWS X-Ray subsegment for the wrapped consumer.</param>
     /// <exception cref="ArgumentNullException">Thrown when the name is not provided.</exception>
-    public static void WithSubsegment(string name, Action<Subsegment> subsegment)
+    public static void WithSubsegment(string name, Action<TracingSubsegment> subsegment)
     {
         WithSubsegment(null, name, subsegment);
     }
@@ -145,7 +145,7 @@ public static class Tracing
     /// <param name="name">The name of the subsegment.</param>
     /// <param name="subsegment">The AWS X-Ray subsegment for the wrapped consumer.</param>
     /// <exception cref="System.ArgumentNullException">name</exception>
-    public static void WithSubsegment(string nameSpace, string name, Action<Subsegment> subsegment)
+    public static void WithSubsegment(string nameSpace, string name, Action<TracingSubsegment> subsegment)
     {
         if (string.IsNullOrWhiteSpace(name))
             throw new ArgumentNullException(nameof(name));
@@ -154,7 +154,8 @@ public static class Tracing
         XRayRecorder.Instance.SetNamespace(GetNamespaceOrDefault(nameSpace));
         try
         {
-            subsegment?.Invoke((Subsegment) XRayRecorder.Instance.GetEntity());
+            var entity = XRayRecorder.Instance.GetEntity() as TracingSubsegment;
+            subsegment?.Invoke(entity);
         }
         finally
         {
@@ -174,7 +175,7 @@ public static class Tracing
     /// <param name="subsegment">The AWS X-Ray subsegment for the wrapped consumer.</param>
     /// <exception cref="ArgumentNullException">Thrown when the name is not provided.</exception>
     /// <exception cref="ArgumentNullException">Thrown when the entity is not provided.</exception>
-    public static void WithSubsegment(string name, Entity entity, Action<Subsegment> subsegment)
+    public static void WithSubsegment(string name, Entity entity, Action<TracingSubsegment> subsegment)
     {
         WithSubsegment(null, name, subsegment);
     }
@@ -191,7 +192,7 @@ public static class Tracing
     /// <param name="subsegment">The AWS X-Ray subsegment for the wrapped consumer.</param>
     /// <exception cref="System.ArgumentNullException">name</exception>
     /// <exception cref="System.ArgumentNullException">entity</exception>
-    public static void WithSubsegment(string nameSpace, string name, Entity entity, Action<Subsegment> subsegment)
+    public static void WithSubsegment(string nameSpace, string name, Entity entity, Action<TracingSubsegment> subsegment)
     {
         if (string.IsNullOrWhiteSpace(name))
             throw new ArgumentNullException(nameof(name));
@@ -199,7 +200,7 @@ public static class Tracing
         if (entity is null)
             throw new ArgumentNullException(nameof(entity));
 
-        var childSubsegment = new Subsegment($"## {name}");
+        var childSubsegment = new TracingSubsegment($"## {name}");
         entity.AddSubsegment(childSubsegment);
         childSubsegment.Sampled = entity.Sampled;
         childSubsegment.SetStartTimeToNow();

--- a/libraries/src/AWS.Lambda.Powertools.Tracing/Tracing.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Tracing/Tracing.cs
@@ -130,7 +130,7 @@ public static class Tracing
     /// <param name="name">The name of the subsegment.</param>
     /// <param name="subsegment">The AWS X-Ray subsegment for the wrapped consumer.</param>
     /// <exception cref="ArgumentNullException">Thrown when the name is not provided.</exception>
-    public static void WithSubsegment(string name, Action<Subsegment> subsegment)
+    public static void WithSubsegment(string name, Action<TracingSubsegment> subsegment)
     {
         WithSubsegment(null, name, subsegment);
     }
@@ -145,7 +145,7 @@ public static class Tracing
     /// <param name="name">The name of the subsegment.</param>
     /// <param name="subsegment">The AWS X-Ray subsegment for the wrapped consumer.</param>
     /// <exception cref="System.ArgumentNullException">name</exception>
-    public static void WithSubsegment(string nameSpace, string name, Action<Subsegment> subsegment)
+    public static void WithSubsegment(string nameSpace, string name, Action<TracingSubsegment> subsegment)
     {
         if (string.IsNullOrWhiteSpace(name))
             throw new ArgumentNullException(nameof(name));
@@ -154,7 +154,8 @@ public static class Tracing
         XRayRecorder.Instance.SetNamespace(GetNamespaceOrDefault(nameSpace));
         try
         {
-            subsegment?.Invoke((Subsegment) XRayRecorder.Instance.GetEntity());
+            var entity = XRayRecorder.Instance.GetEntity() as TracingSubsegment;
+            subsegment?.Invoke(entity);
         }
         finally
         {
@@ -174,7 +175,7 @@ public static class Tracing
     /// <param name="subsegment">The AWS X-Ray subsegment for the wrapped consumer.</param>
     /// <exception cref="ArgumentNullException">Thrown when the name is not provided.</exception>
     /// <exception cref="ArgumentNullException">Thrown when the entity is not provided.</exception>
-    public static void WithSubsegment(string name, Entity entity, Action<Subsegment> subsegment)
+    public static void WithSubsegment(string name, Entity entity, Action<TracingSubsegment> subsegment)
     {
         WithSubsegment(null, name, subsegment);
     }
@@ -191,7 +192,7 @@ public static class Tracing
     /// <param name="subsegment">The AWS X-Ray subsegment for the wrapped consumer.</param>
     /// <exception cref="System.ArgumentNullException">name</exception>
     /// <exception cref="System.ArgumentNullException">entity</exception>
-    public static void WithSubsegment(string nameSpace, string name, Entity entity, Action<Subsegment> subsegment)
+    public static void WithSubsegment(string nameSpace, string name, Entity entity, Action<TracingSubsegment> subsegment)
     {
         if (string.IsNullOrWhiteSpace(name))
             throw new ArgumentNullException(nameof(name));
@@ -199,7 +200,7 @@ public static class Tracing
         if (entity is null)
             throw new ArgumentNullException(nameof(entity));
 
-        var childSubsegment = new Subsegment($"## {name}");
+        var childSubsegment = new TracingSubsegment($"## {name}");
         entity.AddSubsegment(childSubsegment);
         childSubsegment.Sampled = entity.Sampled;
         childSubsegment.SetStartTimeToNow();
@@ -240,7 +241,7 @@ public static class Tracing
 
         return PowertoolsConfigurations.Instance.Service;
     }
-    
+
     /// <summary>
     ///     Registers X-Ray for all instances of <see cref="Amazon.Runtime.AmazonServiceClient"/>.
     /// </summary>

--- a/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/TracingSubsegmentTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/TracingSubsegmentTests.cs
@@ -193,15 +193,6 @@ public class TracingSubsegmentTests
         Assert.IsType<TracingSubsegment>(passedSubsegment);
     }
 
-    [Fact]
-    public void WithSubsegment_WithEntity_HandlesNullAction()
-    {
-        // Arrange
-        var parent = new Segment("parent", TraceId.NewId());
-
-        // Act & Assert - Should not throw
-        Tracing.WithSubsegment("test-namespace", "test-name", parent, null);
-    }
 
     [Fact]
     public void WithSubsegment_WithEntity_UsesDefaultNamespaceWhenNull()

--- a/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/TracingSubsegmentTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/TracingSubsegmentTests.cs
@@ -1,6 +1,7 @@
 using AWS.Lambda.Powertools.Tracing.Internal;
 using Xunit;
 using Amazon.XRay.Recorder.Core.Internal.Entities;
+using System;
 
 namespace AWS.Lambda.Powertools.Tracing.Tests;
 
@@ -84,5 +85,160 @@ public class TracingSubsegmentTests
 
         // Assert
         Assert.True(delegateInvoked);
+    }
+
+    [Fact]
+    public void WithSubsegment_WithEntity_ThrowsArgumentNullException_WhenNameIsNull()
+    {
+        // Arrange
+        var parent = new Segment("parent", TraceId.NewId());
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => 
+            Tracing.WithSubsegment(null, null, parent, _ => { }));
+    }
+
+    [Fact]
+    public void WithSubsegment_WithEntity_ThrowsArgumentNullException_WhenNameIsEmpty()
+    {
+        // Arrange
+        var parent = new Segment("parent", TraceId.NewId());
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => 
+            Tracing.WithSubsegment(null, "", parent, _ => { }));
+    }
+
+    [Fact]
+    public void WithSubsegment_WithEntity_ThrowsArgumentNullException_WhenEntityIsNull()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => 
+            Tracing.WithSubsegment(null, "test", null, _ => { }));
+    }
+
+    [Fact]
+    public void WithSubsegment_WithEntity_CreatesSubsegmentWithCorrectName()
+    {
+        // Arrange
+        var parent = new Segment("parent", TraceId.NewId());
+        TracingSubsegment capturedSubsegment = null;
+
+        // Act
+        Tracing.WithSubsegment("test-namespace", "test-name", parent, subsegment =>
+        {
+            capturedSubsegment = subsegment;
+        });
+
+        // Assert
+        Assert.NotNull(capturedSubsegment);
+        Assert.Equal("## test-name", capturedSubsegment.Name);
+        Assert.Equal("test-namespace", capturedSubsegment.Namespace);
+    }
+
+    [Fact]
+    public void WithSubsegment_WithEntity_SetsSubsegmentProperties()
+    {
+        // Arrange
+        var parent = new Segment("parent", TraceId.NewId());
+        TracingSubsegment capturedSubsegment = null;
+
+        // Act
+        Tracing.WithSubsegment("test-namespace", "test-name", parent, subsegment =>
+        {
+            capturedSubsegment = subsegment;
+        });
+
+        // Assert
+        Assert.NotNull(capturedSubsegment);
+        Assert.Equal(parent.Sampled, capturedSubsegment.Sampled);
+        Assert.False(capturedSubsegment.IsInProgress);
+        Assert.True(capturedSubsegment.StartTime > 0);
+        Assert.True(capturedSubsegment.EndTime > 0);
+    }
+
+    [Fact]
+    public void WithSubsegment_WithEntity_AddsSubsegmentToParent()
+    {
+        // Arrange
+        var parent = new Segment("parent", TraceId.NewId());
+        var initialSubsegmentCount = parent.Subsegments?.Count ?? 0;
+
+        // Act
+        Tracing.WithSubsegment("test-namespace", "test-name", parent, _ => { });
+
+        // Assert
+        Assert.True(parent.IsSubsegmentsAdded);
+        Assert.Equal(initialSubsegmentCount + 1, parent.Subsegments.Count);
+    }
+
+    [Fact]
+    public void WithSubsegment_WithEntity_InvokesActionWithSubsegment()
+    {
+        // Arrange
+        var parent = new Segment("parent", TraceId.NewId());
+        bool actionInvoked = false;
+        TracingSubsegment passedSubsegment = null;
+
+        // Act
+        Tracing.WithSubsegment("test-namespace", "test-name", parent, subsegment =>
+        {
+            actionInvoked = true;
+            passedSubsegment = subsegment;
+        });
+
+        // Assert
+        Assert.True(actionInvoked);
+        Assert.NotNull(passedSubsegment);
+        Assert.IsType<TracingSubsegment>(passedSubsegment);
+    }
+
+    [Fact]
+    public void WithSubsegment_WithEntity_HandlesNullAction()
+    {
+        // Arrange
+        var parent = new Segment("parent", TraceId.NewId());
+
+        // Act & Assert - Should not throw
+        Tracing.WithSubsegment("test-namespace", "test-name", parent, null);
+    }
+
+    [Fact]
+    public void WithSubsegment_WithEntity_UsesDefaultNamespaceWhenNull()
+    {
+        // Arrange
+        var parent = new Segment("parent", TraceId.NewId());
+        TracingSubsegment capturedSubsegment = null;
+
+        // Act
+        Tracing.WithSubsegment(null, "test-name", parent, subsegment =>
+        {
+            capturedSubsegment = subsegment;
+        });
+
+        // Assert
+        Assert.NotNull(capturedSubsegment);
+        Assert.NotNull(capturedSubsegment.Namespace);
+    }
+
+    [Fact]
+    public void WithSubsegment_WithEntity_HandlesExceptionInAction()
+    {
+        // Arrange
+        var parent = new Segment("parent", TraceId.NewId());
+        var expectedException = new InvalidOperationException("Test exception");
+
+        // Act & Assert
+        var actualException = Assert.Throws<InvalidOperationException>(() =>
+        {
+            Tracing.WithSubsegment("test-namespace", "test-name", parent, subsegment =>
+            {
+                throw expectedException;
+            });
+        });
+
+        Assert.Equal(expectedException, actualException);
+        // Verify subsegment was still properly cleaned up
+        Assert.True(parent.IsSubsegmentsAdded);
     }
 }

--- a/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/TracingSubsegmentTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/TracingSubsegmentTests.cs
@@ -1,0 +1,88 @@
+using AWS.Lambda.Powertools.Tracing.Internal;
+using Xunit;
+using Amazon.XRay.Recorder.Core.Internal.Entities;
+
+namespace AWS.Lambda.Powertools.Tracing.Tests;
+
+[Collection("Sequential")]
+public class TracingSubsegmentTests
+{
+
+    [Fact]
+    public void TracingSubsegment_Constructor_Should_Set_Name()
+    {
+        // Arrange
+        var name = "test-segment";
+
+        // Act
+        var subsegment = new TracingSubsegment(name);
+
+        // Assert
+        Assert.Equal("test-segment", subsegment.Name);
+        Assert.True(Entity.IsIdValid(subsegment.Id));
+        Assert.Null(subsegment.TraceId);
+        Assert.Null(subsegment.ParentId);
+        Assert.False(subsegment.IsSubsegmentsAdded);
+    }
+
+    [Fact]
+    public void Test_Add_Ref_And_Release_With_TracingSubsegment()
+    {
+        // Arrange
+        var parent = new Segment("parent", TraceId.NewId());
+        var child = new TracingSubsegment("child");
+
+        // Act
+        parent.AddSubsegment(child);
+
+        // Assert
+        Assert.Equal(2, parent.Reference);
+        Assert.Equal(1, child.Reference);
+
+        child.Release();
+        Assert.Equal(1, parent.Reference);
+        Assert.Equal(0, child.Reference);
+        Assert.False(parent.IsEmittable());
+        Assert.False(child.IsEmittable());
+
+        parent.Release();
+        Assert.Equal(0, parent.Reference);
+        Assert.True(parent.IsEmittable());
+        Assert.True(child.IsEmittable());
+    }
+
+    [Fact]
+    public void IsEmittable_Returns_False_Without_Parent()
+    {
+        var subsegment = new TracingSubsegment("segment");
+        Assert.False(subsegment.IsEmittable());
+    }
+
+    [Fact]
+    public void TracingSubsegment_Is_Assignable_BaseClass()
+    {
+        // Arrange
+        var subsegment = new TracingSubsegment("segment");
+
+        // Act & Assert
+        Assert.IsAssignableFrom<Subsegment>(subsegment);
+    }
+
+    [Fact]
+    public void Tracing_WithSubsegment_Invokes_Delegate_With_TracingSubsegment()
+    {
+        // Arrange
+        bool delegateInvoked = false;
+
+        void TracingSubsegmentDelegate(TracingSubsegment subsegment)
+        {
+            delegateInvoked = true;
+        }
+
+        // Act
+        Tracing.WithSubsegment("namespace", "test", TracingSubsegmentDelegate);
+
+        // Assert
+        Assert.True(delegateInvoked);
+    }
+}


### PR DESCRIPTION
Issue number: #603 

## Summary

### Changes

This PR creates a wrapper to prevent exposing internal lib `Amazon.XRayRecorder`.

- Created `libraries/src/AWS.Lambda.Powertools.Tracing/Internal/TracingSubsegment.cs` to place the wrapper;
- Changed `libraries/src/AWS.Lambda.Powertools.Tracing/Tracing.cs` to include the wrapper;

### User experience

Before the changes, users had to include the reference to `Amazon.XRay.Recorder.Core.Internal.Entities` to use the `Subsegment` class. Now, the `TracingSubsegment` was created and users can now import them using the `AWS.Lambda.Powertools.Tracing.Internal` reference.

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

NO
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
