### PR TITLE
chore: remove dotnet6 from docs and add migration guides for v2 and v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![codecov.io](https://codecov.io/github/aws-powertools/powertools-lambda-dotnet/branch/develop/graphs/badge.svg)](https://app.codecov.io/gh/aws-powertools/powertools-lambda-dotnet)
 [![dotnet support](https://img.shields.io/static/v1?label=dotnet&message=%20NET8.0&color=blue?style=flat-square&logo=dotnet)](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/AWS.Lambda.Powertools.Logging.svg)](https://www.nuget.org/packages?q=AWS.Lambda.Powertools) [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/aws-powertools/powertools-lambda-dotnet/badge)](https://scorecard.dev/viewer/?uri=github.com/aws-powertools/powertools-lambda-dotnet)
-[![Join our Discord](https://img.shields.io/badge/Discord-%235865F2.svg?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/B8zZKbbyET)
+[![Discord](https://img.shields.io/badge/Discord-Join_Community-7289da.svg)](https://discord.gg/B8zZKbbyET)
 
 Powertools for AWS Lambda (.NET) is a developer toolkit to implement Serverless [best practices and increase developer velocity](https://docs.powertools.aws.dev/lambda-dotnet/#features).
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![codecov.io](https://codecov.io/github/aws-powertools/powertools-lambda-dotnet/branch/develop/graphs/badge.svg)](https://app.codecov.io/gh/aws-powertools/powertools-lambda-dotnet)
 [![dotnet support](https://img.shields.io/static/v1?label=dotnet&message=%20NET8.0&color=blue?style=flat-square&logo=dotnet)](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/AWS.Lambda.Powertools.Logging.svg)](https://www.nuget.org/packages?q=AWS.Lambda.Powertools) [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/aws-powertools/powertools-lambda-dotnet/badge)](https://scorecard.dev/viewer/?uri=github.com/aws-powertools/powertools-lambda-dotnet)
-[![Join our Discord](https://dcbadge.vercel.app/api/server/B8zZKbbyET?style=flat-square)](https://discord.gg/B8zZKbbyET)
+[![Join our Discord](https://img.shields.io/badge/Discord-%235865F2.svg?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/B8zZKbbyET)
 
 Powertools for AWS Lambda (.NET) is a developer toolkit to implement Serverless [best practices and increase developer velocity](https://docs.powertools.aws.dev/lambda-dotnet/#features).
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![aws provider](https://img.shields.io/badge/provider-AWS-orange?logo=amazon-aws&color=ff9900)
 [![Build](https://github.com/aws-powertools/powertools-lambda-dotnet/actions/workflows/build.yml/badge.svg?branch=develop)](https://github.com/aws-powertools/powertools-lambda-dotnet/actions/workflows/build.yml)
 [![codecov.io](https://codecov.io/github/aws-powertools/powertools-lambda-dotnet/branch/develop/graphs/badge.svg)](https://app.codecov.io/gh/aws-powertools/powertools-lambda-dotnet)
-[![dotnet support](https://img.shields.io/static/v1?label=dotnet&message=%20NET6.0|NET8.0&color=blue?style=flat-square&logo=dotnet)](https://dotnet.microsoft.com/en-us/download/dotnet/6.0)
+[![dotnet support](https://img.shields.io/static/v1?label=dotnet&message=%20NET8.0&color=blue?style=flat-square&logo=dotnet)](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/AWS.Lambda.Powertools.Logging.svg)](https://www.nuget.org/packages?q=AWS.Lambda.Powertools) [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/aws-powertools/powertools-lambda-dotnet/badge)](https://scorecard.dev/viewer/?uri=github.com/aws-powertools/powertools-lambda-dotnet)
 [![Join our Discord](https://dcbadge.vercel.app/api/server/B8zZKbbyET?style=flat-square)](https://discord.gg/B8zZKbbyET)
 
@@ -37,7 +37,7 @@ Powertools for AWS Lambda (.NET) provides three core utilities:
 
 ### Installation
 
-The Powertools for AWS Lambda (.NET) utilities (.NET 6 and .NET 8) are available as NuGet packages. You can install the packages from [NuGet Gallery](https://www.nuget.org/packages?q=AWS+Lambda+Powertools*) or from Visual Studio editor by searching `AWS.Lambda.Powertools*` to see various utilities available.
+The Powertools for AWS Lambda (.NET) utilities are available as NuGet packages. You can install the packages from [NuGet Gallery](https://www.nuget.org/packages?q=AWS+Lambda+Powertools*) or from Visual Studio editor by searching `AWS.Lambda.Powertools*` to see various utilities available.
 
 * [AWS.Lambda.Powertools.Logging](https://www.nuget.org/packages/AWS.Lambda.Powertools.Logging):
 
@@ -75,9 +75,22 @@ The Powertools for AWS Lambda (.NET) utilities (.NET 6 and .NET 8) are available
 
     `dotnet add package AWS.Lambda.Powertools.EventHandler.Resolvers.BedrockAgentFunction`
 
+* [AWS.Lambda.Powertools.Kafka.Avro](https://www.nuget.org/packages/AWS.Lambda.Powertools.Kafka.Avro):
+
+    `dotnet add package AWS.Lambda.Powertools.Kafka.Avro`
+
+* [AWS.Lambda.Powertools.Kafka.Json](https://www.nuget.org/packages/AWS.Lambda.Powertools.Kafka.Json):
+
+    `dotnet add package AWS.Lambda.Powertools.Kafka.Json`
+
+* [AWS.Lambda.Powertools.Kafka.Protobuf](https://www.nuget.org/packages/AWS.Lambda.Powertools.Kafka.Protobuf):
+
+    `dotnet add package AWS.Lambda.Powertools.Kafka.Protobuf`
+
+
 ## Examples
 
-We have provided examples focused specifically on each of the utilities. Each solution comes with an AWS Serverless Application Model (AWS SAM) templates to run your functions as a Zip package using the AWS Lambda .NET 6 or .NET 8 managed runtime; or as a container package using the AWS base images for .NET.
+We have provided examples focused specifically on each of the utilities. Each solution comes with an AWS Serverless Application Model (AWS SAM) templates to run your functions as a Zip package using the AWS Lambda .NET 8 managed runtime; or as a container package using the AWS base images for .NET.
 
 * **[Logging example](examples/Logging/)**
 * **[Metrics example](examples/Metrics/)**

--- a/docs/core/event_handler/appsync_events.md
+++ b/docs/core/event_handler/appsync_events.md
@@ -48,6 +48,18 @@ stateDiagram-v2
 
 **[AWS AppSync Events](https://docs.aws.amazon.com/appsync/latest/eventapi/event-api-welcome.html){target="_blank"}**. A service that enables you to quickly build secure, scalable real-time WebSocket APIs without managing infrastructure or writing API code. It handles connection management, message broadcasting, authentication, and monitoring, reducing time to market and operational costs.
 
+!!! warning "Migrating to v3"
+
+    If you're upgrading to v3, please review the [Migration Guide v3](../migration-guide-v3.md) for important breaking changes including .NET 8 requirement and AWS SDK v4 migration.
+
+## Installation
+
+Install the package via NuGet:
+
+```bash
+dotnet add package AWS.Lambda.Powertools.EventHandler
+```
+
 ## Getting started
 
 ???+ tip "Tip: New to AppSync Real-time API?"

--- a/docs/core/event_handler/bedrock_agent_function.md
+++ b/docs/core/event_handler/bedrock_agent_function.md
@@ -49,6 +49,9 @@ flowchart LR
 
 **Amazon Bedrock Agent** is an Amazon Bedrock feature to build and deploy conversational agents that can interact with your customers using Large Language Models (LLM) and AWS Lambda functions.
 
+!!! warning "Migrating to v3"
+
+    If you're upgrading to v3, please review the [Migration Guide v3](../migration-guide-v3.md) for important breaking changes including .NET 8 requirement and AWS SDK v4 migration.
 
 ## Installation
 

--- a/docs/core/logging.md
+++ b/docs/core/logging.md
@@ -29,9 +29,6 @@ The logging utility provides a Lambda optimized logger with output structured as
 
     If you're upgrading to v3, please review the [Migration Guide v3](../migration-guide-v3.md) for important breaking changes including .NET 8 requirement and AWS SDK v4 migration.
 
-    If you're upgrading to v2, please review the [Migration Guide v2](../migration-guide-v2.md/#logging).
-
-
 ## Installation
 
 Powertools for AWS Lambda (.NET) are available as NuGet packages. You can install the packages

--- a/docs/core/logging.md
+++ b/docs/core/logging.md
@@ -25,75 +25,11 @@ The logging utility provides a Lambda optimized logger with output structured as
   interface
 * Support for message templates `{}` and `{@}` for structured logging
 
-## Breaking changes from v1 (dependency updates)
+!!! warning "Migrating to v3"
 
-!!! info
+    If you're upgrading to v3, please review the [Migration Guide v3](../migration-guide-v3.md) for important breaking changes including .NET 8 requirement and AWS SDK v4 migration.
 
-    Loooking for V1 specific documentation please go to [Logging v1](/lambda/dotnet/core/logging-v1)    
-
-| Change | Before (v1.x) | After (v2.0) | Migration Action |
-|--------|---------------|--------------|-----------------|
-| Amazon.Lambda.Core | 2.2.0|2.5.0 | dotnet add package Amazon.Lambda.Core |
-| Amazon.Lambda.Serialization.SystemTextJson | 2.4.3 | 2.4.4 | dotnet add package Amazon.Lambda.Serialization.SystemTextJson |
-| Microsoft.Extensions.DependencyInjection | 8.0.0 | 8.0.1 | dotnet add package Microsoft.Extensions.DependencyInjection |
-
-#### Extra keys - Breaking change
-
-In v1.x, the extra keys were added to the log entry as a dictionary. In v2.x, the extra keys are added to the log entry as
-a JSON object.
-
-There is no longer a method that accepts extra keys as first argument.
-
-=== "Before (v1)"
-
-    ```csharp
-    public class User
-    {
-        public string Name { get; set; }
-        public int Age { get; set; }
-    }
-    
-    Logger.LogInformation<User>(user, "{Name} is {Age} years old", 
-          new object[]{user.Name, user.Age});
-    
-    var scopeKeys = new
-    {
-        PropOne = "Value 1",
-        PropTwo = "Value 2"
-    };
-    Logger.LogInformation(scopeKeys, "message");
-    
-    ```
-
-=== "After (v2)"
-
-    ```csharp
-    public class User
-    {
-        public string Name { get; set; }
-        public int Age { get; set; }
-        
-        public override string ToString()
-        {
-            return $"{Name} is {Age} years old";
-        }
-    }
-
-    // It uses the ToString() method of the object to log the message
-    // the extra keys are added because of the {@} in the message template
-    Logger.LogInformation("{@user}", user);
-    
-    var scopeKeys = new
-    {
-        PropOne = "Value 1",
-        PropTwo = "Value 2"
-    };
-
-    // there is no longer a method that accepts extra keys as first argument.
-    Logger.LogInformation("{@keys}", scopeKeys);
-    ```
-
-This change was made to improve the performance of the logger and to make it easier to work with the extra keys.
+    If you're upgrading to v2, please review the [Migration Guide v2](../migration-guide-v2.md/#logging).
 
 
 ## Installation
@@ -1078,7 +1014,7 @@ inheriting the ``ILogFormatter`` class and implementing the ``object FormatLogEn
 
 === "CustomLogFormatter.cs"
 
-    ```c#
+    ```csharp
     public class CustomLogFormatter : ILogFormatter
     {
         public object FormatLogEntry(LogEntry logEntry)

--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -16,22 +16,11 @@ These metrics can be visualized through [Amazon CloudWatch Console](https://aws.
 * Ahead-of-Time compilation to native code support [AOT](https://docs.aws.amazon.com/lambda/latest/dg/dotnet-native-aot.html) from version 1.7.0
 * Support for AspNetCore middleware and filters to capture metrics for HTTP requests
 
-## Breaking changes from V1
+!!! warning "Migrating to v3"
 
-!!! info
+    If you're upgrading to v3, please review the [Migration Guide v3](../migration-guide-v3.md) for important breaking changes including .NET 8 requirement and AWS SDK v4 migration.
 
-    Loooking for v1 specific documentation please go to [Metrics v1](/lambda/dotnet/core/metrics-v1)    
-
-* **`Dimensions`** outputs as an array of arrays instead of an array of objects. Example: `Dimensions: [["service", "Environment"]]` instead of `Dimensions: ["service", "Environment"]`
-* **`FunctionName`** is not added as default dimension and only to cold start metric.
-* **`Default Dimensions`** can now be included in Cold Start metrics, this is a potential breaking change if you were relying on the absence of default dimensions in Cold Start metrics when searching.
-
-<br />
-
-<figure>
-  <img src="../../media/metrics_utility_showcase.png" loading="lazy" alt="Screenshot of the Amazon CloudWatch Console showing an example of business metrics in the Metrics Explorer" />
-  <figcaption>Metrics showcase - Metrics Explorer</figcaption>
-</figure>
+    If you're upgrading to v2, please review the [Migration Guide v2](../migration-guide-v2.md/#metrics).
 
 ## Installation
 

--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -20,8 +20,6 @@ These metrics can be visualized through [Amazon CloudWatch Console](https://aws.
 
     If you're upgrading to v3, please review the [Migration Guide v3](../migration-guide-v3.md) for important breaking changes including .NET 8 requirement and AWS SDK v4 migration.
 
-    If you're upgrading to v2, please review the [Migration Guide v2](../migration-guide-v2.md/#metrics).
-
 ## Installation
 
 Powertools for AWS Lambda (.NET) are available as NuGet packages. You can install the packages from [NuGet Gallery](https://www.nuget.org/packages?q=AWS+Lambda+Powertools*){target="_blank"} or from Visual Studio editor by searching `AWS.Lambda.Powertools*` to see various utilities available.

--- a/docs/core/tracing.md
+++ b/docs/core/tracing.md
@@ -18,6 +18,10 @@ a provides functionality to reduce the overhead of performing common tracing tas
 * Auto-disable when not running in AWS Lambda environment
 * Ahead-of-Time compilation to native code support [AOT](https://docs.aws.amazon.com/lambda/latest/dg/dotnet-native-aot.html) from version 1.5.0
 
+!!! warning "Migrating to v3"
+
+    If you're upgrading to v3, please review the [Migration Guide v3](../migration-guide-v3.md) for important breaking changes including .NET 8 requirement and AWS SDK v4 migration.
+
 ## Installation
 
 Powertools for AWS Lambda (.NET) are available as NuGet packages. You can install the packages from [NuGet Gallery](https://www.nuget.org/packages?q=AWS+Lambda+Powertools*){target="_blank"} or from Visual Studio editor by searching `AWS.Lambda.Powertools*` to see various utilities available.

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ description: Powertools for AWS Lambda (.NET)
 Powertools for AWS Lambda (.NET) (which from here will be referred as Powertools) is a suite of utilities for [AWS Lambda](https://aws.amazon.com/lambda/) functions to ease adopting best practices such as tracing, structured logging, custom metrics, and more.
 
 !!! info
-    **Supports .NET 6 and .NET 8 runtimes**
+    **Supports .NET 8 runtime**
 
 ???+ tip
     Powertools is also available for [Python](https://docs.powertools.aws.dev/lambda/python/){target="_blank"}, [Java](https://docs.powertools.aws.dev/lambda/java/){target="_blank"}, and [TypeScript](https://docs.powertools.aws.dev/lambda/typescript/latest/){target="_blank"}.
@@ -71,14 +71,14 @@ We have provided you with a custom template for the Serverless Application Model
 To use the SAM CLI, you need the following tools.
 
 * SAM CLI - [Install the SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html)
-* .NET 6.0 (LTS)  - [Install .NET 6.0](https://www.microsoft.com/net/download)
+* .NET 8.0 (LTS)  - [Install .NET 8.0](https://www.microsoft.com/net/download)
 * Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community)
 
-Once you have SAM CLI installed, follow the these steps to initialize a .NET 6 project using Powertools for AWS (.NET)
+Once you have SAM CLI installed, follow the these steps to initialize a .NET 8 project using Powertools for AWS (.NET)
 
 1. Run the following command in your command line
     ```bash
-    sam init -r dotnet6
+    sam init -r dotnet8
     ```
 2. Select option 1 as your template source
 

--- a/docs/migration-guide-v2.md
+++ b/docs/migration-guide-v2.md
@@ -1,0 +1,101 @@
+---
+title: Migration Guide v2
+slug: migration-guide-v2
+description: Migration guide to upgrade to v2
+---
+
+# Migration Guide to v2
+
+This guide will help you migrate to v2
+
+## Logging
+
+### Breaking changes from v1 (dependency updates)
+
+!!! info
+
+    Looking for V1 specific documentation please go to [Logging v1](/lambda/dotnet/core/logging-v1)
+
+| Change | Before (v1.x) | After (v2.0) | Migration Action |
+|--------|---------------|--------------|-----------------|
+| Amazon.Lambda.Core | 2.2.0|2.5.0 | dotnet add package Amazon.Lambda.Core |
+| Amazon.Lambda.Serialization.SystemTextJson | 2.4.3 | 2.4.4 | dotnet add package Amazon.Lambda.Serialization.SystemTextJson |
+| Microsoft.Extensions.DependencyInjection | 8.0.0 | 8.0.1 | dotnet add package Microsoft.Extensions.DependencyInjection |
+
+#### Extra keys - Breaking change
+
+In v1.x, the extra keys were added to the log entry as a dictionary. In v2.x, the extra keys are added to the log entry as
+a JSON object.
+
+There is no longer a method that accepts extra keys as first argument.
+
+=== "Before (v1)"
+
+    ```csharp
+    public class User
+    {
+        public string Name { get; set; }
+        public int Age { get; set; }
+    }
+    
+    Logger.LogInformation<User>(user, "{Name} is {Age} years old", 
+          new object[]{user.Name, user.Age});
+    
+    var scopeKeys = new
+    {
+        PropOne = "Value 1",
+        PropTwo = "Value 2"
+    };
+    Logger.LogInformation(scopeKeys, "message");
+    
+    ```
+
+=== "After (v2)"
+
+    ```csharp
+    public class User
+    {
+        public string Name { get; set; }
+        public int Age { get; set; }
+        
+        public override string ToString()
+        {
+            return $"{Name} is {Age} years old";
+        }
+    }
+
+    // It uses the ToString() method of the object to log the message
+    // the extra keys are added because of the {@} in the message template
+    Logger.LogInformation("{@user}", user);
+    
+    var scopeKeys = new
+    {
+        PropOne = "Value 1",
+        PropTwo = "Value 2"
+    };
+
+    // there is no longer a method that accepts extra keys as first argument.
+    Logger.LogInformation("{@keys}", scopeKeys);
+    ```
+
+This change was made to improve the performance of the logger and to make it easier to work with the extra keys.
+
+## Metrics
+
+### Breaking changes from V1
+
+!!! info
+
+    Loooking for v1 specific documentation please go to [Metrics v1](/lambda/dotnet/core/metrics-v1)    
+
+* **`Dimensions`** outputs as an array of arrays instead of an array of objects. Example: `Dimensions: [["service", "Environment"]]` instead of `Dimensions: ["service", "Environment"]`
+* **`FunctionName`** is not added as default dimension and only to cold start metric.
+* **`Default Dimensions`** can now be included in Cold Start metrics, this is a potential breaking change if you were relying on the absence of default dimensions in Cold Start metrics when searching.
+
+<br />
+
+<figure>
+  <img src="../../media/metrics_utility_showcase.png" loading="lazy" alt="Screenshot of the Amazon CloudWatch Console showing an example of business metrics in the Metrics Explorer" />
+  <figcaption>Metrics showcase - Metrics Explorer</figcaption>
+</figure>
+

--- a/docs/migration-guide-v3.md
+++ b/docs/migration-guide-v3.md
@@ -1,0 +1,76 @@
+---
+title: Migration Guide v3
+slug: migration-guide-v3 
+description: Migration guide to upgrade to v3
+---
+
+# Migration Guide to v3
+
+This guide will help you migrate to v3
+
+## Breaking Changes
+
+⚠️ Important: Please review these breaking changes before upgrading:
+
+* Removed support for .NET 6 - Now requires .NET 8 or later
+* AWS SDK v3 no longer supported - Migrated to AWS SDK v4  
+
+## Upgrade Steps
+
+### 1. Update Target Framework
+
+Update your `.csproj` file to target .NET 8 or later:
+
+**Before (v2):**
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+</Project>
+```
+
+**After (v3):**
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+</Project>
+```
+
+### 2. Update AWS SDK Packages
+
+Migrate from AWS SDK v3 to v4. Update package references in your `.csproj`:
+
+**Before (v2):**
+```xml
+<ItemGroup>
+  <PackageReference Include="Amazon.Lambda.Core" Version="2.5.0" />
+  <PackageReference Include="AWSSDK.Core" Version="3.7.*" />
+  <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.*" />
+  <PackageReference Include="AWSSDK.S3" Version="3.7.*" />
+</ItemGroup>
+```
+
+**After (v3):**
+```xml
+<ItemGroup>
+  <PackageReference Include="Amazon.Lambda.Core" Version="2.7.0" />
+  <PackageReference Include="AWSSDK.Core" Version="4.0.*" />
+  <PackageReference Include="AWSSDK.DynamoDBv2" Version="4.0.*" />
+  <PackageReference Include="AWSSDK.S3" Version="4.0.*" />
+</ItemGroup>
+```
+
+### 3. Update Powertools Packages
+
+Update all Powertools package references to v3:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="3.0.*" />
+  <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="3.0.*" />
+  <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="3.0.*" />
+</ItemGroup>
+```

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -46,9 +46,9 @@ Updating metrics implementation to support latest EMF specifications and improve
 Ensuring enterprise-grade security and compatibility with latest .NET developments.
 
 - [ ] .NET 10 support from day one
-- [ ] Deprecation path for .NET 6
+- [x] Deprecation path for .NET 6
 - [x] Scorecard implementation
-- [ ] Security compliance checks on our pipeline
+- [x] Security compliance checks on our pipeline
 - [ ] All utilities with end-to-end tests in our pipeline
 
 ### Feature Parity and ASP.NET Support (P2)

--- a/docs/utilities/batch-processing.md
+++ b/docs/utilities/batch-processing.md
@@ -66,6 +66,10 @@ This behavior changes when you enable Report Batch Item Failures feature in your
 
 	You can find more details on how Lambda works with either [SQS](https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html){target="_blank"}, [Kinesis](https://docs.aws.amazon.com/lambda/latest/dg/with-kinesis.html){target="_blank"}, or [DynamoDB](https://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html){target="_blank"} in the AWS Documentation.
 
+!!! warning "Migrating to v3"
+
+    If you're upgrading to v3, please review the [Migration Guide v3](../migration-guide-v3.md) for important breaking changes including .NET 8 requirement and AWS SDK v4 migration.
+
 ## Installation
 
 You should install with NuGet:

--- a/docs/utilities/idempotency.md
+++ b/docs/utilities/idempotency.md
@@ -49,6 +49,9 @@ classDiagram
 <i>Idempotency record representation</i>
 </div>
 
+!!! warning "Migrating to v3"
+
+    If you're upgrading to v3, please review the [Migration Guide v3](../migration-guide-v3.md) for important breaking changes including .NET 8 requirement and AWS SDK v4 migration.
 
 ## Getting started
 

--- a/docs/utilities/kafka.md
+++ b/docs/utilities/kafka.md
@@ -56,6 +56,10 @@ Lambda processes Kafka messages as discrete events rather than continuous stream
 | **Schema Validation** | Client-side schema validation | Optional Schema Registry integration with Event Source Mapping |
 | **Error Handling** | Per-message retry control | Batch-level retry policies |
 
+!!! warning "Migrating to v3"
+
+    If you're upgrading to v3, please review the [Migration Guide v3](../migration-guide-v3.md) for important breaking changes including .NET 8 requirement and AWS SDK v4 migration.
+
 ## Getting started
 
 ### Installation

--- a/docs/utilities/parameters.md
+++ b/docs/utilities/parameters.md
@@ -13,6 +13,10 @@ The Parameters utility provides high-level functionality to retrieve one or mult
 * Transform parameter values from JSON or base 64 encoded strings
 * Bring your own parameter store provider
 
+!!! warning "Migrating to v3"
+
+    If you're upgrading to v3, please review the [Migration Guide v3](../migration-guide-v3.md) for important breaking changes including .NET 8 requirement and AWS SDK v4 migration.
+
 ## Installation
 
 Powertools for AWS Lambda (.NET) are available as NuGet packages. You can install the packages from [NuGet Gallery](https://www.nuget.org/packages?q=AWS+Lambda+Powertools*){target="_blank"} or from Visual Studio editor by searching `AWS.Lambda.Powertools*` to see various utilities available.

--- a/examples/BatchProcessing/README.md
+++ b/examples/BatchProcessing/README.md
@@ -28,7 +28,7 @@ To use the AWS SAM CLI, you need the following tools.
 * Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community)
 
 You will need the following for local testing.
-* .NET 6.0 - [Install .NET 6.0](https://www.microsoft.com/net/download)
+* .NET 8.0 - [Install .NET 8.0](https://www.microsoft.com/net/download)
 
 To build and deploy your application for the first time, run the following in your shell. Make sure the `template.yaml` file is in your current directory:
 

--- a/examples/Idempotency/README.md
+++ b/examples/Idempotency/README.md
@@ -25,7 +25,7 @@ To use the AWS SAM CLI, you need the following tools.
 * Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community)
 
 You will need the following for local testing.
-* .NET 6.0 - [Install .NET 6.0](https://www.microsoft.com/net/download)
+* .NET 8.0 - [Install .NET 8.0](https://www.microsoft.com/net/download)
 
 To build and deploy your application for the first time, run the following in your shell. Make sure the `template.yaml` file is in your current directory:
 

--- a/examples/Logging/README.md
+++ b/examples/Logging/README.md
@@ -25,7 +25,7 @@ To use the AWS SAM CLI, you need the following tools.
 * Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community)
 
 You will need the following for local testing.
-* .NET 6.0 - [Install .NET 6.0](https://www.microsoft.com/net/download)
+* .NET 8.0 - [Install .NET 8.0](https://www.microsoft.com/net/download)
 
 To build and deploy your application for the first time, run the following in your shell. Make sure the `template.yaml` file is in your current directory:
 

--- a/examples/Metrics/README.md
+++ b/examples/Metrics/README.md
@@ -25,7 +25,7 @@ To use the AWS SAM CLI, you need the following tools.
 * Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community)
 
 You will need the following for local testing.
-* .NET 6.0 - [Install .NET 6.0](https://www.microsoft.com/net/download)
+* .NET 8.0 - [Install .NET 8.0](https://www.microsoft.com/net/download)
 
 To build and deploy your application for the first time, run the following in your shell. Make sure the `template.yaml` file is in your current directory:
 

--- a/examples/Parameters/README.md
+++ b/examples/Parameters/README.md
@@ -25,7 +25,7 @@ To use the AWS SAM CLI, you need the following tools.
 * Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community)
 
 You will need the following for local testing.
-* .NET 6.0 - [Install .NET 6.0](https://www.microsoft.com/net/download)
+* .NET 8.0 - [Install .NET 8.0](https://www.microsoft.com/net/download)
 
 To build and deploy your application for the first time, run the following in your shell. Make sure the `template.yaml` file is in your current directory:
 

--- a/examples/ServerlessApi/Readme.md
+++ b/examples/ServerlessApi/Readme.md
@@ -27,7 +27,7 @@ To use the AWS SAM CLI, you need the following tools.
 * Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community)
 
 You will need the following for local testing.
-* .NET 6.0 - [Install .NET 6.0](https://www.microsoft.com/net/download)
+* .NET 8.0 - [Install .NET 8.0](https://www.microsoft.com/net/download)
 
 To build and deploy your application for the first time, run the following in your shell. Make sure the `serverless.template` file is in your current directory:
 

--- a/examples/Tracing/README.md
+++ b/examples/Tracing/README.md
@@ -25,7 +25,7 @@ To use the AWS SAM CLI, you need the following tools.
 * Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community)
 
 You will need the following for local testing.
-* .NET 6.0 - [Install .NET 6.0](https://www.microsoft.com/net/download)
+* .NET 8.0 - [Install .NET 8.0](https://www.microsoft.com/net/download)
 
 To build and deploy your application for the first time, run the following in your shell. Make sure the `template.yaml` file is in your current directory:
 

--- a/libraries/src/AWS.Lambda.Powertools.Kafka.Avro/Readme.md
+++ b/libraries/src/AWS.Lambda.Powertools.Kafka.Avro/Readme.md
@@ -96,7 +96,7 @@ var serializer = new PowertoolsKafkaAvroSerializer(MyJsonContext.Default);
 
 ## Requirements
 
-- **.NET 6.0+**: This library targets .NET 6.0 and later versions
+- **.NET 8.0+**: This library targets .NET 8.0 and later versions
 - **Avro.NET**: Requires the Apache Avro library for .NET
 - **Avro Schema**: Your data classes must include a public static `_SCHEMA` field
 - **AWS Lambda**: Designed specifically for AWS Lambda runtime environments

--- a/libraries/src/AWS.Lambda.Powertools.Kafka.Json/Readme.md
+++ b/libraries/src/AWS.Lambda.Powertools.Kafka.Json/Readme.md
@@ -133,7 +133,7 @@ public class Function
 
 ## Requirements
 
-- **.NET 6.0+**: This library targets .NET 6.0 and later versions
+- **.NET 8.0+**: This library targets .NET 8.0 and later versions
 - **System.Text.Json**: Uses the high-performance JSON library from .NET
 - **JSON Serializable Types**: Your data classes should be compatible with System.Text.Json
 - **AWS Lambda**: Designed specifically for AWS Lambda runtime environments

--- a/libraries/src/AWS.Lambda.Powertools.Kafka.Protobuf/Readme.md
+++ b/libraries/src/AWS.Lambda.Powertools.Kafka.Protobuf/Readme.md
@@ -125,7 +125,7 @@ public class Function
 
 ## Requirements
 
-- **.NET 6.0+**: This library targets .NET 6.0 and later versions
+- **.NET 8.0+**: This library targets .NET 8.0 and later versions
 - **Google.Protobuf**: Requires the Google Protocol Buffers library for .NET
 - **Protobuf Compiler**: Use `protoc` to generate C# classes from `.proto` files
 - **IMessage Implementation**: Your data classes must implement `IMessage<T>`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,8 @@ nav:
         - utilities/jmespath-functions.md
         - utilities/kafka.md
     - Resources:
+        - migration-guide-v2.md
+        - migration-guide-v3.md
         - "llms.txt": ./llms.txt
         - "llms.txt (full version)": ./llms-full.txt
   - API Reference: api/" target="_blank


### PR DESCRIPTION
> Please provide the issue number

Issue number: #1009 

## Summary

### Changes

- remove .NET 6 references
- add migration guide to v3 #1017 in all utilities
- add missing utilities in the readme

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [ ] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
