### PR TITLE
chore: Update examples with latest nuget versions. Fix PTENV check in tests

### DIFF
--- a/examples/AOT/AOT_Logging/src/AOT_Logging/AOT_Logging.csproj
+++ b/examples/AOT/AOT_Logging/src/AOT_Logging/AOT_Logging.csproj
@@ -17,9 +17,9 @@
         <TrimMode>partial</TrimMode>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.10.0"/>
-        <PackageReference Include="Amazon.Lambda.Core" Version="2.5.0"/>
+        <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.13.4" />
+        <PackageReference Include="Amazon.Lambda.Core" Version="2.7.1" />
         <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4"/>
-        <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.6.5" />
+        <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="3.0.0" />
     </ItemGroup>
 </Project>

--- a/examples/AOT/AOT_Logging/test/AOT_Logging.Tests/AOT_Logging.Tests.csproj
+++ b/examples/AOT/AOT_Logging/test/AOT_Logging.Tests/AOT_Logging.Tests.csproj
@@ -6,8 +6,8 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="2.5.0" />
-    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.7.1" />
+    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="3.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />

--- a/examples/AOT/AOT_Metrics/src/AOT_Metrics/AOT_Metrics.csproj
+++ b/examples/AOT/AOT_Metrics/src/AOT_Metrics/AOT_Metrics.csproj
@@ -17,9 +17,9 @@
         <TrimMode>partial</TrimMode>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.10.0"/>
-        <PackageReference Include="Amazon.Lambda.Core" Version="2.5.0"/>
+        <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.13.4" />
+        <PackageReference Include="Amazon.Lambda.Core" Version="2.7.1" />
         <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4"/>
-        <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="2.0.0" />
+        <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="3.0.0" />
     </ItemGroup>
 </Project>

--- a/examples/AOT/AOT_Metrics/test/AOT_Metrics.Tests/AOT_Metrics.Tests.csproj
+++ b/examples/AOT/AOT_Metrics/test/AOT_Metrics.Tests/AOT_Metrics.Tests.csproj
@@ -6,8 +6,8 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="2.5.0" />
-    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.7.1" />
+    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="3.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />

--- a/examples/AOT/AOT_Tracing/src/AOT_Tracing/AOT_Tracing.csproj
+++ b/examples/AOT/AOT_Tracing/src/AOT_Tracing/AOT_Tracing.csproj
@@ -17,9 +17,9 @@
         <TrimMode>partial</TrimMode>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.10.0"/>
-        <PackageReference Include="Amazon.Lambda.Core" Version="2.5.0"/>
+        <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.13.4" />
+        <PackageReference Include="Amazon.Lambda.Core" Version="2.7.1" />
         <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4"/>
-        <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="1.6.1" />
+        <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="3.0.0" />
     </ItemGroup>
 </Project>

--- a/examples/AOT/AOT_Tracing/test/AOT_Tracing.Tests/AOT_Tracing.Tests.csproj
+++ b/examples/AOT/AOT_Tracing/test/AOT_Tracing.Tests/AOT_Tracing.Tests.csproj
@@ -6,8 +6,8 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="2.5.0" />
-    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.7.1" />
+    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="3.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />

--- a/examples/BatchProcessing/src/HelloWorld/HelloWorld.csproj
+++ b/examples/BatchProcessing/src/HelloWorld/HelloWorld.csproj
@@ -5,10 +5,10 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Amazon.Lambda.Core" Version="2.5.0" />
+        <PackageReference Include="Amazon.Lambda.Core" Version="2.7.1" />
         <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4" />
-        <PackageReference Include="AWS.Lambda.Powertools.BatchProcessing" Version="1.1.2" />
-        <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.6.5" />
+        <PackageReference Include="AWS.Lambda.Powertools.BatchProcessing" Version="3.0.0" />
+        <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="3.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     </ItemGroup>
 </Project>

--- a/examples/BatchProcessing/test/HelloWorld.Test/HelloWorld.Tests.csproj
+++ b/examples/BatchProcessing/test/HelloWorld.Test/HelloWorld.Tests.csproj
@@ -3,14 +3,14 @@
 		<TargetFramework>net8.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Amazon.Lambda.Core" Version="2.5.0" />
-		<PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="3.1.0" />
-		<PackageReference Include="Amazon.Lambda.KinesisEvents" Version="2.2.0" />
+		<PackageReference Include="Amazon.Lambda.Core" Version="2.7.1" />
+		<PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="3.1.1" />
+		<PackageReference Include="Amazon.Lambda.KinesisEvents" Version="3.0.0" />
 		<PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.2.0" />
-		<PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
+		<PackageReference Include="Amazon.Lambda.TestUtilities" Version="3.0.1" />
 		<PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4" />
-		<PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.301.18" />
-		<PackageReference Include="AWSSDK.SQS" Version="3.7.300.54" />
+		<PackageReference Include="AWSSDK.DynamoDBv2" Version="4.0.7" />
+		<PackageReference Include="AWSSDK.SQS" Version="4.0.1.8" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 		<PackageReference Include="xunit" Version="2.7.0" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">

--- a/examples/Idempotency/src/HelloWorld/HelloWorld.csproj
+++ b/examples/Idempotency/src/HelloWorld/HelloWorld.csproj
@@ -5,10 +5,10 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Amazon.Lambda.Core" Version="2.5.0" />
-        <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.0" />
+        <PackageReference Include="Amazon.Lambda.Core" Version="2.7.1" />
+        <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.1" />
         <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4" />
-        <PackageReference Include="AWS.Lambda.Powertools.Idempotency" Version="1.3.0" />
-        <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.6.5" />
+        <PackageReference Include="AWS.Lambda.Powertools.Idempotency" Version="3.0.0" />
+        <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="3.0.0" />
     </ItemGroup>
 </Project>

--- a/examples/Idempotency/test/HelloWorld.Test/HelloWorld.Tests.csproj
+++ b/examples/Idempotency/test/HelloWorld.Test/HelloWorld.Tests.csproj
@@ -3,8 +3,8 @@
 		<TargetFramework>net8.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Amazon.Lambda.Core" Version="2.5.0" />
-		<PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
+		<PackageReference Include="Amazon.Lambda.Core" Version="2.7.1" />
+		<PackageReference Include="Amazon.Lambda.TestUtilities" Version="3.0.1" />
 		<PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 		<PackageReference Include="xunit" Version="2.7.0" />

--- a/examples/Kafka/Avro/src/Avro.csproj
+++ b/examples/Kafka/Avro/src/Avro.csproj
@@ -15,11 +15,11 @@
 
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.12.0"/>
-        <PackageReference Include="Amazon.Lambda.Core" Version="2.5.0"/>
+        <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.13.4" />
+        <PackageReference Include="Amazon.Lambda.Core" Version="2.7.1" />
         <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4"/>
-        <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="2.0.0" />
-        <PackageReference Include="AWS.Lambda.Powertools.Kafka.Avro" Version="1.0.2" />
+        <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="3.0.0" />
+        <PackageReference Include="AWS.Lambda.Powertools.Kafka.Avro" Version="3.0.0" />
     </ItemGroup>
     <Target Name="GenerateAvroClasses" BeforeTargets="CoreCompile">
         <Exec Command="avrogen -s $(ProjectDir)CustomerProfile.avsc $(ProjectDir)Generated"/>

--- a/examples/Kafka/Json/src/Json.csproj
+++ b/examples/Kafka/Json/src/Json.csproj
@@ -12,11 +12,11 @@
         <PublishReadyToRun>true</PublishReadyToRun>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.12.0"/>
-        <PackageReference Include="Amazon.Lambda.Core" Version="2.5.0"/>
+        <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.13.4" />
+        <PackageReference Include="Amazon.Lambda.Core" Version="2.7.1" />
         <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4"/>
-        <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="2.0.0" />
-        <PackageReference Include="AWS.Lambda.Powertools.Kafka.Json" Version="1.0.2" />
+        <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="3.0.0" />
+        <PackageReference Include="AWS.Lambda.Powertools.Kafka.Json" Version="3.0.0" />
     </ItemGroup>
     <ItemGroup>
         <None Remove="kafka-json-event.json" />

--- a/examples/Kafka/JsonClassLibrary/src/ProtoBufClassLibrary.csproj
+++ b/examples/Kafka/JsonClassLibrary/src/ProtoBufClassLibrary.csproj
@@ -11,10 +11,10 @@
         <PublishReadyToRun>true</PublishReadyToRun>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Amazon.Lambda.Core" Version="2.5.0"/>
+        <PackageReference Include="Amazon.Lambda.Core" Version="2.7.1" />
         <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4"/>
-        <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="2.0.0" />
-        <PackageReference Include="AWS.Lambda.Powertools.Kafka.Protobuf" Version="1.0.2" />
+        <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="3.0.0" />
+        <PackageReference Include="AWS.Lambda.Powertools.Kafka.Protobuf" Version="3.0.0" />
         <PackageReference Include="Grpc.Tools" Version="2.72.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/examples/Kafka/Protobuf/src/Protobuf.csproj
+++ b/examples/Kafka/Protobuf/src/Protobuf.csproj
@@ -12,11 +12,11 @@
          <PublishReadyToRun>true</PublishReadyToRun>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.12.0" />
-        <PackageReference Include="Amazon.Lambda.Core" Version="2.5.0" />
+        <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.13.4" />
+        <PackageReference Include="Amazon.Lambda.Core" Version="2.7.1" />
         <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4" />
-        <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="2.0.0" />
-        <PackageReference Include="AWS.Lambda.Powertools.Kafka.Protobuf" Version="1.0.2" />
+        <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="3.0.0" />
+        <PackageReference Include="AWS.Lambda.Powertools.Kafka.Protobuf" Version="3.0.0" />
         <PackageReference Include="Grpc.Tools" Version="2.72.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/examples/Logging/src/HelloWorld/HelloWorld.csproj
+++ b/examples/Logging/src/HelloWorld/HelloWorld.csproj
@@ -5,10 +5,10 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Amazon.Lambda.Core" Version="2.5.0" />
-        <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.0" />
+        <PackageReference Include="Amazon.Lambda.Core" Version="2.7.1" />
+        <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.1" />
         <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4" />
-        <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.6.5" />
-        <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.301.18" />
+        <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="3.0.0" />
+        <PackageReference Include="AWSSDK.DynamoDBv2" Version="4.0.7" />
     </ItemGroup>
 </Project>

--- a/examples/Logging/test/HelloWorld.Test/HelloWorld.Tests.csproj
+++ b/examples/Logging/test/HelloWorld.Test/HelloWorld.Tests.csproj
@@ -3,10 +3,10 @@
 		<TargetFramework>net8.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Amazon.Lambda.Core" Version="2.5.0" />
-		<PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
+		<PackageReference Include="Amazon.Lambda.Core" Version="2.7.1" />
+		<PackageReference Include="Amazon.Lambda.TestUtilities" Version="3.0.1" />
 		<PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4" />
-		<PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.301.18" />
+		<PackageReference Include="AWSSDK.DynamoDBv2" Version="4.0.7" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 		<PackageReference Include="NSubstitute" Version="5.1.0" />
 		<PackageReference Include="xunit" Version="2.7.0" />

--- a/examples/Metrics/src/HelloWorld/HelloWorld.csproj
+++ b/examples/Metrics/src/HelloWorld/HelloWorld.csproj
@@ -5,11 +5,11 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Amazon.Lambda.Core" Version="2.5.0" />
-        <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.0" />
+        <PackageReference Include="Amazon.Lambda.Core" Version="2.7.1" />
+        <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.1" />
         <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4" />
-        <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.6.5" />
-        <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="2.0.0" />
-        <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.301.18" />
+        <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="3.0.0" />
+        <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="3.0.0" />
+        <PackageReference Include="AWSSDK.DynamoDBv2" Version="4.0.7" />
     </ItemGroup>
 </Project>

--- a/examples/Metrics/test/HelloWorld.Test/HelloWorld.Tests.csproj
+++ b/examples/Metrics/test/HelloWorld.Test/HelloWorld.Tests.csproj
@@ -3,10 +3,10 @@
 		<TargetFramework>net8.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Amazon.Lambda.Core" Version="2.5.0" />
-		<PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
+		<PackageReference Include="Amazon.Lambda.Core" Version="2.7.1" />
+		<PackageReference Include="Amazon.Lambda.TestUtilities" Version="3.0.1" />
 		<PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4" />
-		<PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.301.18" />
+		<PackageReference Include="AWSSDK.DynamoDBv2" Version="4.0.7" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 		<PackageReference Include="NSubstitute" Version="5.1.0" />
 		<PackageReference Include="xunit" Version="2.7.0" />

--- a/examples/Parameters/cfn/HelloWorld.Cfn/HelloWorld.Cfn.csproj
+++ b/examples/Parameters/cfn/HelloWorld.Cfn/HelloWorld.Cfn.csproj
@@ -6,7 +6,7 @@
         <RootNamespace>HelloWorld.Cfn</RootNamespace>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Amazon.Lambda.Core" Version="2.5.0" />
+        <PackageReference Include="Amazon.Lambda.Core" Version="2.7.1" />
         <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4" />
     </ItemGroup>
     <ItemGroup>

--- a/examples/Parameters/src/HelloWorld/HelloWorld.csproj
+++ b/examples/Parameters/src/HelloWorld/HelloWorld.csproj
@@ -5,9 +5,9 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Amazon.Lambda.Core" Version="2.5.0" />
-        <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.0" />
+        <PackageReference Include="Amazon.Lambda.Core" Version="2.7.1" />
+        <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.1" />
         <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4" />
-        <PackageReference Include="AWS.Lambda.Powertools.Parameters" Version="1.2.0" />
+        <PackageReference Include="AWS.Lambda.Powertools.Parameters" Version="3.0.0" />
     </ItemGroup>
 </Project>

--- a/examples/Parameters/test/HelloWorld.Test/HelloWorld.Tests.csproj
+++ b/examples/Parameters/test/HelloWorld.Test/HelloWorld.Tests.csproj
@@ -3,8 +3,8 @@
 		<TargetFramework>net8.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Amazon.Lambda.Core" Version="2.5.0" />
-		<PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
+		<PackageReference Include="Amazon.Lambda.Core" Version="2.7.1" />
+		<PackageReference Include="Amazon.Lambda.TestUtilities" Version="3.0.1" />
 		<PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 		<PackageReference Include="NSubstitute" Version="5.1.0" />

--- a/examples/ServerlessApi/src/LambdaPowertoolsAPI/LambdaPowertoolsAPI.csproj
+++ b/examples/ServerlessApi/src/LambdaPowertoolsAPI/LambdaPowertoolsAPI.csproj
@@ -12,9 +12,9 @@
     <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="9.0.0" />
-    <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.6.5" />
-    <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="2.0.0" />
-    <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="1.6.1" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="9.2.0" />
+    <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="3.0.0" />
+    <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="3.0.0" />
+    <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="3.0.0" />
   </ItemGroup>
 </Project>

--- a/examples/ServerlessApi/test/LambdaPowertoolsAPI.Tests/LambdaPowertoolsAPI.Tests.csproj
+++ b/examples/ServerlessApi/test/LambdaPowertoolsAPI.Tests/LambdaPowertoolsAPI.Tests.csproj
@@ -16,10 +16,10 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="2.5.0" />
-    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
-    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.0" />
-    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.300" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.7.1" />
+    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="3.0.1" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.1" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.3.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="xunit" Version="2.7.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">

--- a/examples/Tracing/src/HelloWorld/Function.cs
+++ b/examples/Tracing/src/HelloWorld/Function.cs
@@ -87,13 +87,10 @@ public class Function
             greeting: "Hello Powertools for AWS Lambda (.NET)", ipAddress: location);
 
         // Trace Fluent API
-        Tracing.WithSubsegment("LoggingResponse",
-            subsegment =>
-            {
-                subsegment.AddAnnotation("AccountId", apigwProxyEvent.RequestContext.AccountId);
-                subsegment.AddMetadata("LookupRecord", lookupRecord);
-            });
-
+        using var gatewaySegment = Tracing.BeginSubsegment("LoggingResponse");
+        gatewaySegment.AddAnnotation("AccountId", apigwProxyEvent.RequestContext.AccountId);
+        gatewaySegment.AddMetadata("LookupRecord", lookupRecord);
+        
         try
         {
             await SaveRecordInDynamo(lookupRecord);

--- a/examples/Tracing/src/HelloWorld/HelloWorld.csproj
+++ b/examples/Tracing/src/HelloWorld/HelloWorld.csproj
@@ -5,11 +5,11 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Amazon.Lambda.Core" Version="2.5.0" />
-        <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.0" />
+        <PackageReference Include="Amazon.Lambda.Core" Version="2.7.1" />
+        <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.1" />
         <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4" />
-        <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.6.5" />
-        <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="1.6.1" />
-        <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.301.18" />
+        <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="3.0.0" />
+        <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="3.0.0" />
+        <PackageReference Include="AWSSDK.DynamoDBv2" Version="4.0.7" />
     </ItemGroup>
 </Project>

--- a/examples/Tracing/test/HelloWorld.Test/HelloWorld.Tests.csproj
+++ b/examples/Tracing/test/HelloWorld.Test/HelloWorld.Tests.csproj
@@ -3,10 +3,10 @@
 		<TargetFramework>net8.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Amazon.Lambda.Core" Version="2.5.0" />
-		<PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
+		<PackageReference Include="Amazon.Lambda.Core" Version="2.7.1" />
+		<PackageReference Include="Amazon.Lambda.TestUtilities" Version="3.0.1" />
 		<PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4" />
-		<PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.301.18" />
+		<PackageReference Include="AWSSDK.DynamoDBv2" Version="4.0.7" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 		<PackageReference Include="NSubstitute" Version="5.1.0" />
 		<PackageReference Include="xunit" Version="2.7.0" />

--- a/libraries/tests/AWS.Lambda.Powertools.ModuleInitializer.Tests/EnvWrapperTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.ModuleInitializer.Tests/EnvWrapperTests.cs
@@ -53,8 +53,6 @@ public class EnvWrapperTests
         Assert.NotNull(_appId);
         Assert.Contains("PTEnv/", _appId);
         _output.WriteLine(_appId);
-        // check that it is last in the string
-        Assert.EndsWith("PTEnv/", _appId, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -71,8 +69,8 @@ public class EnvWrapperTests
     {
         Assert.NotNull(_appId);
         
-        // Should end with PTEnv/
-        Assert.EndsWith("PTEnv/", _appId);
+        // Should have PTEnv/
+        Assert.Contains("PTEnv/", _appId);
         
         // Should contain at least one PT/ entry
         var ptEntries = Regex.Matches(_appId, @"PT/[^/]+/\d+\.\d+\.\d+");
@@ -172,8 +170,8 @@ public class EnvWrapperTests
             _output.WriteLine($"✓ Found utility: {utility}");
         }
         
-        // Verify PTEnv/ is at the end
-        Assert.EndsWith("PTEnv/", appId);
+        // Verify PTEnv/ exists
+        Assert.Contains("PTEnv/", appId);
         
         // Verify each utility appears exactly once
         foreach (var utility in expectedUtilities)
@@ -237,8 +235,8 @@ public class EnvWrapperTests
             _output.WriteLine($"✓ Not Found utility: {utility}");
         }
         
-        // Verify PTEnv/ is at the end
-        Assert.EndsWith("PTEnv/", appId);
+        // Verify PTEnv/ is present
+        Assert.Contains("PTEnv/", appId);
         
         // Count total PT/ entries
         var ptEntries = Regex.Matches(appId, @"PT/[^/]+/\d+\.\d+\.\d+");
@@ -308,8 +306,8 @@ public class EnvWrapperTests
         // Verify the specific utility is present
         Assert.Contains($"PT/{expectedUtility}/", appId);
         
-        // Verify PTEnv/ is at the end
-        Assert.EndsWith("PTEnv/", appId);
+        // Verify PTEnv/ is present
+        Assert.Contains("PTEnv/", appId);
         
         _output.WriteLine($"Testing {expectedUtility}: {appId}");
     }


### PR DESCRIPTION
> Please provide the issue number

Issue number: closes #1029 

## Summary

### Changes

This pull request updates the examples to the latest nuget package verions and Powertools v3
This also fixes an issue in CI when testing if the string ends with PTENV/
It fails because ECS adds the app id `AWS_ECS_EC2`
Now we only check for Contains

```
[xUnit.net 00:00:00.30]       Assert.EndsWith() Failure: String end does not match
--
[xUnit.net 00:00:00.30]       String:       "PT/Logging/3.0.0 PTEnv/AWS_ECS_EC2"
[xUnit.net 00:00:00.30]       Expected end: "PTEnv/"
```

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [ ] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
