### PR TITLE
chore: Remove .NET 6 from TargetFrameworks

### DIFF
--- a/libraries/src/Directory.Build.props
+++ b/libraries/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFramework>net8.0</TargetFramework>
         <LangVersion>default</LangVersion>
         <!-- Version is generated when packaging the individual csproj -->
         <Version>$(Version)</Version>


### PR DESCRIPTION
This PR removes .NET 6 support by changing TargetFrameworks to target only .NET 8.

## Changes Made
- Updated `libraries/src/Directory.Build.props` to change `TargetFrameworks` to `TargetFramework` targeting only `net8.0`

This is the absolute minimal change to deprecate .NET 6 support as requested in PR #987.

**1 file changed, 1 insertion, 1 deletion**