### PR TITLE
chore: enable dependabot for more ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,15 +3,35 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
-    commit-message:
-      prefix: chore
-      include: scope
+      interval: weekly
 
   - package-ecosystem: docker
     directory: /docs
-    commit-message:
-      prefix: chore
-      include: scope
     schedule:
-      interval: daily
+      interval: monthly
+  
+  - package-ecosystem: npm
+    directories:
+      - "/"
+    labels: [ ]
+    schedule:
+      interval: monthly
+    versioning-strategy: increase
+    allow:
+      - dependency-name: "@aws-cdk/toolkit-lib"
+      - dependency-name: "aws-cdk-lib"
+      - dependency-name: "aws-cdk"
+    groups:
+      aws-cdk:
+        patterns:
+        - "@aws-cdk/toolkit-lib"
+        - "aws-cdk-lib"
+        - "aws-cdk"
+
+  - package-ecosystem: nuget
+    directories:
+      - "/"
+    labels: [ ]
+    schedule:
+      interval: monthly
+    versioning-strategy: increase

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "aws-cdk": "^2.1000.2",
-        "aws-cdk-lib": "^2.189.1"
+        "aws-cdk": "^2.1100.0",
+        "aws-cdk-lib": "^2.232.2"
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.230",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.230.tgz",
-      "integrity": "sha512-kUnhKIYu42hqBa6a8x2/7o29ObpJgjYGQy28lZDq9awXyvpR62I2bRxrNKNR3uFUQz3ySuT9JXhGHhuZPdbnFw==",
+      "version": "2.2.242",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.242.tgz",
+      "integrity": "sha512-4c1bAy2ISzcdKXYS1k4HYZsNrgiwbiDzj36ybwFVxEWZXVAP0dimQTCaB9fxu7sWzEjw3d+eaw6Fon+QTfTIpQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
@@ -25,9 +25,9 @@
       "integrity": "sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A=="
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "41.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-41.2.0.tgz",
-      "integrity": "sha512-JaulVS6z9y5+u4jNmoWbHZRs9uGOnmn/ktXygNWKNu1k6lF3ad4so3s18eRu15XCbUIomxN9WPYT6Ehh7hzONw==",
+      "version": "48.20.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-48.20.0.tgz",
+      "integrity": "sha512-+eeiav9LY4wbF/EFuCt/vfvi/Zoxo8bf94PW5clbMraChEliq83w4TbRVy0jB9jE0v1ooFTtIjSQkowSPkfISg==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -35,10 +35,10 @@
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "~1.4.1",
-        "semver": "^7.7.1"
+        "semver": "^7.7.2"
       },
       "engines": {
-        "node": ">= 14.15.0"
+        "node": ">= 18.0.0"
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
@@ -50,7 +50,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.7.1",
+      "version": "7.7.2",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -61,23 +61,24 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.1000.2",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1000.2.tgz",
-      "integrity": "sha512-QsXqJhGWjHNqP7etgE3sHOTiDBXItmSKdFKgsm1qPMBabCMyFfmWZnEeUxfZ4sMaIoxvLpr3sqoWSNeLuUk4sg==",
+      "version": "2.1100.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1100.0.tgz",
+      "integrity": "sha512-EadIbrhBodY6Sl+7ujTgZGCyUdcDpbWdDEqq9HsAtYW4CiB/Idu30O7mwITXCqiMAGreko/clMttVh/XfgEbJA==",
+      "license": "Apache-2.0",
       "bin": {
         "cdk": "bin/cdk"
       },
       "engines": {
-        "node": ">= 16.0.0"
+        "node": ">= 18.0.0"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.189.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.189.1.tgz",
-      "integrity": "sha512-9JU0yUr2iRTJ1oCPrHyx7hOtBDWyUfyOcdb6arlumJnMcQr2cyAMASY8HuAXHc8Y10ipVp8dRTW+J4/132IIYA==",
+      "version": "2.232.2",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.232.2.tgz",
+      "integrity": "sha512-jrAxZy5mvSM9YVuF1M++hP8IIGyNmPzW8+C5nnvOnx+eYuySRiCSAzKVKlvB+UNpA0VEVCDNyTxKiu0mFBeg/g==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -93,23 +94,23 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.229",
+        "@aws-cdk/asset-awscli-v1": "2.2.242",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
-        "@aws-cdk/cloud-assembly-schema": "^41.0.0",
+        "@aws-cdk/cloud-assembly-schema": "^48.20.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.3.0",
+        "fs-extra": "^11.3.2",
         "ignore": "^5.3.2",
         "jsonschema": "^1.5.0",
         "mime-types": "^2.1.35",
         "minimatch": "^3.1.2",
         "punycode": "^2.3.1",
-        "semver": "^7.7.1",
+        "semver": "^7.7.3",
         "table": "^6.9.0",
         "yaml": "1.10.2"
       },
       "engines": {
-        "node": ">= 14.15.0"
+        "node": ">= 18.0.0"
       },
       "peerDependencies": {
         "constructs": "^10.0.0"
@@ -171,7 +172,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "1.1.11",
+      "version": "1.1.12",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -219,7 +220,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fast-uri": {
-      "version": "3.0.6",
+      "version": "3.1.0",
       "funding": [
         {
           "type": "github",
@@ -234,7 +235,7 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.3.0",
+      "version": "11.3.2",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -273,7 +274,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
-      "version": "6.1.0",
+      "version": "6.2.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -343,7 +344,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.7.1",
+      "version": "7.7.3",
       "inBundle": true,
       "license": "ISC",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "aws-cdk": "^2.1000.2",
-    "aws-cdk-lib": "^2.189.1"
+    "aws-cdk": "^2.1100.0",
+    "aws-cdk-lib": "^2.232.2"
   }
 }


### PR DESCRIPTION
> Please provide the issue number

Issue number: closes #1087

## Summary

### Changes

> Please provide a summary of what's being changed

This PR updates the AWS CDK dependencies used in the project's CI and enables Dependabot for both `npm` and `nuget`'s package managers with a monthly cadence.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://docs.aws.amazon.com/powertools/dotnet/tenets)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
