### PR TITLE
chore(gitignore): add .kiro, .claude, .amazonq to prevent deletion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ samconfig.toml
 .kiro
 .claude
 .amazonq
+.github/instructions

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ AWS.Lambda.Powertools.sln.DotSettings.user
 dist/
 site/
 samconfig.toml
+
+.kiro
+.claude
+.amazonq


### PR DESCRIPTION
> Please provide the issue number

Issue number: #954

## Summary
Kiro, Claude, and Amazon Q create local configuration folders (.kiro/, .claude/, .amazonq/).
When developers run git clean, these folders may be deleted, causing loss of settings and session data.

### Changes
Added .kiro/, .claude/, and .amazonq/ to the root .gitignore.


### User experience
Before: Running git clean risked deleting the .kiro, .claude, and .amazonq folders, causing the loss of personalized configurations.
After: By adding these folders to .gitignore, they remain protected and developer settings are retained.


## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
