### PR TITLE
chore: remove versioning-strategy from nuget dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,4 +34,3 @@ updates:
     labels: [ ]
     schedule:
       interval: monthly
-    versioning-strategy: increase


### PR DESCRIPTION
> Please provide the issue number

Issue number: closes #1087

## Summary

### Changes

> Please provide a summary of what's being changed

This PR amends a change made in #1088 which included an incorrect setting (`versioning-strategy`) for the `nuget` package manager in the Dependabot config. This setting is supported only by other package managers ([docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#versioning-strategy--)) and should not have been used.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [ ] [Meets tenets criteria](https://docs.aws.amazon.com/powertools/dotnet/tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
