### PR TITLE
chore: Deprecate .NET 6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Powertools for AWS Lambda (.NET) provides three core utilities:
 
 ### Installation
 
-The Powertools for AWS Lambda (.NET) utilities (.NET 6 and .NET 8) are available as NuGet packages. You can install the packages from [NuGet Gallery](https://www.nuget.org/packages?q=AWS+Lambda+Powertools*) or from Visual Studio editor by searching `AWS.Lambda.Powertools*` to see various utilities available.
+The Powertools for AWS Lambda (.NET) utilities (.NET 8) are available as NuGet packages. You can install the packages from [NuGet Gallery](https://www.nuget.org/packages?q=AWS+Lambda+Powertools*) or from Visual Studio editor by searching `AWS.Lambda.Powertools*` to see various utilities available.
 
 * [AWS.Lambda.Powertools.Logging](https://www.nuget.org/packages?q=AWS.Lambda.Powertools.Logging):
 
@@ -61,7 +61,7 @@ The Powertools for AWS Lambda (.NET) utilities (.NET 6 and .NET 8) are available
 
 ## Examples
 
-We have provided examples focused specifically on each of the utilities. Each solution comes with an AWS Serverless Application Model (AWS SAM) templates to run your functions as a Zip package using the AWS Lambda .NET 6 or .NET 8 managed runtime; or as a container package using the AWS base images for .NET.
+We have provided examples focused specifically on each of the utilities. Each solution comes with an AWS Serverless Application Model (AWS SAM) templates to run your functions as a Zip package using the AWS Lambda .NET 8 managed runtime; or as a container package using the AWS base images for .NET.
 
 * **[Logging example](examples/Logging/)**
 * **[Metrics example](examples/Metrics/)**

--- a/docs/core/tracing.md
+++ b/docs/core/tracing.md
@@ -44,7 +44,7 @@ To enable active tracing on an AWS Serverless Application Model (AWS SAM) AWS::S
             Type: AWS::Serverless::Function
             Properties:
             ...
-            Runtime: dotnet6.0
+            Runtime: dotnet8.0
     
             Tracing: Active
             Environment:

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ description: Powertools for AWS Lambda (.NET)
 Powertools for AWS Lambda (.NET) (which from here will be referred as Powertools) is a suite of utilities for [AWS Lambda](https://aws.amazon.com/lambda/) functions to ease adopting best practices such as tracing, structured logging, custom metrics, and more.
 
 !!! info
-    **Supports .NET 6 and .NET 8 runtimes**
+    **Supports .NET 8 runtime**
 
 ???+ tip
     Powertools is also available for [Python](https://docs.powertools.aws.dev/lambda/python/){target="_blank"}, [Java](https://docs.powertools.aws.dev/lambda/java/){target="_blank"}, and [TypeScript](https://docs.powertools.aws.dev/lambda/typescript/latest/){target="_blank"}.
@@ -71,14 +71,14 @@ We have provided you with a custom template for the Serverless Application Model
 To use the SAM CLI, you need the following tools.
 
 * SAM CLI - [Install the SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html)
-* .NET 6.0 (LTS)  - [Install .NET 6.0](https://www.microsoft.com/net/download)
+* .NET 8.0 (LTS)  - [Install .NET 8.0](https://www.microsoft.com/net/download)
 * Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community)
 
-Once you have SAM CLI installed, follow the these steps to initialize a .NET 6 project using Powertools for AWS (.NET)
+Once you have SAM CLI installed, follow the these steps to initialize a .NET 8 project using Powertools for AWS (.NET)
 
 1. Run the following command in your command line
     ```bash
-    sam init -r dotnet6
+    sam init -r dotnet8
     ```
 2. Select option 1 as your template source
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -46,7 +46,7 @@ Updating metrics implementation to support latest EMF specifications and improve
 Ensuring enterprise-grade security and compatibility with latest .NET developments.
 
 - [ ] .NET 10 support from day one
-- [ ] Deprecation path for .NET 6
+- [x] .NET 6 deprecation completed
 - [ ] Scorecard implementation
 - [ ] Security compliance checks on our pipeline
 - [ ] All utilities with end-to-end tests in our pipeline

--- a/examples/BatchProcessing/README.md
+++ b/examples/BatchProcessing/README.md
@@ -28,7 +28,7 @@ To use the AWS SAM CLI, you need the following tools.
 * Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community)
 
 You will need the following for local testing.
-* .NET 6.0 - [Install .NET 6.0](https://www.microsoft.com/net/download)
+* .NET 8.0 - [Install .NET 8.0](https://www.microsoft.com/net/download)
 
 To build and deploy your application for the first time, run the following in your shell. Make sure the `template.yaml` file is in your current directory:
 

--- a/examples/Idempotency/README.md
+++ b/examples/Idempotency/README.md
@@ -25,7 +25,7 @@ To use the AWS SAM CLI, you need the following tools.
 * Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community)
 
 You will need the following for local testing.
-* .NET 6.0 - [Install .NET 6.0](https://www.microsoft.com/net/download)
+* .NET 8.0 - [Install .NET 8.0](https://www.microsoft.com/net/download)
 
 To build and deploy your application for the first time, run the following in your shell. Make sure the `template.yaml` file is in your current directory:
 

--- a/examples/Logging/README.md
+++ b/examples/Logging/README.md
@@ -25,7 +25,7 @@ To use the AWS SAM CLI, you need the following tools.
 * Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community)
 
 You will need the following for local testing.
-* .NET 6.0 - [Install .NET 6.0](https://www.microsoft.com/net/download)
+* .NET 8.0 - [Install .NET 8.0](https://www.microsoft.com/net/download)
 
 To build and deploy your application for the first time, run the following in your shell. Make sure the `template.yaml` file is in your current directory:
 

--- a/examples/Metrics/README.md
+++ b/examples/Metrics/README.md
@@ -25,7 +25,7 @@ To use the AWS SAM CLI, you need the following tools.
 * Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community)
 
 You will need the following for local testing.
-* .NET 6.0 - [Install .NET 6.0](https://www.microsoft.com/net/download)
+* .NET 8.0 - [Install .NET 8.0](https://www.microsoft.com/net/download)
 
 To build and deploy your application for the first time, run the following in your shell. Make sure the `template.yaml` file is in your current directory:
 

--- a/examples/Parameters/README.md
+++ b/examples/Parameters/README.md
@@ -25,7 +25,7 @@ To use the AWS SAM CLI, you need the following tools.
 * Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community)
 
 You will need the following for local testing.
-* .NET 6.0 - [Install .NET 6.0](https://www.microsoft.com/net/download)
+* .NET 8.0 - [Install .NET 8.0](https://www.microsoft.com/net/download)
 
 To build and deploy your application for the first time, run the following in your shell. Make sure the `template.yaml` file is in your current directory:
 

--- a/examples/ServerlessApi/Readme.md
+++ b/examples/ServerlessApi/Readme.md
@@ -27,7 +27,7 @@ To use the AWS SAM CLI, you need the following tools.
 * Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community)
 
 You will need the following for local testing.
-* .NET 6.0 - [Install .NET 6.0](https://www.microsoft.com/net/download)
+* .NET 8.0 - [Install .NET 8.0](https://www.microsoft.com/net/download)
 
 To build and deploy your application for the first time, run the following in your shell. Make sure the `serverless.template` file is in your current directory:
 

--- a/examples/Tracing/README.md
+++ b/examples/Tracing/README.md
@@ -25,7 +25,7 @@ To use the AWS SAM CLI, you need the following tools.
 * Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community)
 
 You will need the following for local testing.
-* .NET 6.0 - [Install .NET 6.0](https://www.microsoft.com/net/download)
+* .NET 8.0 - [Install .NET 8.0](https://www.microsoft.com/net/download)
 
 To build and deploy your application for the first time, run the following in your shell. Make sure the `template.yaml` file is in your current directory:
 

--- a/libraries/src/AWS.Lambda.Powertools.Idempotency/Idempotency.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Idempotency/Idempotency.cs
@@ -181,7 +181,6 @@ public sealed class Idempotency
             return this;
         }
 
-#if NET8_0_OR_GREATER
         /// <summary>
         /// Set Customer JsonSerializerContext to append to IdempotencySerializationContext 
         /// </summary>
@@ -192,6 +191,5 @@ public sealed class Idempotency
             IdempotencySerializer.AddTypeInfoResolver(context);
             return this;
         }
-#endif
     }
 }

--- a/libraries/src/AWS.Lambda.Powertools.Idempotency/IdempotencyOptionsBuilder.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Idempotency/IdempotencyOptionsBuilder.cs
@@ -122,9 +122,7 @@ public class IdempotencyOptionsBuilder
     /// </summary>
     /// <param name="hashFunction">Can be any algorithm supported by HashAlgorithm.Create</param>
     /// <returns>the instance of the builder (to chain operations)</returns>
-#if NET8_0_OR_GREATER
     [Obsolete("Idempotency uses MD5 and does not support other hash algorithms.")]
-#endif
     public IdempotencyOptionsBuilder WithHashFunction(string hashFunction)
     {
         return this;

--- a/libraries/src/AWS.Lambda.Powertools.Idempotency/IdempotencyOptionsBuilder.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Idempotency/IdempotencyOptionsBuilder.cs
@@ -127,10 +127,6 @@ public class IdempotencyOptionsBuilder
 #endif
     public IdempotencyOptionsBuilder WithHashFunction(string hashFunction)
     {
-#if NET6_0
-        // for backward compability keep this code in .net 6
-        _hashFunction = hashFunction;
-#endif
         return this;
     }
 }

--- a/libraries/src/AWS.Lambda.Powertools.Idempotency/Internal/Serializers/IdempotencySerializationContext.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Idempotency/Internal/Serializers/IdempotencySerializationContext.cs
@@ -17,8 +17,6 @@ using System.Text.Json.Serialization;
 
 namespace AWS.Lambda.Powertools.Idempotency.Internal.Serializers;
 
-#if NET8_0_OR_GREATER
-
 
 /// <summary>
 /// The source generated JsonSerializerContext to be used to Serialize Idempotency types 
@@ -29,4 +27,3 @@ public partial class IdempotencySerializationContext : JsonSerializerContext
 {
     
 }
-#endif

--- a/libraries/src/AWS.Lambda.Powertools.Idempotency/Internal/Serializers/IdempotencySerializer.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Idempotency/Internal/Serializers/IdempotencySerializer.cs
@@ -98,9 +98,6 @@ internal static class IdempotencySerializer
     /// <returns>A JSON string representation of the object.</returns>
     internal static string Serialize(object value, Type inputType)
     {
-#if NET6_0
-        return JsonSerializer.Serialize(value, _jsonOptions);
-#else
         if (RuntimeFeatureWrapper.IsDynamicCodeSupported)
         {
 #pragma warning disable
@@ -115,7 +112,6 @@ internal static class IdempotencySerializer
         }
 
         return JsonSerializer.Serialize(value, typeInfo);
-#endif
     }
 
     /// <summary>
@@ -128,15 +124,11 @@ internal static class IdempotencySerializer
     [UnconditionalSuppressMessage("AOT", "IL3050:Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.", Justification = "False positive")]
     internal static T Deserialize<T>(string value)
     {
-#if NET6_0
-        return JsonSerializer.Deserialize<T>(value,_jsonOptions);
-#else
         if (RuntimeFeatureWrapper.IsDynamicCodeSupported)
         {
             return JsonSerializer.Deserialize<T>(value, _jsonOptions);
         }
 
         return (T)JsonSerializer.Deserialize(value, GetTypeInfo(typeof(T)));
-#endif
     }
 }

--- a/libraries/src/AWS.Lambda.Powertools.Idempotency/Internal/Serializers/IdempotencySerializer.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Idempotency/Internal/Serializers/IdempotencySerializer.cs
@@ -44,22 +44,18 @@ internal static class IdempotencySerializer
         {
             PropertyNameCaseInsensitive = true
         };
-#if NET8_0_OR_GREATER
         if (!RuntimeFeatureWrapper.IsDynamicCodeSupported)
         {
             _jsonOptions.TypeInfoResolverChain.Add(IdempotencySerializationContext.Default);
         }
-#endif
     }
-
-#if NET8_0_OR_GREATER
 
     /// <summary>
     /// Adds a JsonTypeInfoResolver to the JsonSerializerOptions.
     /// </summary>
     /// <param name="context">The JsonTypeInfoResolver to add.</param>
     /// <remarks>
-    /// This method is only available in .NET 8.0 and later versions.
+    /// This method is available in .NET 8.0 and later versions.
     /// </remarks>
     internal static void AddTypeInfoResolver(JsonSerializerContext context)
     {
@@ -88,7 +84,6 @@ internal static class IdempotencySerializer
     {
         _jsonOptions = options;
     }
-#endif
 
     /// <summary>
     /// Serializes the specified object to a JSON string.

--- a/libraries/src/AWS.Lambda.Powertools.Idempotency/Persistence/BasePersistenceStore.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Idempotency/Persistence/BasePersistenceStore.cs
@@ -339,12 +339,8 @@ public abstract class BasePersistenceStore : IPersistenceStore
     /// <exception cref="ArgumentException"></exception>
     internal string GenerateHash(JsonElement data)
     {
-#if NET8_0_OR_GREATER
         // starting .NET 8 no option to change hash algorithm
         using var hashAlgorithm = MD5.Create();
-#else
-        using var hashAlgorithm = HashAlgorithm.Create(_idempotencyOptions.HashFunction);
-#endif
         if (hashAlgorithm == null)
         {
             throw new ArgumentException("Invalid HashAlgorithm");

--- a/libraries/src/AWS.Lambda.Powertools.JMESPath/Serializers/JMESPathSerializationContext.cs
+++ b/libraries/src/AWS.Lambda.Powertools.JMESPath/Serializers/JMESPathSerializationContext.cs
@@ -18,8 +18,6 @@ using System.Text.Json.Serialization;
 
 namespace AWS.Lambda.Powertools.JMESPath.Serializers;
 
-#if NET8_0_OR_GREATER
-
 /// <summary>
 /// The source generated JsonSerializerContext to be used to Serialize JMESPath types 
 /// </summary>
@@ -32,5 +30,3 @@ namespace AWS.Lambda.Powertools.JMESPath.Serializers;
 public partial class JmesPathSerializationContext : JsonSerializerContext
 {
 }
-
-#endif

--- a/libraries/src/AWS.Lambda.Powertools.JMESPath/Serializers/JMESPathSerializer.cs
+++ b/libraries/src/AWS.Lambda.Powertools.JMESPath/Serializers/JMESPathSerializer.cs
@@ -31,12 +31,7 @@ internal static class JmesPathSerializer
     /// <returns>System.String.</returns>
     internal static string Serialize(object value, Type inputType)
     {
-#if NET6_0
-        return JsonSerializer.Serialize(value);
-#else
-
         return JsonSerializer.Serialize(value, inputType, JmesPathSerializationContext.Default);
-#endif
     }
     
     /// <summary>
@@ -47,11 +42,6 @@ internal static class JmesPathSerializer
     /// <returns>T.</returns>
     internal static T Deserialize<T>(string value)
     {
-#if NET6_0
-        return JsonSerializer.Deserialize<T>(value);
-#else
-
         return (T)JsonSerializer.Deserialize(value, typeof(T), JmesPathSerializationContext.Default);
-#endif
     }
 }

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Internal/PowertoolsLogger.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Internal/PowertoolsLogger.cs
@@ -261,11 +261,7 @@ internal sealed class PowertoolsLogger : ILogger
             var logObject = logFormatter.FormatLogEntry(logEntry);
             if (logObject is null)
                 throw new LogFormatException($"{logFormatter.GetType().FullName} returned Null value.");
-#if NET8_0_OR_GREATER
             return PowertoolsLoggerHelpers.ObjectToDictionary(logObject);
-#else
-            return logObject;
-#endif
         }
         catch (Exception e)
         {
@@ -289,13 +285,8 @@ internal sealed class PowertoolsLogger : ILogger
         if (exception is not null)
             return false;
 
-#if NET8_0_OR_GREATER
         var stateKeys = (state as IEnumerable<KeyValuePair<string, object>>)?
             .ToDictionary(i => i.Key, i => PowertoolsLoggerHelpers.ObjectToDictionary(i.Value));
-#else
-        var stateKeys = (state as IEnumerable<KeyValuePair<string, object>>)?
-            .ToDictionary(i => i.Key, i => i.Value);
-#endif
 
         if (stateKeys is null || stateKeys.Count != 2)
             return false;

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Logger.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Logger.cs
@@ -96,12 +96,8 @@ public class Logger
         if (string.IsNullOrWhiteSpace(key))
             throw new ArgumentNullException(nameof(key));
             
-#if NET8_0_OR_GREATER
         Scope[key] = PowertoolsLoggerHelpers.ObjectToDictionary(value) ??
                      throw new ArgumentNullException(nameof(value));
-#else
-        Scope[key] = value ?? throw new ArgumentNullException(nameof(value));
-#endif
     }
 
     /// <summary>

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Serializers/LoggingSerializationContext.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Serializers/LoggingSerializationContext.cs
@@ -20,8 +20,6 @@ using System.Text.Json.Serialization;
 
 namespace AWS.Lambda.Powertools.Logging.Serializers;
 
-#if NET8_0_OR_GREATER
-
 /// <summary>
 /// Custom JSON serializer context for AWS.Lambda.Powertools.Logging
 /// </summary>
@@ -44,5 +42,3 @@ public partial class PowertoolsLoggingSerializationContext : JsonSerializerConte
 {
 }
 
-
-#endif

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Serializers/PowertoolsLoggingSerializer.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Serializers/PowertoolsLoggingSerializer.cs
@@ -66,10 +66,6 @@ internal static class PowertoolsLoggingSerializer
     /// <exception cref="InvalidOperationException">Thrown when the input type is not known to the serializer.</exception>
     internal static string Serialize(object value, Type inputType)
     {
-#if NET6_0
-        var options = GetSerializerOptions();
-        return JsonSerializer.Serialize(value, options);
-#else
         if (RuntimeFeatureWrapper.IsDynamicCodeSupported)
         {
             var options = GetSerializerOptions();
@@ -85,7 +81,6 @@ internal static class PowertoolsLoggingSerializer
         }
 
         return JsonSerializer.Serialize(value, typeInfo);
-#endif
     }
 
 #if NET8_0_OR_GREATER
@@ -135,13 +130,8 @@ internal static class PowertoolsLoggingSerializer
                 _jsonOptions.DictionaryKeyPolicy = PascalCaseNamingPolicy.Instance;
                 break;
             default: // Snake case
-#if NET8_0_OR_GREATER
                 _jsonOptions.PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower;
                 _jsonOptions.DictionaryKeyPolicy = JsonNamingPolicy.SnakeCaseLower;
-#else
-                _jsonOptions.PropertyNamingPolicy = SnakeCaseNamingPolicy.Instance;
-                _jsonOptions.DictionaryKeyPolicy = SnakeCaseNamingPolicy.Instance;
-#endif
                 break;
         }
 
@@ -152,11 +142,7 @@ internal static class PowertoolsLoggingSerializer
         _jsonOptions.Converters.Add(new DateOnlyConverter());
         _jsonOptions.Converters.Add(new TimeOnlyConverter());
 
-#if NET8_0_OR_GREATER
         _jsonOptions.Converters.Add(new LogLevelJsonConverter());
-#elif NET6_0
-        _jsonOptions.Converters.Add(new LogLevelJsonConverter());
-#endif
 
         _jsonOptions.Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping;
         _jsonOptions.PropertyNameCaseInsensitive = true;

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Serializers/PowertoolsLoggingSerializer.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Serializers/PowertoolsLoggingSerializer.cs
@@ -83,7 +83,6 @@ internal static class PowertoolsLoggingSerializer
         return JsonSerializer.Serialize(value, typeInfo);
     }
 
-#if NET8_0_OR_GREATER
     /// <summary>
     /// Adds a JsonSerializerContext to the serializer options.
     /// </summary>
@@ -109,7 +108,6 @@ internal static class PowertoolsLoggingSerializer
         var options = GetSerializerOptions();
         return options.TypeInfoResolver?.GetTypeInfo(type, options);
     }
-#endif
 
     /// <summary>
     /// Builds and configures the JsonSerializerOptions.
@@ -147,8 +145,6 @@ internal static class PowertoolsLoggingSerializer
         _jsonOptions.Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping;
         _jsonOptions.PropertyNameCaseInsensitive = true;
 
-#if NET8_0_OR_GREATER
-
         // Only add TypeInfoResolver if AOT mode
         if (!RuntimeFeatureWrapper.IsDynamicCodeSupported)
         {
@@ -158,11 +154,9 @@ internal static class PowertoolsLoggingSerializer
                 _jsonOptions.TypeInfoResolverChain.Add(context);
             }
         }
-#endif
         return _jsonOptions;
     }
 
-#if NET8_0_OR_GREATER
     internal static bool HasContext(JsonSerializerContext customContext)
     {
         return AdditionalContexts.Contains(customContext);
@@ -172,7 +166,6 @@ internal static class PowertoolsLoggingSerializer
     {
         AdditionalContexts.Clear();
     }
-#endif
 
     /// <summary>
     /// Clears options for tests

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Serializers/PowertoolsSourceGeneratorSerializer.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Serializers/PowertoolsSourceGeneratorSerializer.cs
@@ -13,8 +13,6 @@
  * permissions and limitations under the License.
  */
 
-#if NET8_0_OR_GREATER
-
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
@@ -77,5 +75,3 @@ public sealed class PowertoolsSourceGeneratorSerializer<
         PowertoolsLoggingSerializer.AddSerializerContext(jsonSerializerContext);
     }
 }
-
-#endif

--- a/libraries/src/AWS.Lambda.Powertools.Metrics/Model/MetricUnit.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/Model/MetricUnit.cs
@@ -21,11 +21,7 @@ namespace AWS.Lambda.Powertools.Metrics;
 /// <summary>
 /// Enum MetricUnit
 /// </summary>
-#if NET8_0_OR_GREATER
 [JsonConverter(typeof(JsonStringEnumConverter<MetricUnit>))]
-#else
-[JsonConverter(typeof(JsonStringEnumConverter))]
-#endif
 public enum MetricUnit
 {
     /// <summary>

--- a/libraries/src/AWS.Lambda.Powertools.Metrics/Model/RootNode.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/Model/RootNode.cs
@@ -65,11 +65,6 @@ public class RootNode
     {
         if (string.IsNullOrWhiteSpace(AWS.GetNamespace())) throw new SchemaValidationException("namespace");
 
-#if NET8_0_OR_GREATER
-
         return JsonSerializer.Serialize(this, typeof(RootNode), MetricsSerializationContext.Default);
-#else
-        return JsonSerializer.Serialize(this);
-#endif
     }
 }

--- a/libraries/src/AWS.Lambda.Powertools.Metrics/Serializer/MetricsSerializationContext.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/Serializer/MetricsSerializationContext.cs
@@ -18,7 +18,6 @@ using System.Text.Json.Serialization;
 
 namespace AWS.Lambda.Powertools.Metrics;
 
-#if NET8_0_OR_GREATER
 /// <summary>
 /// Source generator for Metrics types
 /// </summary>
@@ -37,4 +36,3 @@ public partial class MetricsSerializationContext : JsonSerializerContext
 {
 
 }
-#endif

--- a/libraries/src/AWS.Lambda.Powertools.Tracing/Internal/TracingAspect.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Tracing/Internal/TracingAspect.cs
@@ -168,7 +168,6 @@ public class TracingAspect
         // Skip if the result is VoidTaskResult
         if (result.GetType().Name == "VoidTaskResult") return;
 
-#if NET8_0_OR_GREATER
         if (!RuntimeFeatureWrapper.IsDynamicCodeSupported) // is AOT
         {
             _xRayRecorder.AddMetadata(
@@ -178,7 +177,6 @@ public class TracingAspect
             );
             return;
         }
-#endif
 
         _xRayRecorder.AddMetadata(
             @namespace,

--- a/libraries/src/AWS.Lambda.Powertools.Tracing/Serializers/PowertoolsTracingSerializer.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Tracing/Serializers/PowertoolsTracingSerializer.cs
@@ -14,8 +14,6 @@
  */
 
 
-#if NET8_0_OR_GREATER
-
 using System;
 using System.Collections.Generic;
 using System.Text.Json;
@@ -104,5 +102,3 @@ public static class PowertoolsTracingSerializer
         }
     }
 }
-
-#endif

--- a/libraries/src/AWS.Lambda.Powertools.Tracing/Serializers/TracingSerializerExtensions.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Tracing/Serializers/TracingSerializerExtensions.cs
@@ -13,8 +13,6 @@
  * permissions and limitations under the License.
  */
 
-#if NET8_0_OR_GREATER
-
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
@@ -55,5 +53,3 @@ public static class TracingSerializerExtensions
         return serializer;
     }
 }
-
-#endif

--- a/libraries/src/Directory.Build.props
+++ b/libraries/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <LangVersion>default</LangVersion>
         <!-- Version is generated when packaging the individual csproj -->
         <Version>0.0.1</Version>

--- a/libraries/src/Directory.Build.props
+++ b/libraries/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFramework>net8.0</TargetFramework>
         <LangVersion>default</LangVersion>
         <!-- Version is generated when packaging the individual csproj -->
         <Version>0.0.1</Version>

--- a/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Internal/IdempotencySerializerTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Internal/IdempotencySerializerTests.cs
@@ -14,9 +14,7 @@ public class IdempotencySerializerTests
 {
     public IdempotencySerializerTests()
     {
-#if NET8_0_OR_GREATER
         IdempotencySerializer.AddTypeInfoResolver(TestJsonSerializerContext.Default);
-#endif
     }
 
     [Fact]
@@ -58,8 +56,6 @@ public class IdempotencySerializerTests
         // Assert
         Assert.True(options.PropertyNameCaseInsensitive);
     }
-
-#if NET8_0_OR_GREATER
 
     [Fact]
     public void GetTypeInfo_UnknownType_ThrowsException()
@@ -155,5 +151,4 @@ public class IdempotencySerializerTests
         Assert.Same(newOptions, options);
     }
     
-#endif
 }

--- a/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Internal/IdempotentAspectTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Internal/IdempotentAspectTests.cs
@@ -41,9 +41,7 @@ public class IdempotentAspectTests : IDisposable
         var store = Substitute.For<BasePersistenceStore>();
         Idempotency.Configure(builder =>
             builder
-#if NET8_0_OR_GREATER
                 .WithJsonSerializationContext(TestJsonSerializerContext.Default)
-#endif
                 .WithPersistenceStore(store)
                 .WithOptions(optionsBuilder => optionsBuilder.WithEventKeyJmesPath("Id"))
         );
@@ -89,9 +87,7 @@ public class IdempotentAspectTests : IDisposable
         // GIVEN
         Idempotency.Configure(builder =>
             builder
-#if NET8_0_OR_GREATER
                 .WithJsonSerializationContext(TestJsonSerializerContext.Default)
-#endif
                 .WithPersistenceStore(store)
                 .WithOptions(optionsBuilder => optionsBuilder.WithEventKeyJmesPath("Id"))
         );
@@ -128,9 +124,7 @@ public class IdempotentAspectTests : IDisposable
         Idempotency.Configure(builder =>
             builder
                 .WithPersistenceStore(store)
-#if NET8_0_OR_GREATER
                 .WithJsonSerializationContext(TestJsonSerializerContext.Default)
-#endif
                 .WithOptions(optionsBuilder => optionsBuilder.WithEventKeyJmesPath("Id"))
         );
 
@@ -169,9 +163,7 @@ public class IdempotentAspectTests : IDisposable
         Idempotency.Configure(builder =>
             builder
                 .WithPersistenceStore(store)
-#if NET8_0_OR_GREATER
                 .WithJsonSerializationContext(TestJsonSerializerContext.Default)
-#endif
                 .WithOptions(optionsBuilder => optionsBuilder.WithEventKeyJmesPath("Id"))
         );
 
@@ -212,9 +204,7 @@ public class IdempotentAspectTests : IDisposable
         Idempotency.Configure(builder =>
             builder
                 .WithPersistenceStore(store)
-#if NET8_0_OR_GREATER
                 .WithJsonSerializationContext(TestJsonSerializerContext.Default)
-#endif
                 .WithOptions(optionsBuilder => optionsBuilder.WithEventKeyJmesPath("Id"))
         );
 
@@ -242,9 +232,7 @@ public class IdempotentAspectTests : IDisposable
         Idempotency.Configure(builder =>
             builder
                 .WithPersistenceStore(store)
-#if NET8_0_OR_GREATER
                 .WithJsonSerializationContext(TestJsonSerializerContext.Default)
-#endif
                 .WithOptions(optionsBuilder => optionsBuilder.WithEventKeyJmesPath("Id"))
         );
 
@@ -360,9 +348,7 @@ public class IdempotentAspectTests : IDisposable
         Idempotency.Configure(builder =>
             builder
                 .WithPersistenceStore(store)
-#if NET8_0_OR_GREATER
                 .WithJsonSerializationContext(TestJsonSerializerContext.Default)
-#endif
                 .WithOptions(optionsBuilder => optionsBuilder.WithEventKeyJmesPath("Id"))
         );
 

--- a/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Persistence/BasePersistenceStoreTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Persistence/BasePersistenceStoreTests.cs
@@ -566,9 +566,7 @@ public class BasePersistenceStoreTests
         var eventJson = File.ReadAllText("./resources/apigw_event.json");
         try
         {
-#if NET8_0_OR_GREATER
             IdempotencySerializer.AddTypeInfoResolver(TestJsonSerializerContext.Default);
-#endif
             var request = IdempotencySerializer.Deserialize<APIGatewayProxyRequest>(eventJson);
             return request!;
         }

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Attributes/LoggerAspectTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Attributes/LoggerAspectTests.cs
@@ -41,10 +41,8 @@ public class LoggerAspectTests : IDisposable
     public void OnEntry_ShouldInitializeLogger_WhenCalledWithValidArguments()
     {
         // Arrange
-#if NET8_0_OR_GREATER
         // Add seriolization context for AOT
         PowertoolsLoggingSerializer.AddSerializerContext(TestJsonContext.Default);
-#endif
 
         var instance = new object();
         var name = "TestMethod";
@@ -84,11 +82,8 @@ public class LoggerAspectTests : IDisposable
     public void OnEntry_ShouldLog_Event_When_EnvironmentVariable_Set()
     {
         // Arrange
-#if NET8_0_OR_GREATER
-
         // Add seriolization context for AOT
         PowertoolsLoggingSerializer.AddSerializerContext(TestJsonContext.Default);
-#endif
 
         var instance = new object();
         var name = "TestMethod";
@@ -134,11 +129,8 @@ public class LoggerAspectTests : IDisposable
     public void OnEntry_ShouldLog_SamplingRate_When_EnvironmentVariable_Set()
     {
         // Arrange
-#if NET8_0_OR_GREATER
-
         // Add seriolization context for AOT
         PowertoolsLoggingSerializer.AddSerializerContext(TestJsonContext.Default);
-#endif
 
         var instance = new object();
         var name = "TestMethod";
@@ -209,11 +201,8 @@ public class LoggerAspectTests : IDisposable
     public void OnEntry_ShouldNot_Log_Info_When_LogLevel_Higher_EnvironmentVariable()
     {
         // Arrange
-#if NET8_0_OR_GREATER
-
         // Add seriolization context for AOT
         PowertoolsLoggingSerializer.AddSerializerContext(TestJsonContext.Default);
-#endif
 
         var instance = new object();
         var name = "TestMethod";
@@ -253,11 +242,8 @@ public class LoggerAspectTests : IDisposable
     public void OnEntry_Should_LogDebug_WhenSet_EnvironmentVariable()
     {
         // Arrange
-#if NET8_0_OR_GREATER
-
         // Add seriolization context for AOT
         PowertoolsLoggingSerializer.AddSerializerContext(TestJsonContext.Default);
-#endif
 
         var instance = new object();
         var name = "TestMethod";

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Attributes/LoggingAttributeTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Attributes/LoggingAttributeTest.cs
@@ -119,11 +119,8 @@ namespace AWS.Lambda.Powertools.Logging.Tests.Attributes
             SystemWrapper.Instance.SetOut(consoleOut);
             var correlationId = Guid.NewGuid().ToString();
                 
-#if NET8_0_OR_GREATER
-
             // Add seriolization context for AOT
             PowertoolsLoggingSerializer.AddSerializerContext(TestJsonContext.Default);
-#endif
             var context = new TestLambdaContext()
             {
                 FunctionName = "PowertoolsLoggingSample-HelloWorldFunction-Gg8rhPwO7Wa1"
@@ -152,11 +149,8 @@ namespace AWS.Lambda.Powertools.Logging.Tests.Attributes
             var consoleOut = Substitute.For<StringWriter>();
             SystemWrapper.Instance.SetOut(consoleOut);
             
-#if NET8_0_OR_GREATER
-
             // Add seriolization context for AOT
             PowertoolsLoggingSerializer.AddSerializerContext(TestJsonContext.Default);
-#endif
             var context = new TestLambdaContext()
             {
                 FunctionName = "PowertoolsLoggingSample-HelloWorldFunction-Gg8rhPwO7Wa1"
@@ -209,11 +203,8 @@ namespace AWS.Lambda.Powertools.Logging.Tests.Attributes
             // Arrange
             var correlationId = Guid.NewGuid().ToString();
 
-#if NET8_0_OR_GREATER
-
             // Add seriolization context for AOT
             PowertoolsLoggingSerializer.AddSerializerContext(TestJsonContext.Default);
-#endif
 
             // Act
             switch (correlationIdPath)
@@ -270,11 +261,8 @@ namespace AWS.Lambda.Powertools.Logging.Tests.Attributes
             // Arrange
             var correlationId = Guid.NewGuid().ToString();
 
-#if NET8_0_OR_GREATER
-
             // Add seriolization context for AOT
             PowertoolsLoggingSerializer.AddSerializerContext(TestJsonContext.Default);
-#endif
 
             // Act
             switch (outputCase)
@@ -325,11 +313,8 @@ namespace AWS.Lambda.Powertools.Logging.Tests.Attributes
             // Arrange
             var correlationId = Guid.NewGuid().ToString();
 
-#if NET8_0_OR_GREATER
-
             // Add seriolization context for AOT
             PowertoolsLoggingSerializer.AddSerializerContext(TestJsonContext.Default);
-#endif
 
             // Act
             switch (outputCase)

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Formatter/LogFormatterTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Formatter/LogFormatterTest.cs
@@ -244,19 +244,11 @@ namespace AWS.Lambda.Powertools.Logging.Tests.Formatter
             // serializer works differently in .net 8 and AOT. In .net 6 it writes properties that have null
             // in .net 8 it removes null properties
 
-#if NET8_0_OR_GREATER
             consoleOut.Received(1).WriteLine(
                 Arg.Is<string>(i =>
                     i.Contains(
                         "\"correlation_ids\":{\"aws_request_id\":\"requestId\"},\"lambda_function\":{\"name\":\"funtionName\",\"arn\":\"function::arn\",\"memory_limit_in_mb\":128,\"version\":\"version\",\"cold_start\":true},\"level\":\"Information\""))
             );
-#else
-            consoleOut.Received(1).WriteLine(
-                Arg.Is<string>(i =>
-                    i.Contains(
-                    "{\"message\":\"test\",\"service\":\"my_service\",\"correlation_ids\":{\"aws_request_id\":\"requestId\",\"x_ray_trace_id\":null,\"correlation_id\":null},\"lambda_function\":{\"name\":\"funtionName\",\"arn\":\"function::arn\",\"memory_limit_in_m_b\":128,\"version\":\"version\",\"cold_start\":true},\"level\":\"Information\",\"timestamp\":\"2024-01-01T00:00:00.0000000\",\"logger\":{\"name\":\"AWS.Lambda.Powertools.Logging.Logger\",\"sample_rate\""))
-            );
-#endif
         }
 
         [Fact]
@@ -280,19 +272,11 @@ namespace AWS.Lambda.Powertools.Logging.Tests.Formatter
             // serializer works differently in .net 8 and AOT. In .net 6 it writes properties that have null
             // in .net 8 it removes null properties
 
-#if NET8_0_OR_GREATER
             consoleOut.Received(1).WriteLine(
                 Arg.Is<string>(i =>
                     i ==
                     "{\"message\":\"test\",\"service\":\"service_undefined\",\"correlation_ids\":{},\"lambda_function\":{\"cold_start\":true},\"level\":\"Information\",\"timestamp\":\"2024-01-01T00:00:00.0000000\",\"logger\":{\"name\":\"AWS.Lambda.Powertools.Logging.Logger\",\"sample_rate\":0}}")
             );
-#else
-            consoleOut.Received(1).WriteLine(
-                Arg.Is<string>(i =>
-                    i ==
-                    "{\"message\":\"test\",\"service\":\"service_undefined\",\"correlation_ids\":{\"aws_request_id\":null,\"x_ray_trace_id\":null,\"correlation_id\":null},\"lambda_function\":{\"name\":null,\"arn\":null,\"memory_limit_in_m_b\":null,\"version\":null,\"cold_start\":true},\"level\":\"Information\",\"timestamp\":\"2024-01-01T00:00:00.0000000\",\"logger\":{\"name\":\"AWS.Lambda.Powertools.Logging.Logger\",\"sample_rate\":0}}")
-            );
-#endif
         }
 
         [Fact]
@@ -305,19 +289,11 @@ namespace AWS.Lambda.Powertools.Logging.Tests.Formatter
 
             _testHandler.TestCustomFormatterWithDecoratorNoContext("test");
 
-#if NET8_0_OR_GREATER
             consoleOut.Received(1).WriteLine(
                 Arg.Is<string>(i =>
                     i ==
                     "{\"message\":\"test\",\"service\":\"my_service\",\"correlation_ids\":{},\"lambda_function\":{\"cold_start\":true},\"level\":\"Information\",\"timestamp\":\"2024-01-01T00:00:00.0000000\",\"logger\":{\"name\":\"AWS.Lambda.Powertools.Logging.Logger\",\"sample_rate\":0.2}}")
             );
-#else
-            consoleOut.Received(1).WriteLine(
-                Arg.Is<string>(i =>
-                    i ==
-                    "{\"message\":\"test\",\"service\":\"my_service\",\"correlation_ids\":{\"aws_request_id\":null,\"x_ray_trace_id\":null,\"correlation_id\":null},\"lambda_function\":{\"name\":null,\"arn\":null,\"memory_limit_in_m_b\":null,\"version\":null,\"cold_start\":true},\"level\":\"Information\",\"timestamp\":\"2024-01-01T00:00:00.0000000\",\"logger\":{\"name\":\"AWS.Lambda.Powertools.Logging.Logger\",\"sample_rate\":0.2}}")
-            );
-#endif
         }
 
         public void Dispose()

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Serializers/PowertoolsLambdaSerializerTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Serializers/PowertoolsLambdaSerializerTests.cs
@@ -228,34 +228,4 @@ public class PowertoolsLambdaSerializerTests : IDisposable
         PowertoolsLoggingSerializer.ClearOptions();
     }
 
-#if NET6_0
-
-    [Fact]
-    public void Should_Serialize_Net6()
-    {
-        // Arrange
-        PowertoolsLoggingSerializer.ConfigureNamingPolicy(LoggingConstants.DefaultLoggerOutputCase);
-        var testObject = new APIGatewayProxyRequest
-        {
-            Path = "asda",
-            RequestContext = new APIGatewayProxyRequest.ProxyRequestContext
-            {
-                RequestId = "asdas"
-            }
-        };
-
-        var log = new LogEntry
-        {
-            Name = "dasda",
-            Message = testObject
-        };
-
-        var outptuMySerializer = PowertoolsLoggingSerializer.Serialize(log, null);
-
-        // Assert
-        Assert.Equal(
-            "{\"cold_start\":false,\"x_ray_trace_id\":null,\"correlation_id\":null,\"timestamp\":\"0001-01-01T00:00:00\",\"level\":\"Trace\",\"service\":null,\"name\":\"dasda\",\"message\":{\"resource\":null,\"path\":\"asda\",\"http_method\":null,\"headers\":null,\"multi_value_headers\":null,\"query_string_parameters\":null,\"multi_value_query_string_parameters\":null,\"path_parameters\":null,\"stage_variables\":null,\"request_context\":{\"path\":null,\"account_id\":null,\"resource_id\":null,\"stage\":null,\"request_id\":\"asdas\",\"identity\":null,\"resource_path\":null,\"http_method\":null,\"api_id\":null,\"extended_request_id\":null,\"connection_id\":null,\"connected_at\":0,\"domain_name\":null,\"domain_prefix\":null,\"event_type\":null,\"message_id\":null,\"route_key\":null,\"authorizer\":null,\"operation_name\":null,\"error\":null,\"integration_latency\":null,\"message_direction\":null,\"request_time\":null,\"request_time_epoch\":0,\"status\":null},\"body\":null,\"is_base64_encoded\":false},\"sampling_rate\":null,\"extra_keys\":null,\"exception\":null,\"lambda_context\":null}",
-            outptuMySerializer);
-    }
-#endif
 }

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Serializers/PowertoolsLambdaSerializerTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Serializers/PowertoolsLambdaSerializerTests.cs
@@ -30,7 +30,6 @@ namespace AWS.Lambda.Powertools.Logging.Tests.Serializers;
 
 public class PowertoolsLambdaSerializerTests : IDisposable
 {
-#if NET8_0_OR_GREATER
     [Fact]
     public void Constructor_ShouldNotThrowException()
     {
@@ -221,7 +220,6 @@ public class PowertoolsLambdaSerializerTests : IDisposable
     }
 
 
-#endif
     public void Dispose()
     {
         PowertoolsLoggingSerializer.ConfigureNamingPolicy(LoggingConstants.DefaultLoggerOutputCase);

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Serializers/PowertoolsLoggingSerializerTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Serializers/PowertoolsLoggingSerializerTests.cs
@@ -35,9 +35,7 @@ public class PowertoolsLoggingSerializerTests : IDisposable
     public PowertoolsLoggingSerializerTests()
     {
         PowertoolsLoggingSerializer.ConfigureNamingPolicy(LoggingConstants.DefaultLoggerOutputCase);
-#if NET8_0_OR_GREATER
         PowertoolsLoggingSerializer.ClearContext();
-#endif
     }
     
     [Fact]
@@ -61,18 +59,12 @@ public class PowertoolsLoggingSerializerTests : IDisposable
             converter => Assert.IsType<ConstantClassConverter>(converter),
             converter => Assert.IsType<DateOnlyConverter>(converter),
             converter => Assert.IsType<TimeOnlyConverter>(converter),
-#if NET8_0_OR_GREATER
             converter => Assert.IsType<LogLevelJsonConverter>(converter));
-#elif NET6_0
-            converter => Assert.IsType<LogLevelJsonConverter>(converter));
-#endif
 
         Assert.Equal(JavaScriptEncoder.UnsafeRelaxedJsonEscaping, options.Encoder);
 
-#if NET8_0_OR_GREATER
         Assert.Collection(options.TypeInfoResolverChain,
             resolver => Assert.IsType<PowertoolsLoggingSerializationContext>(resolver));
-#endif
     }
     
     [Fact]
@@ -89,17 +81,11 @@ public class PowertoolsLoggingSerializerTests : IDisposable
             converter => Assert.IsType<ConstantClassConverter>(converter),
             converter => Assert.IsType<DateOnlyConverter>(converter),
             converter => Assert.IsType<TimeOnlyConverter>(converter),
-#if NET8_0_OR_GREATER
             converter => Assert.IsType<LogLevelJsonConverter>(converter));
-#elif NET6_0
-            converter => Assert.IsType<LogLevelJsonConverter>(converter));
-#endif
 
         Assert.Equal(JavaScriptEncoder.UnsafeRelaxedJsonEscaping, options.Encoder);
 
-#if NET8_0_OR_GREATER
         Assert.Empty(options.TypeInfoResolverChain);
-#endif
     }
 
     [Fact]
@@ -167,7 +153,6 @@ public class PowertoolsLoggingSerializerTests : IDisposable
         Assert.Contains("\"level\":\"Error\"", json);
     }
 
-#if NET8_0_OR_GREATER
     [Fact]
     public void Serialize_UnknownType_ThrowsInvalidOperationException()
     {
@@ -201,7 +186,6 @@ public class PowertoolsLoggingSerializerTests : IDisposable
     {
         public string SomeProperty { get; set; }
     }
-#endif
 
     private string SerializeTestObject(LoggerOutputCase? outputCase)
     {
@@ -217,9 +201,7 @@ public class PowertoolsLoggingSerializerTests : IDisposable
     public void Dispose()
     {
         PowertoolsLoggingSerializer.ConfigureNamingPolicy(LoggingConstants.DefaultLoggerOutputCase);
-#if NET8_0_OR_GREATER
         PowertoolsLoggingSerializer.ClearContext();
-#endif
         PowertoolsLoggingSerializer.ClearOptions();
         RuntimeFeatureWrapper.Reset();
     }

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Utilities/PowertoolsLoggerHelpersTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Utilities/PowertoolsLoggerHelpersTests.cs
@@ -1,5 +1,3 @@
-#if NET8_0_OR_GREATER
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -205,5 +203,3 @@ public class PowertoolsLoggerHelpersTests : IDisposable
         PowertoolsLoggingSerializer.ClearOptions();
     }
 }
-
-#endif

--- a/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/Serializers/PowertoolsTracingSerializerTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/Serializers/PowertoolsTracingSerializerTests.cs
@@ -13,7 +13,6 @@
  * permissions and limitations under the License.
  */
 
-#if NET8_0_OR_GREATER
 using System;
 using System.Collections.Generic;
 using System.Text.Json;
@@ -252,4 +251,3 @@ public class TestArrayObject
 {
     public int[] Values { get; set; }
 }
-#endif

--- a/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/Serializers/TestJsonContext.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/Serializers/TestJsonContext.cs
@@ -13,8 +13,6 @@
  * permissions and limitations under the License.
  */
 
-#if NET8_0_OR_GREATER
-
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
@@ -43,7 +41,6 @@ public class TestComplexObject
     public Dictionary<string, object> NestedObject { get; set; }
 }
 
-#endif
 
 public class TestResponse
 {

--- a/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/Serializers/TracingSerializerExtensionsTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/Serializers/TracingSerializerExtensionsTests.cs
@@ -14,7 +14,6 @@
  */
 
 
-#if NET8_0_OR_GREATER
 using Amazon.Lambda.Serialization.SystemTextJson;
 using AWS.Lambda.Powertools.Tracing.Serializers;
 using Xunit;
@@ -41,4 +40,3 @@ public class TracingSerializerExtensionsTests
         Assert.Contains("\"Name\":\"Test\"", serialized);
     }
 }
-#endif

--- a/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/TracingAspectTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/TracingAspectTests.cs
@@ -23,10 +23,8 @@ using AWS.Lambda.Powertools.Tracing.Internal;
 using NSubstitute;
 using Xunit;
 
-#if NET8_0_OR_GREATER
 using AWS.Lambda.Powertools.Tracing.Serializers;
 using AWS.Lambda.Powertools.Tracing.Tests.Serializers;
-#endif
 
 namespace AWS.Lambda.Powertools.Tracing.Tests;
 
@@ -113,7 +111,6 @@ public class TracingAspectTests
         _mockXRayRecorder.Received(1).EndSubsegment();
     }
 
-#if NET8_0_OR_GREATER
     [Fact]
     public void Around_SyncMethod_HandlesResponseAndSegmentCorrectly_AOT()
     {
@@ -177,7 +174,6 @@ public class TracingAspectTests
             PowertoolsTracingSerializer.Serialize(result));
         _mockXRayRecorder.Received(1).EndSubsegment();
     }
-#endif
 
     [Fact]
     public async Task Around_VoidAsyncMethod_HandlesSegmentCorrectly()

--- a/libraries/tests/Directory.Build.props
+++ b/libraries/tests/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
     <ItemGroup>

--- a/libraries/tests/Directory.Build.props
+++ b/libraries/tests/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
     <ItemGroup>

--- a/libraries/tests/e2e/functions/core/logging/Function/src/Function/Function.csproj
+++ b/libraries/tests/e2e/functions/core/logging/Function/src/Function/Function.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/libraries/tests/e2e/functions/core/logging/Function/src/Function/Function.csproj
+++ b/libraries/tests/e2e/functions/core/logging/Function/src/Function/Function.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/libraries/tests/e2e/functions/core/metrics/Function/src/Function/Function.csproj
+++ b/libraries/tests/e2e/functions/core/metrics/Function/src/Function/Function.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/libraries/tests/e2e/functions/core/metrics/Function/src/Function/Function.csproj
+++ b/libraries/tests/e2e/functions/core/metrics/Function/src/Function/Function.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/libraries/tests/e2e/functions/core/tracing/Function/src/Function/Function.csproj
+++ b/libraries/tests/e2e/functions/core/tracing/Function/src/Function/Function.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/libraries/tests/e2e/functions/core/tracing/Function/src/Function/Function.csproj
+++ b/libraries/tests/e2e/functions/core/tracing/Function/src/Function/Function.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/libraries/tests/e2e/functions/idempotency/Function/src/Function/Function.csproj
+++ b/libraries/tests/e2e/functions/idempotency/Function/src/Function/Function.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/libraries/tests/e2e/functions/idempotency/Function/src/Function/Function.csproj
+++ b/libraries/tests/e2e/functions/idempotency/Function/src/Function/Function.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>


### PR DESCRIPTION
Hey team! I implemented the .NET 6 deprecation as requested in #749. Since .NET 6 is out of support and AWS Lambda is dropping it in October, I cleaned up all the dual-targeting mess we had.

### What I did:

**Fixed the targeting:**
- I updated both `Directory.Build.props` files to only target `net8.0` (removed `net6.0;net8.0`)
- Found 4 e2e test projects that were still trying to build for .NET 6 and fixed those too

**Cleaned up the code:**
- I nuked all 7 `#if NET6_0` blocks across the codebase
- I simplified the `#if NET8_0_OR_GREATER` blocks that had fallback code for .NET 6
- For example, that MD5 hash thing in BasePersistenceStore now just uses `MD5.Create()` instead of the old `HashAlgorithm.Create()` fallback

**Updated docs:**
- I went through README, docs, and all the example READMEs to change ".NET 6" mentions to ".NET 8"
- Updated the roadmap to mark this as done

### Testing:
I ran the full test suite - all 703 unit tests pass! Build is clean too. The e2e tests fail but that's because of missing Lambda functions in the cloud, not our changes.

### Breaking change heads up:
Yeah, this is breaking. If you're still on .NET 6, you'll need to upgrade your projects to .NET 8. But honestly, you should be doing that anyway since .NET 6 is EOL.

Just change your `<TargetFramework>net6.0</TargetFramework>` to `<TargetFramework>net8.0</TargetFramework>` and install .NET 8. No API changes needed.

Fixes #749