### PR TITLE
chore: Remove reference customer section from documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -154,23 +154,6 @@ There are many ways you can help us gain future investments to improve everyone'
 
 </div>
 
-### Becoming a reference customer
-
-Knowing which companies are using this library is important to help prioritize the project internally. The following companies, among others, use Powertools:
-
-<div class="grid" style="text-align:center;" markdown>
-
-[**Caylent**](https://caylent.com/){target="_blank" rel="nofollow"}
-{ .card }
-
-[**Instil Software**](https://instil.co/){target="_blank" rel="nofollow"}
-{ .card }
-
-[**Pushpay**](https://pushpay.com/){target="_blank" rel="nofollow"}
-{ .card }
-
-</div>
-
 ## Tenets
 
 These are our core principles to guide our decision making.


### PR DESCRIPTION
Removed the section on becoming a reference customer and the associated companies.

> Please provide the issue number

Issue number: #981

## Summary

### Changes

This pull request makes a small change to the documentation by removing the "Becoming a reference customer" section from `docs/index.md`.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [ ] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
