### PR TITLE
chore: Fix correlationid case insensitive

### DIFF
--- a/libraries/src/AWS.Lambda.Powertools.Logging/Internal/LoggingAspect.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Internal/LoggingAspect.cs
@@ -133,9 +133,32 @@ public class LoggingAspect : IMethodAspectHandler
                 // TODO: For casing parsing to be removed from Logging v2 when we get rid of outputcase without this CorrelationIdPaths.ApiGatewayRest would not work
                 // TODO: This will be removed and replaced by JMesPath
 
-                var pathWithOutputCase = correlationIdPaths[i].ToCase(_currentConfig.LoggerOutputCase);
-                if (!element.TryGetProperty(pathWithOutputCase, out var childElement))
-                    break;
+                var pathSegment = correlationIdPaths[i];
+                JsonElement childElement;
+                
+                // Try original path first (case-sensitive)
+                if (!element.TryGetProperty(pathSegment, out childElement))
+                {
+                    // Try with output case transformation
+                    var pathWithOutputCase = pathSegment.ToCase(_currentConfig.LoggerOutputCase);
+                    if (!element.TryGetProperty(pathWithOutputCase, out childElement))
+                    {
+                        // Try case-insensitive match as last resort
+                        var found = false;
+                        foreach (var property in element.EnumerateObject())
+                        {
+                            if (string.Equals(property.Name, pathSegment, StringComparison.OrdinalIgnoreCase))
+                            {
+                                childElement = property.Value;
+                                found = true;
+                                break;
+                            }
+                        }
+                        
+                        if (!found)
+                            break;
+                    }
+                }
 
                 element = childElement;
                 if (i == correlationIdPaths.Length - 1)

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Logger.Scope.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Logger.Scope.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using AWS.Lambda.Powertools.Logging.Internal;
 using AWS.Lambda.Powertools.Logging.Internal.Helpers;
 
 namespace AWS.Lambda.Powertools.Logging;
@@ -12,6 +13,22 @@ public static partial class Logger
     /// </summary>
     /// <value>The scope.</value>
     private static IDictionary<string, object> Scope { get; } = new Dictionary<string, object>(StringComparer.Ordinal);
+
+    /// <summary>
+    ///     Gets the correlation identifier from the log context.
+    /// </summary>
+    /// <value>The correlation identifier, or null if not set.</value>
+    public static string CorrelationId
+    {
+        get
+        {
+            if (Scope.TryGetValue(LoggingConstants.KeyCorrelationId, out var value))
+            {
+                return value?.ToString();
+            }
+            return null;
+        }
+    }
 
     /// <summary>
     ///     Appending additional key to the log context.

--- a/libraries/src/AWS.Lambda.Powertools.Logging/PowertoolsLoggerExtensions.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/PowertoolsLoggerExtensions.cs
@@ -171,6 +171,16 @@ public static class PowertoolsLoggerExtensions
     #endregion
     
     /// <summary>
+    ///     Gets the correlation identifier from the log context.
+    /// </summary>
+    /// <param name="logger">The logger instance.</param>
+    /// <returns>The correlation identifier, or null if not set.</returns>
+    public static string GetCorrelationId(this ILogger logger)
+    {
+        return Logger.CorrelationId;
+    }
+
+    /// <summary>
     ///     Appending additional key to the log context.
     /// </summary>
     /// <param name="logger"></param>

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Attributes/LoggingAttributeTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Attributes/LoggingAttributeTest.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using Amazon.Lambda.APIGatewayEvents;
 using Amazon.Lambda.ApplicationLoadBalancerEvents;
+using Amazon.Lambda.CloudWatchEvents;
 using Amazon.Lambda.CloudWatchEvents.S3Events;
 using Amazon.Lambda.TestUtilities;
 using AWS.Lambda.Powertools.Common;
@@ -172,6 +173,7 @@ namespace AWS.Lambda.Powertools.Logging.Tests.Attributes
         [InlineData(CorrelationIdPaths.ApplicationLoadBalancer)]
         [InlineData(CorrelationIdPaths.EventBridge)]
         [InlineData("/headers/my_request_id_header")]
+        [InlineData("/detail/correlationId")]
         public void OnEntry_WhenEventArgExists_CapturesCorrelationId(string correlationIdPath)
         {
             // Arrange
@@ -210,6 +212,15 @@ namespace AWS.Lambda.Powertools.Logging.Tests.Attributes
                         Headers = new Header
                         {
                             MyRequestIdHeader = correlationId
+                        }
+                    });
+                    break;
+                case "/detail/correlationId":
+                    _testHandlers.CorrelationCloudWatchEventCustomPath(new CloudWatchEvent<CwEvent>
+                    {
+                        Detail = new CwEvent
+                        {
+                            CorrelationId = correlationId
                         }
                     });
                     break;

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Attributes/LoggingAttributeTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Attributes/LoggingAttributeTest.cs
@@ -405,6 +405,59 @@ namespace AWS.Lambda.Powertools.Logging.Tests.Attributes
         }
         
         [Fact]
+        public void OnEntry_WhenPropertyCasingDoesNotMatch_UsesCaseInsensitiveFallback()
+        {
+            // Arrange
+            var correlationId = Guid.NewGuid().ToString();
+            
+            // This test uses a path "/detail/CORRELATIONID" (all caps) 
+            // but the actual property is "correlationId" (camelCase)
+            // This should trigger the case-insensitive fallback
+            
+            // Act
+            _testHandlers.CorrelationIdCaseInsensitiveFallback(new CloudWatchEvent<CwEvent>
+            {
+                Detail = new CwEvent
+                {
+                    CorrelationId = correlationId
+                }
+            });
+            
+            // Assert
+            var allKeys = Logger.GetAllKeys()
+                .ToDictionary(keyValuePair => keyValuePair.Key, keyValuePair => keyValuePair.Value);
+    
+            Assert.True(allKeys.ContainsKey(LoggingConstants.KeyCorrelationId));
+            Assert.Equal((string)allKeys[LoggingConstants.KeyCorrelationId], correlationId);
+        }
+        
+        [Fact]
+        public void OnEntry_WhenNestedPropertyCasingDoesNotMatch_UsesCaseInsensitiveFallback()
+        {
+            // Arrange
+            var correlationId = Guid.NewGuid().ToString();
+            
+            // This test uses a path with mismatched casing at multiple levels
+            // Path: "/DETAIL/CORRELATIONID" but actual properties are "detail" and "correlationId"
+            
+            // Act
+            _testHandlers.CorrelationIdNestedCaseInsensitive(new CloudWatchEvent<CwEvent>
+            {
+                Detail = new CwEvent
+                {
+                    CorrelationId = correlationId
+                }
+            });
+            
+            // Assert
+            var allKeys = Logger.GetAllKeys()
+                .ToDictionary(keyValuePair => keyValuePair.Key, keyValuePair => keyValuePair.Value);
+    
+            Assert.True(allKeys.ContainsKey(LoggingConstants.KeyCorrelationId));
+            Assert.Equal((string)allKeys[LoggingConstants.KeyCorrelationId], correlationId);
+        }
+        
+        [Fact]
         public void When_Setting_Service_Should_Update_Key()
         {
             // Arrange

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Attributes/LoggingAttributeTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Attributes/LoggingAttributeTest.cs
@@ -358,6 +358,53 @@ namespace AWS.Lambda.Powertools.Logging.Tests.Attributes
         }
         
         [Fact]
+        public void CorrelationId_Property_Should_Return_CorrelationId()
+        {
+            // Arrange
+            var correlationId = Guid.NewGuid().ToString();
+            
+            // Act
+            _testHandlers.CorrelationCloudWatchEventCustomPath(new CloudWatchEvent<CwEvent>
+            {
+                Detail = new CwEvent
+                {
+                    CorrelationId = correlationId
+                }
+            });
+            
+            // Assert - Static Logger property
+            Assert.Equal(correlationId, Logger.CorrelationId);
+        }
+        
+        [Fact]
+        public void CorrelationId_Extension_Should_Return_CorrelationId_Via_ILogger()
+        {
+            // Arrange
+            var correlationId = Guid.NewGuid().ToString();
+            
+            // Act
+            _testHandlers.CorrelationIdExtensionTest(new CloudWatchEvent<CwEvent>
+            {
+                Detail = new CwEvent
+                {
+                    CorrelationId = correlationId
+                }
+            });
+            
+            // Assert - The test handler will verify the extension method works
+            Assert.Equal(correlationId, Logger.CorrelationId);
+        }
+        
+        [Fact]
+        public void CorrelationId_Should_Return_Null_When_Not_Set()
+        {
+            // Arrange - no correlation ID set
+            
+            // Act & Assert
+            Assert.Null(Logger.CorrelationId);
+        }
+        
+        [Fact]
         public void When_Setting_Service_Should_Update_Key()
         {
             // Arrange

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Handlers/TestHandlers.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Handlers/TestHandlers.cs
@@ -66,6 +66,11 @@ class TestHandlers
     {
     }
 
+    [Logging(CorrelationIdPath = "/detail/correlationId")]
+    public void CorrelationCloudWatchEventCustomPath(CloudWatchEvent<CwEvent> cwEvent)
+    {
+    }
+
     [Logging(CorrelationIdPath = "/headers/my_request_id_header")]
     public void CorrelationIdFromString(TestObject testObject)
     {
@@ -170,6 +175,21 @@ class TestHandlers
         Dog = 3,
         Lizard = 5
     }
+}
+
+public class CwEvent
+{
+    [JsonPropertyName("rideId")]
+    public string RideId { get; set; } = string.Empty;
+
+    [JsonPropertyName("riderId")]
+    public string RiderId { get; set; } = string.Empty;
+
+    [JsonPropertyName("riderName")]
+    public string RiderName { get; set; } = string.Empty;
+
+    [JsonPropertyName("correlationId")]
+    public string? CorrelationId { get; set; }
 }
 
 public class TestServiceHandler

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Handlers/TestHandlers.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Handlers/TestHandlers.cs
@@ -85,6 +85,22 @@ class TestHandlers
         }
     }
 
+    [Logging(CorrelationIdPath = "/detail/CORRELATIONID")]
+    public void CorrelationIdCaseInsensitiveFallback(CloudWatchEvent<CwEvent> cwEvent)
+    {
+        // This handler uses all caps "CORRELATIONID" in the path
+        // but the actual JSON property is "correlationId" (camelCase)
+        // This tests the case-insensitive fallback logic
+    }
+
+    [Logging(CorrelationIdPath = "/DETAIL/CORRELATIONID")]
+    public void CorrelationIdNestedCaseInsensitive(CloudWatchEvent<CwEvent> cwEvent)
+    {
+        // This handler uses all caps for both path segments
+        // but the actual JSON properties are "detail" and "correlationId"
+        // This tests the case-insensitive fallback at multiple levels
+    }
+
     [Logging(CorrelationIdPath = "/headers/my_request_id_header")]
     public void CorrelationIdFromString(TestObject testObject)
     {

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Handlers/TestHandlers.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Handlers/TestHandlers.cs
@@ -71,6 +71,20 @@ class TestHandlers
     {
     }
 
+    [Logging(CorrelationIdPath = "/detail/correlationId")]
+    public void CorrelationIdExtensionTest(CloudWatchEvent<CwEvent> cwEvent)
+    {
+        // Test that the ILogger extension method works
+        var logger = Microsoft.Extensions.Logging.LoggerFactory.Create(builder => { }).CreateLogger(nameof(TestHandlers));
+        var correlationIdFromExtension = logger.GetCorrelationId();
+        
+        // Verify it matches the static property
+        if (correlationIdFromExtension != Logger.CorrelationId)
+        {
+            throw new Exception("Extension method returned different value than static property");
+        }
+    }
+
     [Logging(CorrelationIdPath = "/headers/my_request_id_header")]
     public void CorrelationIdFromString(TestObject testObject)
     {


### PR DESCRIPTION
> Please provide the issue number

Issue number: closes #1048

## Summary

### Changes

This pull request introduces improved support for retrieving correlation IDs.
The changes focus on making the correlation ID extraction more robust, exposing it via new APIs

### Correlation ID extraction improvements

* Enhanced the `CaptureCorrelationId` method in `LoggingAspect.cs` to try multiple strategies for extracting the correlation ID: first by exact (case-sensitive) match, then by output case transformation, and finally by case-insensitive search. This makes correlation ID retrieval more reliable across various event shapes.

### Public API enhancements

* Added a static `CorrelationId` property to the `Logger` class, allowing easy access to the current correlation ID from log context.
* Introduced a new `GetCorrelationId` extension method for `ILogger`, providing a convenient way to access the correlation ID from any logger instance.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [ ] [Meets tenets criteria](https://docs.aws.amazon.com/powertools/dotnet/tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
