### PR TITLE
chore: drop .NET 6 support, go .NET 8 only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,6 @@ jobs:
         uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # 5.0.0
         with:
           dotnet-version: |
-            6.0.x
             8.0.x
 
       - name: Install dependencies

--- a/.github/workflows/examples-tests.yml
+++ b/.github/workflows/examples-tests.yml
@@ -27,7 +27,6 @@ jobs:
         uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # 5.0.0
         with:
           dotnet-version: |
-            6.0.x
             8.0.x
 
       - name: Install dependencies

--- a/.github/workflows/publish-artifacts-examples-tests.yml
+++ b/.github/workflows/publish-artifacts-examples-tests.yml
@@ -33,7 +33,6 @@ jobs:
         uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # 5.0.0
         with:
           dotnet-version: |
-            6.0.x
             8.0.x
 
       - name: Build libraries
@@ -64,7 +63,6 @@ jobs:
         uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # 5.0.0
         with:
           dotnet-version: |
-            6.0.x
             8.0.x
 
       - name: Download packages
@@ -124,7 +122,6 @@ jobs:
         uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # 5.0.0
         with:
           dotnet-version: |
-            6.0.x
             8.0.x
 
       - name: Setup GitHub Packages source

--- a/libraries/src/AWS.Lambda.Powertools.Idempotency/Idempotency.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Idempotency/Idempotency.cs
@@ -166,9 +166,8 @@ public sealed class Idempotency
             return this;
         }
 
-#if NET8_0_OR_GREATER
         /// <summary>
-        /// Set Customer JsonSerializerContext to append to IdempotencySerializationContext 
+        /// Set Customer JsonSerializerContext to append to IdempotencySerializationContext
         /// </summary>
         /// <param name="context"></param>
         /// <returns>IdempotencyBuilder</returns>
@@ -177,6 +176,5 @@ public sealed class Idempotency
             IdempotencySerializer.AddTypeInfoResolver(context);
             return this;
         }
-#endif
     }
 }

--- a/libraries/src/AWS.Lambda.Powertools.Idempotency/IdempotencyOptionsBuilder.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Idempotency/IdempotencyOptionsBuilder.cs
@@ -160,15 +160,9 @@ public class IdempotencyOptionsBuilder
     /// </summary>
     /// <param name="hashFunction">Can be any algorithm supported by HashAlgorithm.Create</param>
     /// <returns>the instance of the builder (to chain operations)</returns>
-#if NET8_0_OR_GREATER
     [Obsolete("Idempotency uses MD5 and does not support other hash algorithms.")]
-#endif
     public IdempotencyOptionsBuilder WithHashFunction(string hashFunction)
     {
-#if NET6_0
-        // for backward compability keep this code in .net 6
-        _hashFunction = hashFunction;
-#endif
         return this;
     }
 

--- a/libraries/src/AWS.Lambda.Powertools.Idempotency/IdempotencyOptionsBuilder.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Idempotency/IdempotencyOptionsBuilder.cs
@@ -40,7 +40,7 @@ public class IdempotencyOptionsBuilder
     /// <summary>
     /// Default Hash function
     /// </summary>
-    private string _hashFunction = "MD5";
+    private readonly string _hashFunction = "MD5";
 
     /// <summary>
     /// Response hook function

--- a/libraries/src/AWS.Lambda.Powertools.Idempotency/Internal/Serializers/IdempotencySerializationContext.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Idempotency/Internal/Serializers/IdempotencySerializationContext.cs
@@ -17,11 +17,8 @@ using System.Text.Json.Serialization;
 
 namespace AWS.Lambda.Powertools.Idempotency.Internal.Serializers;
 
-#if NET8_0_OR_GREATER
-
-
 /// <summary>
-/// The source generated JsonSerializerContext to be used to Serialize Idempotency types 
+/// The source generated JsonSerializerContext to be used to Serialize Idempotency types
 /// </summary>
 [JsonSerializable(typeof(string))]
 [JsonSerializable(typeof(object))]
@@ -29,4 +26,3 @@ public partial class IdempotencySerializationContext : JsonSerializerContext
 {
     
 }
-#endif

--- a/libraries/src/AWS.Lambda.Powertools.Idempotency/Internal/Serializers/IdempotencySerializer.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Idempotency/Internal/Serializers/IdempotencySerializer.cs
@@ -29,15 +29,11 @@ internal static class IdempotencySerializer
         {
             PropertyNameCaseInsensitive = true
         };
-#if NET8_0_OR_GREATER
         if (!RuntimeFeatureWrapper.IsDynamicCodeSupported)
         {
             _jsonOptions.TypeInfoResolverChain.Add(IdempotencySerializationContext.Default);
         }
-#endif
     }
-
-#if NET8_0_OR_GREATER
 
     /// <summary>
     /// Adds a JsonTypeInfoResolver to the JsonSerializerOptions.
@@ -73,7 +69,6 @@ internal static class IdempotencySerializer
     {
         _jsonOptions = options;
     }
-#endif
 
     /// <summary>
     /// Serializes the specified object to a JSON string.
@@ -83,9 +78,6 @@ internal static class IdempotencySerializer
     /// <returns>A JSON string representation of the object.</returns>
     internal static string Serialize(object value, Type inputType)
     {
-#if NET6_0
-        return JsonSerializer.Serialize(value, _jsonOptions);
-#else
         if (RuntimeFeatureWrapper.IsDynamicCodeSupported)
         {
 #pragma warning disable
@@ -100,7 +92,6 @@ internal static class IdempotencySerializer
         }
 
         return JsonSerializer.Serialize(value, typeInfo);
-#endif
     }
 
     /// <summary>
@@ -113,15 +104,11 @@ internal static class IdempotencySerializer
     [UnconditionalSuppressMessage("AOT", "IL3050:Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.", Justification = "False positive")]
     internal static T Deserialize<T>(string value)
     {
-#if NET6_0
-        return JsonSerializer.Deserialize<T>(value,_jsonOptions);
-#else
         if (RuntimeFeatureWrapper.IsDynamicCodeSupported)
         {
             return JsonSerializer.Deserialize<T>(value, _jsonOptions);
         }
 
         return (T)JsonSerializer.Deserialize(value, GetTypeInfo(typeof(T)));
-#endif
     }
 }

--- a/libraries/src/AWS.Lambda.Powertools.Idempotency/Persistence/BasePersistenceStore.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Idempotency/Persistence/BasePersistenceStore.cs
@@ -324,12 +324,8 @@ public abstract class BasePersistenceStore : IPersistenceStore
     /// <exception cref="ArgumentException"></exception>
     internal string GenerateHash(JsonElement data)
     {
-#if NET8_0_OR_GREATER
         // starting .NET 8 no option to change hash algorithm
         using var hashAlgorithm = MD5.Create();
-#else
-        using var hashAlgorithm = HashAlgorithm.Create(_idempotencyOptions.HashFunction);
-#endif
         if (hashAlgorithm == null)
         {
             throw new ArgumentException("Invalid HashAlgorithm");

--- a/libraries/src/AWS.Lambda.Powertools.JMESPath/Serializers/JMESPathSerializationContext.cs
+++ b/libraries/src/AWS.Lambda.Powertools.JMESPath/Serializers/JMESPathSerializationContext.cs
@@ -3,8 +3,6 @@ using System.Text.Json.Serialization;
 
 namespace AWS.Lambda.Powertools.JMESPath.Serializers;
 
-#if NET8_0_OR_GREATER
-
 /// <summary>
 /// The source generated JsonSerializerContext to be used to Serialize JMESPath types 
 /// </summary>
@@ -17,5 +15,3 @@ namespace AWS.Lambda.Powertools.JMESPath.Serializers;
 public partial class JmesPathSerializationContext : JsonSerializerContext
 {
 }
-
-#endif

--- a/libraries/src/AWS.Lambda.Powertools.JMESPath/Serializers/JMESPathSerializer.cs
+++ b/libraries/src/AWS.Lambda.Powertools.JMESPath/Serializers/JMESPathSerializer.cs
@@ -16,12 +16,7 @@ internal static class JmesPathSerializer
     /// <returns>System.String.</returns>
     internal static string Serialize(object value, Type inputType)
     {
-#if NET6_0
-        return JsonSerializer.Serialize(value);
-#else
-
         return JsonSerializer.Serialize(value, inputType, JmesPathSerializationContext.Default);
-#endif
     }
     
     /// <summary>
@@ -32,11 +27,6 @@ internal static class JmesPathSerializer
     /// <returns>T.</returns>
     internal static T Deserialize<T>(string value)
     {
-#if NET6_0
-        return JsonSerializer.Deserialize<T>(value);
-#else
-
         return (T)JsonSerializer.Deserialize(value, typeof(T), JmesPathSerializationContext.Default);
-#endif
     }
 }

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Internal/PowertoolsLogger.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Internal/PowertoolsLogger.cs
@@ -397,11 +397,7 @@ internal sealed class PowertoolsLogger : ILogger
             if (logObject is null)
                 throw new LogFormatException($"{logFormatter.GetType().FullName} returned Null value.");
 
-#if NET8_0_OR_GREATER
             return PowertoolsLoggerHelpers.ObjectToDictionary(logObject);
-#else
-            return logObject;
-#endif
         }
         catch (Exception e)
         {
@@ -425,7 +421,6 @@ internal sealed class PowertoolsLogger : ILogger
         if (exception is not null)
             return false;
 
-#if NET8_0_OR_GREATER
         var stateKeys = new Dictionary<string, object>();
         if (state is IEnumerable<KeyValuePair<string, object>> keyValuePairs)
         {
@@ -434,16 +429,6 @@ internal sealed class PowertoolsLogger : ILogger
                 stateKeys[kvp.Key] = PowertoolsLoggerHelpers.ObjectToDictionary(kvp.Value);
             }
         }
-#else
-var stateKeys = new Dictionary<string, object>();
-if (state is IEnumerable<KeyValuePair<string, object>> keyValuePairs)
-{
-    foreach (var kvp in keyValuePairs)
-    {
-        stateKeys[kvp.Key] = kvp.Value;
-    }
-}
-#endif
 
         if (stateKeys.Count != 2)
             return false;

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Logger.Scope.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Logger.Scope.cs
@@ -25,12 +25,8 @@ public static partial class Logger
         if (string.IsNullOrWhiteSpace(key))
             throw new ArgumentNullException(nameof(key));
             
-#if NET8_0_OR_GREATER
         Scope[key] = PowertoolsLoggerHelpers.ObjectToDictionary(value) ??
                      throw new ArgumentNullException(nameof(value));
-#else
-        Scope[key] = value ?? throw new ArgumentNullException(nameof(value));
-#endif
     }
 
     /// <summary>

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Serializers/CompositeJsonTypeInfoResolver.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Serializers/CompositeJsonTypeInfoResolver.cs
@@ -1,5 +1,3 @@
-#if NET8_0_OR_GREATER
-
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
@@ -41,4 +39,3 @@ namespace AWS.Lambda.Powertools.Logging.Serializers
         }
     }
 }
-#endif

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Serializers/LoggingSerializationContext.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Serializers/LoggingSerializationContext.cs
@@ -5,8 +5,6 @@ using System.Text.Json.Serialization;
 
 namespace AWS.Lambda.Powertools.Logging.Serializers;
 
-#if NET8_0_OR_GREATER
-
 /// <summary>
 /// Custom JSON serializer context for AWS.Lambda.Powertools.Logging
 /// </summary>
@@ -28,6 +26,3 @@ namespace AWS.Lambda.Powertools.Logging.Serializers;
 public partial class PowertoolsLoggingSerializationContext : JsonSerializerContext
 {
 }
-
-
-#endif

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Serializers/PowertoolsLoggingSerializer.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Serializers/PowertoolsLoggingSerializer.cs
@@ -23,11 +23,9 @@ internal class PowertoolsLoggingSerializer
     private JsonSerializerOptions _jsonOptions;
     private readonly object _lock = new();
 
-#if NET8_0_OR_GREATER
     private readonly ConcurrentBag<JsonSerializerContext> _additionalContexts = new();
     private static JsonSerializerContext _staticAdditionalContexts;
     private IJsonTypeInfoResolver _customTypeInfoResolver;
-#endif
 
     /// <summary>
     /// Gets the JsonSerializerOptions instance.
@@ -79,10 +77,6 @@ internal class PowertoolsLoggingSerializer
     /// <exception cref="InvalidOperationException">Thrown when the input type is not known to the serializer.</exception>
     internal string Serialize(object value, Type inputType)
     {
-#if NET6_0
-        var options = GetSerializerOptions();
-        return JsonSerializer.Serialize(value, options);
-#else
         if (RuntimeFeatureWrapper.IsDynamicCodeSupported)
         {
             var jsonSerializerOptions = GetSerializerOptions();
@@ -99,11 +93,7 @@ internal class PowertoolsLoggingSerializer
         }
 
         return JsonSerializer.Serialize(value, typeInfo);
-
-#endif
     }
-
-#if NET8_0_OR_GREATER
 
     /// <summary>
     /// Adds a JsonSerializerContext to the serializer options.
@@ -177,8 +167,6 @@ internal class PowertoolsLoggingSerializer
         return options.TypeInfoResolver?.GetTypeInfo(type, options);
     }
 
-#endif
-
     /// <summary>
     /// Builds and configures the JsonSerializerOptions.
     /// </summary>
@@ -209,7 +197,6 @@ internal class PowertoolsLoggingSerializer
                 _jsonOptions.UnknownTypeHandling = options.UnknownTypeHandling;
                 _jsonOptions.AllowTrailingCommas = options.AllowTrailingCommas;
 
-#if NET8_0_OR_GREATER
                 // Handle type resolver extraction without setting it yet
                 if (options.TypeInfoResolver != null)
                 {
@@ -221,7 +208,6 @@ internal class PowertoolsLoggingSerializer
                         AddSerializerContext(jsonContext);
                     }
                 }
-#endif
             }
 
             // Set output case and other properties
@@ -230,13 +216,11 @@ internal class PowertoolsLoggingSerializer
             _jsonOptions.Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping;
             _jsonOptions.PropertyNameCaseInsensitive = true;
 
-#if NET8_0_OR_GREATER
             // Set TypeInfoResolver last, as this makes options read-only
             if (!RuntimeFeatureWrapper.IsDynamicCodeSupported)
             {
                 _jsonOptions.TypeInfoResolver = GetCompositeResolver();
             }
-#endif
         }
     }
 
@@ -253,14 +237,9 @@ internal class PowertoolsLoggingSerializer
                 _jsonOptions.DictionaryKeyPolicy = PascalCaseNamingPolicy.Instance;
                 break;
             default: // Snake case
-#if NET8_0_OR_GREATER
                 // If is default (Not Set) and JsonOptions provided with DictionaryKeyPolicy or PropertyNamingPolicy, use it
                 _jsonOptions.DictionaryKeyPolicy ??= JsonNamingPolicy.SnakeCaseLower;
                 _jsonOptions.PropertyNamingPolicy ??= JsonNamingPolicy.SnakeCaseLower;
-#else
-                _jsonOptions.PropertyNamingPolicy = SnakeCaseNamingPolicy.Instance;
-                _jsonOptions.DictionaryKeyPolicy = SnakeCaseNamingPolicy.Instance;
-#endif
                 break;
         }
     }
@@ -274,11 +253,7 @@ internal class PowertoolsLoggingSerializer
         _jsonOptions.Converters.Add(new DateOnlyConverter());
         _jsonOptions.Converters.Add(new TimeOnlyConverter());
 
-#if NET8_0_OR_GREATER
         _jsonOptions.Converters.Add(new LogLevelJsonConverter());
-#elif NET6_0
-        _jsonOptions.Converters.Add(new LogLevelJsonConverter());
-#endif
     }
 
     internal void SetOptions(JsonSerializerOptions options)

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Serializers/PowertoolsSourceGeneratorSerializer.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Serializers/PowertoolsSourceGeneratorSerializer.cs
@@ -1,5 +1,3 @@
-#if NET8_0_OR_GREATER
-
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
@@ -62,5 +60,3 @@ public sealed class PowertoolsSourceGeneratorSerializer<
         PowertoolsLoggingSerializer.AddStaticSerializerContext(jsonSerializerContext);
     }
 }
-
-#endif

--- a/libraries/src/AWS.Lambda.Powertools.Metrics/Model/MetricUnit.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/Model/MetricUnit.cs
@@ -21,11 +21,7 @@ namespace AWS.Lambda.Powertools.Metrics;
 /// <summary>
 /// Enum MetricUnit
 /// </summary>
-#if NET8_0_OR_GREATER
 [JsonConverter(typeof(JsonStringEnumConverter<MetricUnit>))]
-#else
-[JsonConverter(typeof(JsonStringEnumConverter))]
-#endif
 public enum MetricUnit
 {
     /// <summary>

--- a/libraries/src/AWS.Lambda.Powertools.Metrics/Model/RootNode.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/Model/RootNode.cs
@@ -65,11 +65,6 @@ public class RootNode
     {
         if (string.IsNullOrWhiteSpace(AWS.GetNamespace())) throw new SchemaValidationException("namespace");
 
-#if NET8_0_OR_GREATER
-
         return JsonSerializer.Serialize(this, typeof(RootNode), MetricsSerializationContext.Default);
-#else
-        return JsonSerializer.Serialize(this);
-#endif
     }
 }

--- a/libraries/src/AWS.Lambda.Powertools.Metrics/Serializer/MetricsSerializationContext.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/Serializer/MetricsSerializationContext.cs
@@ -3,7 +3,6 @@ using System.Text.Json.Serialization;
 
 namespace AWS.Lambda.Powertools.Metrics;
 
-#if NET8_0_OR_GREATER
 /// <summary>
 /// Source generator for Metrics types
 /// </summary>
@@ -22,4 +21,3 @@ public partial class MetricsSerializationContext : JsonSerializerContext
 {
 
 }
-#endif

--- a/libraries/src/AWS.Lambda.Powertools.Parameters/Internal/Transform/JsonTransformer.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Parameters/Internal/Transform/JsonTransformer.cs
@@ -42,12 +42,10 @@ internal class JsonTransformer : ITransformer
     /// <param name="value">JSON string.</param>
     /// <typeparam name="T">JSON value type.</typeparam>
     /// <returns>JSON value.</returns>
-#if NET6_0_OR_GREATER
     [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
         Justification = "Types are expected to be known at compile time")]
     [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
         Justification = "Types are expected to be preserved")]
-#endif
     public T? Transform<T>(string value)
     {
         if (typeof(T) == typeof(string))

--- a/libraries/src/AWS.Lambda.Powertools.Tracing/Internal/TracingAspect.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Tracing/Internal/TracingAspect.cs
@@ -147,7 +147,6 @@ public class TracingAspect
         // Skip if the result is VoidTaskResult
         if (result.GetType().Name == "VoidTaskResult") return;
 
-#if NET8_0_OR_GREATER
         if (!RuntimeFeatureWrapper.IsDynamicCodeSupported) // is AOT
         {
             _xRayRecorder.AddMetadata(
@@ -157,7 +156,6 @@ public class TracingAspect
             );
             return;
         }
-#endif
 
         _xRayRecorder.AddMetadata(
             @namespace,

--- a/libraries/src/AWS.Lambda.Powertools.Tracing/Serializers/PowertoolsTracingSerializer.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Tracing/Serializers/PowertoolsTracingSerializer.cs
@@ -1,6 +1,4 @@
 
-#if NET8_0_OR_GREATER
-
 using System;
 using System.Collections.Generic;
 using System.Text.Json;
@@ -89,5 +87,3 @@ public static class PowertoolsTracingSerializer
         }
     }
 }
-
-#endif

--- a/libraries/src/AWS.Lambda.Powertools.Tracing/Serializers/TracingSerializerExtensions.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Tracing/Serializers/TracingSerializerExtensions.cs
@@ -1,5 +1,3 @@
-#if NET8_0_OR_GREATER
-
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
@@ -40,5 +38,3 @@ public static class TracingSerializerExtensions
         return serializer;
     }
 }
-
-#endif

--- a/libraries/src/Directory.Build.props
+++ b/libraries/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <LangVersion>default</LangVersion>
         <!-- Version is generated when packaging the individual csproj -->
         <Version>$(Version)</Version>

--- a/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Internal/IdempotencySerializerTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Internal/IdempotencySerializerTests.cs
@@ -14,9 +14,7 @@ public class IdempotencySerializerTests
 {
     public IdempotencySerializerTests()
     {
-#if NET8_0_OR_GREATER
         IdempotencySerializer.AddTypeInfoResolver(TestJsonSerializerContext.Default);
-#endif
     }
 
     [Fact]
@@ -58,8 +56,6 @@ public class IdempotencySerializerTests
         // Assert
         Assert.True(options.PropertyNameCaseInsensitive);
     }
-
-#if NET8_0_OR_GREATER
 
     [Fact]
     public void GetTypeInfo_UnknownType_ThrowsException()
@@ -155,5 +151,4 @@ public class IdempotencySerializerTests
         Assert.Same(newOptions, options);
     }
     
-#endif
 }

--- a/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Internal/IdempotentAspectTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Internal/IdempotentAspectTests.cs
@@ -26,9 +26,7 @@ public class IdempotentAspectTests : IDisposable
         var store = Substitute.For<BasePersistenceStore>();
         Idempotency.Configure(builder =>
             builder
-#if NET8_0_OR_GREATER
                 .WithJsonSerializationContext(TestJsonSerializerContext.Default)
-#endif
                 .WithPersistenceStore(store)
                 .WithOptions(optionsBuilder => optionsBuilder.WithEventKeyJmesPath("Id"))
         );
@@ -74,9 +72,7 @@ public class IdempotentAspectTests : IDisposable
         // GIVEN
         Idempotency.Configure(builder =>
             builder
-#if NET8_0_OR_GREATER
                 .WithJsonSerializationContext(TestJsonSerializerContext.Default)
-#endif
                 .WithPersistenceStore(store)
                 .WithOptions(optionsBuilder => optionsBuilder.WithEventKeyJmesPath("Id"))
         );
@@ -113,9 +109,7 @@ public class IdempotentAspectTests : IDisposable
         Idempotency.Configure(builder =>
             builder
                 .WithPersistenceStore(store)
-#if NET8_0_OR_GREATER
                 .WithJsonSerializationContext(TestJsonSerializerContext.Default)
-#endif
                 .WithOptions(optionsBuilder => optionsBuilder.WithEventKeyJmesPath("Id"))
         );
 
@@ -154,9 +148,7 @@ public class IdempotentAspectTests : IDisposable
         Idempotency.Configure(builder =>
             builder
                 .WithPersistenceStore(store)
-#if NET8_0_OR_GREATER
                 .WithJsonSerializationContext(TestJsonSerializerContext.Default)
-#endif
                 .WithOptions(optionsBuilder => optionsBuilder.WithEventKeyJmesPath("Id"))
         );
 
@@ -197,9 +189,7 @@ public class IdempotentAspectTests : IDisposable
         Idempotency.Configure(builder =>
             builder
                 .WithPersistenceStore(store)
-#if NET8_0_OR_GREATER
                 .WithJsonSerializationContext(TestJsonSerializerContext.Default)
-#endif
                 .WithOptions(optionsBuilder => optionsBuilder.WithEventKeyJmesPath("Id"))
         );
 
@@ -227,9 +217,7 @@ public class IdempotentAspectTests : IDisposable
         Idempotency.Configure(builder =>
             builder
                 .WithPersistenceStore(store)
-#if NET8_0_OR_GREATER
                 .WithJsonSerializationContext(TestJsonSerializerContext.Default)
-#endif
                 .WithOptions(optionsBuilder => optionsBuilder.WithEventKeyJmesPath("Id"))
         );
 
@@ -336,9 +324,7 @@ public class IdempotentAspectTests : IDisposable
         Idempotency.Configure(builder =>
             builder
                 .WithPersistenceStore(store)
-#if NET8_0_OR_GREATER
                 .WithJsonSerializationContext(TestJsonSerializerContext.Default)
-#endif
                 .WithOptions(optionsBuilder => optionsBuilder.WithEventKeyJmesPath("Id"))
         );
 

--- a/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Persistence/BasePersistenceStoreTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Idempotency.Tests/Persistence/BasePersistenceStoreTests.cs
@@ -551,9 +551,7 @@ public class BasePersistenceStoreTests
         var eventJson = File.ReadAllText("./resources/apigw_event.json");
         try
         {
-#if NET8_0_OR_GREATER
             IdempotencySerializer.AddTypeInfoResolver(TestJsonSerializerContext.Default);
-#endif
             var request = IdempotencySerializer.Deserialize<APIGatewayProxyRequest>(eventJson);
             return request!;
         }

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Formatter/LogFormatterTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Formatter/LogFormatterTest.cs
@@ -241,19 +241,11 @@ namespace AWS.Lambda.Powertools.Logging.Tests.Formatter
             // serializer works differently in .net 8 and AOT. In .net 6 it writes properties that have null
             // in .net 8 it removes null properties
 
-#if NET8_0_OR_GREATER
             consoleOut.Received(1).WriteLine(
                 Arg.Is<string>(i =>
                     i.Contains(
                         "\"correlation_ids\":{\"aws_request_id\":\"requestId\"},\"lambda_function\":{\"name\":\"funtionName\",\"arn\":\"function::arn\",\"memory_limit_in_mb\":128,\"version\":\"version\",\"cold_start\":true},\"level\":\"Information\""))
             );
-#else
-            consoleOut.Received(1).WriteLine(
-                Arg.Is<string>(i =>
-                    i.Contains(
-                    "{\"message\":\"test\",\"service\":\"my_service\",\"correlation_ids\":{\"aws_request_id\":\"requestId\",\"x_ray_trace_id\":null,\"correlation_id\":null},\"lambda_function\":{\"name\":\"funtionName\",\"arn\":\"function::arn\",\"memory_limit_in_m_b\":128,\"version\":\"version\",\"cold_start\":true},\"level\":\"Information\",\"timestamp\":\"2024-01-01T00:00:00.0000000\",\"logger\":{\"name\":\"AWS.Lambda.Powertools.Logging.Logger\",\"sample_rate\""))
-            );
-#endif
         }
 
         [Fact]
@@ -283,19 +275,11 @@ namespace AWS.Lambda.Powertools.Logging.Tests.Formatter
             // serializer works differently in .net 8 and AOT. In .net 6 it writes properties that have null
             // in .net 8 it removes null properties
 
-#if NET8_0_OR_GREATER
             consoleOut.Received(1).WriteLine(
                 Arg.Is<string>(i =>
                     i ==
                     "{\"message\":\"test\",\"service\":\"service_undefined\",\"correlation_ids\":{},\"lambda_function\":{\"cold_start\":true},\"level\":\"Information\",\"timestamp\":\"2024-01-01T00:00:00.0000000\",\"logger\":{\"name\":\"AWS.Lambda.Powertools.Logging.Logger\",\"sample_rate\":0}}")
             );
-#else
-            consoleOut.Received(1).WriteLine(
-                Arg.Is<string>(i =>
-                    i ==
-                    "{\"message\":\"test\",\"service\":\"service_undefined\",\"correlation_ids\":{\"aws_request_id\":null,\"x_ray_trace_id\":null,\"correlation_id\":null},\"lambda_function\":{\"name\":null,\"arn\":null,\"memory_limit_in_m_b\":null,\"version\":null,\"cold_start\":true},\"level\":\"Information\",\"timestamp\":\"2024-01-01T00:00:00.0000000\",\"logger\":{\"name\":\"AWS.Lambda.Powertools.Logging.Logger\",\"sample_rate\":0}}")
-            );
-#endif
         }
 
         [Fact]
@@ -312,19 +296,11 @@ namespace AWS.Lambda.Powertools.Logging.Tests.Formatter
 
             _testHandler.TestCustomFormatterWithDecoratorNoContext("test");
 
-#if NET8_0_OR_GREATER
             consoleOut.Received(1).WriteLine(
                 Arg.Is<string>(i =>
                     i ==
                     "{\"message\":\"test\",\"service\":\"my_service\",\"correlation_ids\":{},\"lambda_function\":{\"cold_start\":true},\"level\":\"Information\",\"timestamp\":\"2024-01-01T00:00:00.0000000\",\"logger\":{\"name\":\"AWS.Lambda.Powertools.Logging.Logger\",\"sample_rate\":0.2}}")
             );
-#else
-            consoleOut.Received(1).WriteLine(
-                Arg.Is<string>(i =>
-                    i ==
-                    "{\"message\":\"test\",\"service\":\"my_service\",\"correlation_ids\":{\"aws_request_id\":null,\"x_ray_trace_id\":null,\"correlation_id\":null},\"lambda_function\":{\"name\":null,\"arn\":null,\"memory_limit_in_m_b\":null,\"version\":null,\"cold_start\":true},\"level\":\"Information\",\"timestamp\":\"2024-01-01T00:00:00.0000000\",\"logger\":{\"name\":\"AWS.Lambda.Powertools.Logging.Logger\",\"sample_rate\":0.2}}")
-            );
-#endif
         }
 
         public void Dispose()

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Handlers/HandlerTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Handlers/HandlerTests.cs
@@ -1,5 +1,4 @@
 using System.Text.Json.Serialization;
-#if NET8_0_OR_GREATER
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -557,8 +556,6 @@ public class HandlerTests
         }
     }
 }
-
-#endif
 
 public class ExampleClass
 {

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/PowertoolsLoggerBuilderTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/PowertoolsLoggerBuilderTests.cs
@@ -78,7 +78,6 @@ public class PowertoolsLoggerBuilderTests
         Assert.Contains("Warning message", logOutput);
     }
 
-#if NET8_0_OR_GREATER
     [Fact]
     public void WithJsonOptions_AppliesFormatting()
     {
@@ -107,7 +106,6 @@ public class PowertoolsLoggerBuilderTests
         Assert.Contains("\"name\":\"TestName\"", logOutput);
         Assert.Contains("\n", logOutput); // Indentation includes newlines
     }
-#endif
 
     [Fact]
     public void WithTimestampFormat_FormatsTimestamp()

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Serializers/PowertoolsLambdaSerializerTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Serializers/PowertoolsLambdaSerializerTests.cs
@@ -22,7 +22,6 @@ public class PowertoolsLambdaSerializerTests : IDisposable
         _serializer = new PowertoolsLoggingSerializer();
     }
     
-#if NET8_0_OR_GREATER
     [Fact]
     public void Constructor_ShouldNotThrowException()
     {
@@ -199,40 +198,9 @@ public class PowertoolsLambdaSerializerTests : IDisposable
     }
 
 
-#endif
     public void Dispose()
     {
 
     }
 
-#if NET6_0
-
-    [Fact]
-    public void Should_Serialize_Net6()
-    {
-        // Arrange
-        _serializer.ConfigureNamingPolicy(LoggingConstants.DefaultLoggerOutputCase);
-        var testObject = new APIGatewayProxyRequest
-        {
-            Path = "asda",
-            RequestContext = new APIGatewayProxyRequest.ProxyRequestContext
-            {
-                RequestId = "asdas"
-            }
-        };
-
-        var log = new LogEntry
-        {
-            Name = "dasda",
-            Message = testObject
-        };
-
-        var outptuMySerializer = _serializer.Serialize(log, null);
-
-        // Assert
-        Assert.Equal(
-            "{\"cold_start\":false,\"x_ray_trace_id\":null,\"correlation_id\":null,\"timestamp\":\"0001-01-01T00:00:00\",\"level\":\"Trace\",\"service\":null,\"name\":\"dasda\",\"message\":{\"resource\":null,\"path\":\"asda\",\"http_method\":null,\"headers\":null,\"multi_value_headers\":null,\"query_string_parameters\":null,\"multi_value_query_string_parameters\":null,\"path_parameters\":null,\"stage_variables\":null,\"request_context\":{\"path\":null,\"account_id\":null,\"resource_id\":null,\"stage\":null,\"request_id\":\"asdas\",\"identity\":null,\"resource_path\":null,\"http_method\":null,\"api_id\":null,\"extended_request_id\":null,\"connection_id\":null,\"connected_at\":0,\"domain_name\":null,\"domain_prefix\":null,\"event_type\":null,\"message_id\":null,\"route_key\":null,\"authorizer\":null,\"operation_name\":null,\"error\":null,\"integration_latency\":null,\"message_direction\":null,\"request_time\":null,\"request_time_epoch\":0,\"status\":null},\"body\":null,\"is_base64_encoded\":false},\"sampling_rate\":null,\"extra_keys\":null,\"exception\":null,\"lambda_context\":null}",
-            outptuMySerializer);
-    }
-#endif
 }

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Serializers/PowertoolsLoggingSerializerTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Serializers/PowertoolsLoggingSerializerTests.cs
@@ -24,9 +24,7 @@ public class PowertoolsLoggingSerializerTests : IDisposable
     {
         _serializer = new PowertoolsLoggingSerializer();
         _serializer.ConfigureNamingPolicy(LoggingConstants.DefaultLoggerOutputCase);
-#if NET8_0_OR_GREATER
         ClearContext();
-#endif
     }
 
     [Fact]
@@ -50,18 +48,12 @@ public class PowertoolsLoggingSerializerTests : IDisposable
             converter => Assert.IsType<ConstantClassConverter>(converter),
             converter => Assert.IsType<DateOnlyConverter>(converter),
             converter => Assert.IsType<TimeOnlyConverter>(converter),
-#if NET8_0_OR_GREATER
             converter => Assert.IsType<LogLevelJsonConverter>(converter));
-#elif NET6_0
-            converter => Assert.IsType<LogLevelJsonConverter>(converter));
-#endif
 
         Assert.Equal(JavaScriptEncoder.UnsafeRelaxedJsonEscaping, options.Encoder);
 
-#if NET8_0_OR_GREATER
         Assert.Collection(options.TypeInfoResolverChain,
             resolver => Assert.IsType<CompositeJsonTypeInfoResolver>(resolver));
-#endif
     }
 
     [Fact]
@@ -78,17 +70,11 @@ public class PowertoolsLoggingSerializerTests : IDisposable
             converter => Assert.IsType<ConstantClassConverter>(converter),
             converter => Assert.IsType<DateOnlyConverter>(converter),
             converter => Assert.IsType<TimeOnlyConverter>(converter),
-#if NET8_0_OR_GREATER
             converter => Assert.IsType<LogLevelJsonConverter>(converter));
-#elif NET6_0
-            converter => Assert.IsType<LogLevelJsonConverter>(converter));
-#endif
 
         Assert.Equal(JavaScriptEncoder.UnsafeRelaxedJsonEscaping, options.Encoder);
 
-#if NET8_0_OR_GREATER
         Assert.Empty(options.TypeInfoResolverChain);
-#endif
     }
 
     [Fact]
@@ -156,7 +142,6 @@ public class PowertoolsLoggingSerializerTests : IDisposable
         Assert.Contains("\"level\":\"Error\"", json);
     }
 
-#if NET8_0_OR_GREATER
     [Fact]
     public void Serialize_UnknownType_ThrowsInvalidOperationException()
     {
@@ -236,7 +221,6 @@ public class PowertoolsLoggingSerializerTests : IDisposable
         // Create a new serializer to clear any existing contexts
         _serializer.SetOptions(new JsonSerializerOptions());
     }
-#endif
 
     private string SerializeTestObject(LoggerOutputCase? outputCase)
     {
@@ -304,7 +288,6 @@ public class PowertoolsLoggingSerializerTests : IDisposable
         Assert.Contains("\"level\":\"Warning\"", json);
     }
 
-#if NET6_0_OR_GREATER
     [Fact]
     public void DateOnlyConverter_ShouldSerializeToIsoDate()
     {
@@ -332,7 +315,6 @@ public class PowertoolsLoggingSerializerTests : IDisposable
         // Assert
         Assert.Contains("\"time\":\"13:45:30\"", json);
     }
-#endif
 
     [Fact]
     public void LogLevelJsonConverter_ShouldSerializeAllLogLevels()
@@ -370,10 +352,8 @@ public class PowertoolsLoggingSerializerTests : IDisposable
             Exception = new ArgumentException("Test argument"),
             Stream = new MemoryStream(new byte[] { 4, 5, 6 }),
             Level = LogLevel.Information,
-#if NET6_0_OR_GREATER
             Date = new DateOnly(2023, 1, 15),
             Time = new TimeOnly(14, 30, 0),
-#endif
         };
 
         // Act
@@ -384,10 +364,8 @@ public class PowertoolsLoggingSerializerTests : IDisposable
         Assert.Contains("\"exception\":{\"type\":\"System.ArgumentException\"", json);
         Assert.Contains("\"stream\":\"BAUG\"", json);
         Assert.Contains("\"level\":\"Information\"", json);
-#if NET6_0_OR_GREATER
         Assert.Contains("\"date\":\"2023-01-15\"", json);
         Assert.Contains("\"time\":\"14:30:00\"", json);
-#endif
     }
 
     private class ComplexTestObject
@@ -396,10 +374,8 @@ public class PowertoolsLoggingSerializerTests : IDisposable
         public Exception Exception { get; set; }
         public MemoryStream Stream { get; set; }
         public LogLevel Level { get; set; }
-#if NET6_0_OR_GREATER
         public DateOnly Date { get; set; }
         public TimeOnly Time { get; set; }
-#endif
     }
     
     [Fact]
@@ -455,8 +431,6 @@ public class PowertoolsLoggingSerializerTests : IDisposable
             Assert.Contains("Test", json);
         }
 
-#if NET8_0_OR_GREATER
-
         [Fact]
         public void SetOptions_WithTypeInfoResolver_SetsCustomResolver()
         {
@@ -479,7 +453,6 @@ public class PowertoolsLoggingSerializerTests : IDisposable
             // Assert - options are properly configured
             Assert.NotNull(serializerOptions.TypeInfoResolver);
         }
-#endif
 
         [Fact]
         public void SetOutputCase_CamelCase_SetsPoliciesCorrectly()
@@ -521,15 +494,9 @@ public class PowertoolsLoggingSerializerTests : IDisposable
             // Act
             var options = serializer.GetSerializerOptions();
 
-#if NET8_0_OR_GREATER
             // Assert - in .NET 8 we use built-in SnakeCaseLower
             Assert.Equal(JsonNamingPolicy.SnakeCaseLower, options.PropertyNamingPolicy);
             Assert.Equal(JsonNamingPolicy.SnakeCaseLower, options.DictionaryKeyPolicy);
-#else
-            // Assert - in earlier versions, we use custom SnakeCaseNamingPolicy
-            Assert.IsType<SnakeCaseNamingPolicy>(options.PropertyNamingPolicy);
-            Assert.IsType<SnakeCaseNamingPolicy>(options.DictionaryKeyPolicy);
-#endif
         }
 
         [Fact]
@@ -548,9 +515,7 @@ public class PowertoolsLoggingSerializerTests : IDisposable
             Assert.Contains(options.Converters, c => c is ConstantClassConverter);
             Assert.Contains(options.Converters, c => c is DateOnlyConverter);
             Assert.Contains(options.Converters, c => c is TimeOnlyConverter);
-#if NET8_0_OR_GREATER || NET6_0
             Assert.Contains(options.Converters, c => c is LogLevelJsonConverter);
-#endif
         }
 
         // Test class for serialization
@@ -565,9 +530,7 @@ public class PowertoolsLoggingSerializerTests : IDisposable
 
     public void Dispose()
     {
-#if NET8_0_OR_GREATER
         ClearContext();
-#endif
         _serializer.SetOptions(null);
         RuntimeFeatureWrapper.Reset();
     }

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Utilities/PowertoolsLoggerHelpersTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Utilities/PowertoolsLoggerHelpersTests.cs
@@ -1,5 +1,3 @@
-#if NET8_0_OR_GREATER
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -231,5 +229,3 @@ public class PowertoolsLoggerHelpersTests : IDisposable
         PowertoolsLoggingBuilderExtensions.UpdateConfiguration(config);
     }
 }
-
-#endif

--- a/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/Serializers/PowertoolsTracingSerializerTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/Serializers/PowertoolsTracingSerializerTests.cs
@@ -1,4 +1,3 @@
-#if NET8_0_OR_GREATER
 using System;
 using System.Collections.Generic;
 using System.Text.Json;
@@ -237,4 +236,3 @@ public class TestArrayObject
 {
     public int[] Values { get; set; }
 }
-#endif

--- a/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/Serializers/TestJsonContext.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/Serializers/TestJsonContext.cs
@@ -1,5 +1,3 @@
-#if NET8_0_OR_GREATER
-
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
@@ -27,8 +25,6 @@ public class TestComplexObject
     public bool BoolValue { get; set; }
     public Dictionary<string, object> NestedObject { get; set; }
 }
-
-#endif
 
 public class TestResponse
 {

--- a/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/Serializers/TracingSerializerExtensionsTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/Serializers/TracingSerializerExtensionsTests.cs
@@ -1,5 +1,4 @@
 
-#if NET8_0_OR_GREATER
 using Amazon.Lambda.Serialization.SystemTextJson;
 using AWS.Lambda.Powertools.Tracing.Serializers;
 using Xunit;
@@ -26,4 +25,3 @@ public class TracingSerializerExtensionsTests
         Assert.Contains("\"Name\":\"Test\"", serialized);
     }
 }
-#endif

--- a/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/TracingAspectTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/TracingAspectTests.cs
@@ -8,10 +8,8 @@ using AWS.Lambda.Powertools.Tracing.Internal;
 using NSubstitute;
 using Xunit;
 
-#if NET8_0_OR_GREATER
 using AWS.Lambda.Powertools.Tracing.Serializers;
 using AWS.Lambda.Powertools.Tracing.Tests.Serializers;
-#endif
 
 namespace AWS.Lambda.Powertools.Tracing.Tests;
 
@@ -98,7 +96,6 @@ public class TracingAspectTests
         _mockXRayRecorder.Received(1).EndSubsegment();
     }
 
-#if NET8_0_OR_GREATER
     [Fact]
     public void Around_SyncMethod_HandlesResponseAndSegmentCorrectly_AOT()
     {
@@ -162,7 +159,6 @@ public class TracingAspectTests
             PowertoolsTracingSerializer.Serialize(result));
         _mockXRayRecorder.Received(1).EndSubsegment();
     }
-#endif
 
     [Fact]
     public async Task Around_VoidAsyncMethod_HandlesSegmentCorrectly()

--- a/libraries/tests/Directory.Build.props
+++ b/libraries/tests/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
     <ItemGroup>

--- a/libraries/tests/e2e/InfraShared/FunctionConstruct.cs
+++ b/libraries/tests/e2e/InfraShared/FunctionConstruct.cs
@@ -10,10 +10,10 @@ public class FunctionConstruct : Construct
 
     public FunctionConstruct(Construct scope, string id, FunctionConstructProps props) : base(scope, id)
     {
-        var framework = props.Runtime == Runtime.DOTNET_6 ? "net6.0" : "net8.0";
+        var framework = "net8.0";
         var distPath = $"{props.DistPath}/deploy_{props.Architecture.Name}_{props.Runtime.Name}.zip";
         var command = props.IsAot
-            ? $"dotnet-lambda package -pl {props.SourcePath} -cmd ../../../ -o {distPath} -f net8.0 -farch {props.Architecture.Name} -cifb public.ecr.aws/sam/build-dotnet8"
+            ? $"dotnet-lambda package -pl {props.SourcePath} -cmd ../../../ -o {distPath} -farch {props.Architecture.Name} -cifb public.ecr.aws/sam/build-dotnet8"
             : $"dotnet-lambda package -pl {props.SourcePath} -o {distPath} -f {framework} -farch {props.Architecture.Name}";
         
         Console.WriteLine(command);

--- a/libraries/tests/e2e/InfraShared/IdempotencyStack.cs
+++ b/libraries/tests/e2e/InfraShared/IdempotencyStack.cs
@@ -55,10 +55,6 @@ public class IdempotencyStack : Stack
                 $"E2ETestLambda_X64_NET8_{utility}", path, props);
             CreateFunctionConstruct(this, $"{utility}_arm_net8", Runtime.DOTNET_8, Architecture.ARM_64,
                 $"E2ETestLambda_ARM_NET8_{utility}", path, props);
-            CreateFunctionConstruct(this, $"{utility}_X64_net6", Runtime.DOTNET_6, Architecture.X86_64,
-                $"E2ETestLambda_X64_NET6_{utility}", path, props);
-            CreateFunctionConstruct(this, $"{utility}_arm_net6", Runtime.DOTNET_6, Architecture.ARM_64,
-                $"E2ETestLambda_ARM_NET6_{utility}", path, props);
         }
     }
 

--- a/libraries/tests/e2e/functions/core/logging/Function/src/Function/Function.csproj
+++ b/libraries/tests/e2e/functions/core/logging/Function/src/Function/Function.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/libraries/tests/e2e/functions/core/logging/Function/test/Function.Tests/FunctionTests.cs
+++ b/libraries/tests/e2e/functions/core/logging/Function/test/Function.Tests/FunctionTests.cs
@@ -42,8 +42,6 @@ public class FunctionTests
     }
 
     [Theory]
-    [InlineData("E2ETestLambda_X64_NET6_logging")]
-    [InlineData("E2ETestLambda_ARM_NET6_logging")]
     [InlineData("E2ETestLambda_X64_NET8_logging")]
     [InlineData("E2ETestLambda_ARM_NET8_logging")]
     public async Task FunctionTest(string functionName)
@@ -53,8 +51,6 @@ public class FunctionTests
     }
     
     [Theory]
-    [InlineData("E2ETestLambda_X64_NET6_logging")]
-    [InlineData("E2ETestLambda_ARM_NET6_logging")]
     [InlineData("E2ETestLambda_X64_NET8_logging")]
     [InlineData("E2ETestLambda_ARM_NET8_logging")]
     public async Task StaticConfigurationFunctionTest(string functionName)
@@ -64,8 +60,6 @@ public class FunctionTests
     }
     
     [Theory]
-    [InlineData("E2ETestLambda_X64_NET6_logging")]
-    [InlineData("E2ETestLambda_ARM_NET6_logging")]
     [InlineData("E2ETestLambda_X64_NET8_logging")]
     [InlineData("E2ETestLambda_ARM_NET8_logging")]
     public async Task StaticILoggerConfigurationFunctionTest(string functionName)
@@ -75,8 +69,6 @@ public class FunctionTests
     }
     
     [Theory]
-    [InlineData("E2ETestLambda_X64_NET6_logging")]
-    [InlineData("E2ETestLambda_ARM_NET6_logging")]
     [InlineData("E2ETestLambda_X64_NET8_logging")]
     [InlineData("E2ETestLambda_ARM_NET8_logging")]
     public async Task ILoggerConfigurationFunctionTest(string functionName)
@@ -86,8 +78,6 @@ public class FunctionTests
     }
     
     [Theory]
-    [InlineData("E2ETestLambda_X64_NET6_logging")]
-    [InlineData("E2ETestLambda_ARM_NET6_logging")]
     [InlineData("E2ETestLambda_X64_NET8_logging")]
     [InlineData("E2ETestLambda_ARM_NET8_logging")]
     public async Task ILoggerBuilderFunctionTest(string functionName)

--- a/libraries/tests/e2e/functions/core/metrics/Function/src/Function/Function.csproj
+++ b/libraries/tests/e2e/functions/core/metrics/Function/src/Function/Function.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/libraries/tests/e2e/functions/core/metrics/Function/test/Function.Tests/FunctionTests.cs
+++ b/libraries/tests/e2e/functions/core/metrics/Function/test/Function.Tests/FunctionTests.cs
@@ -37,8 +37,6 @@ public class FunctionTests
     }
 
     [Theory]
-    [InlineData("E2ETestLambda_X64_NET6_metrics")]
-    [InlineData("E2ETestLambda_ARM_NET6_metrics")]
     [InlineData("E2ETestLambda_X64_NET8_metrics")]
     [InlineData("E2ETestLambda_ARM_NET8_metrics")]
     public async Task FunctionTest(string functionName)

--- a/libraries/tests/e2e/functions/core/tracing/Function/src/Function/Function.csproj
+++ b/libraries/tests/e2e/functions/core/tracing/Function/src/Function/Function.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/libraries/tests/e2e/functions/core/tracing/Function/test/Function.Tests/FunctionTests.cs
+++ b/libraries/tests/e2e/functions/core/tracing/Function/test/Function.Tests/FunctionTests.cs
@@ -33,8 +33,6 @@ public class FunctionTests
     }
 
     [Theory]
-    [InlineData("E2ETestLambda_X64_NET6_tracing")]
-    [InlineData("E2ETestLambda_ARM_NET6_tracing")]
     [InlineData("E2ETestLambda_X64_NET8_tracing")]
     [InlineData("E2ETestLambda_ARM_NET8_tracing")]
     public async Task FunctionTest(string functionName)

--- a/libraries/tests/e2e/functions/idempotency/Function/src/Function/Function.csproj
+++ b/libraries/tests/e2e/functions/idempotency/Function/src/Function/Function.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/libraries/tests/e2e/functions/idempotency/Function/test/Function.Tests/FunctionTests.cs
+++ b/libraries/tests/e2e/functions/idempotency/Function/test/Function.Tests/FunctionTests.cs
@@ -57,8 +57,6 @@ public class FunctionTests
     [Theory]
     [InlineData("E2ETestLambda_X64_NET8_idempotency")]
     [InlineData("E2ETestLambda_ARM_NET8_idempotency")]
-    [InlineData("E2ETestLambda_X64_NET6_idempotency")]
-    [InlineData("E2ETestLambda_ARM_NET6_idempotency")]
     public async Task IdempotencyPayloadSubsetTest(string functionName)
     {
         _tableName = "IdempotencyTable";
@@ -69,8 +67,6 @@ public class FunctionTests
     [Theory]
     [InlineData("E2ETestLambda_X64_NET8_idempotency")]
     [InlineData("E2ETestLambda_ARM_NET8_idempotency")]
-    [InlineData("E2ETestLambda_X64_NET6_idempotency")]
-    [InlineData("E2ETestLambda_ARM_NET6_idempotency")]
     public async Task IdempotencyAttributeTest(string functionName)
     {
         _tableName = "IdempotencyTable";
@@ -81,8 +77,6 @@ public class FunctionTests
     [Theory]
     [InlineData("E2ETestLambda_X64_NET8_idempotency")]
     [InlineData("E2ETestLambda_ARM_NET8_idempotency")]
-    [InlineData("E2ETestLambda_X64_NET6_idempotency")]
-    [InlineData("E2ETestLambda_ARM_NET6_idempotency")]
     public async Task IdempotencyHandlerTest(string functionName)
     {
         _tableName = "IdempotencyTable";
@@ -93,8 +87,6 @@ public class FunctionTests
     [Theory]
     [InlineData("E2ETestLambda_X64_NET8_idempotency")]
     [InlineData("E2ETestLambda_ARM_NET8_idempotency")]
-    [InlineData("E2ETestLambda_X64_NET6_idempotency")]
-    [InlineData("E2ETestLambda_ARM_NET6_idempotency")]
     public async Task IdempotencyHandlerCustomKey(string functionName)
     {
         _tableName = "IdempotencyTable";

--- a/libraries/tests/e2e/infra/CoreStack.cs
+++ b/libraries/tests/e2e/infra/CoreStack.cs
@@ -44,8 +44,6 @@ namespace Infra
 
             CreateFunctionConstruct(new ConstructArgs(this, $"{utility}_X64_net8", Runtime.DOTNET_8, Architecture.X86_64, $"E2ETestLambda_X64_NET8_{utility}", basePath, distPath));
             CreateFunctionConstruct(new ConstructArgs(this, $"{utility}_arm_net8", Runtime.DOTNET_8, Architecture.ARM_64, $"E2ETestLambda_ARM_NET8_{utility}", basePath, distPath));
-            CreateFunctionConstruct(new ConstructArgs(this, $"{utility}_X64_net6", Runtime.DOTNET_6, Architecture.X86_64, $"E2ETestLambda_X64_NET6_{utility}", basePath, distPath));
-            CreateFunctionConstruct(new ConstructArgs(this, $"{utility}_arm_net6", Runtime.DOTNET_6, Architecture.ARM_64, $"E2ETestLambda_ARM_NET6_{utility}", basePath, distPath));
         }
 
         private void CreateFunctionConstruct(ConstructArgs constructArgs)


### PR DESCRIPTION
Removes .NET 6 support as requested in #749

- removed all net6.0 target frameworks  
- cleaned up conditional compilation blocks
- simplified code by removing version checks
- updated e2e tests to only use net8.0 functions

All unit tests pass (1,362 tests). E2E test failures are expected due to missing deployed functions.

Fixes #749