### PR TITLE
feat(logging): thread safety with ConcurrentDictionary for scope storage

### DIFF
--- a/libraries/src/AWS.Lambda.Powertools.Logging/Logger.Scope.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Logger.Scope.cs
@@ -14,20 +14,21 @@ public static partial class Logger
     ///     Thread-safe dictionary for per-thread scope storage.
     ///     Uses ManagedThreadId as key to ensure isolation when Lambda processes
     ///     multiple concurrent requests (AWS_LAMBDA_MAX_CONCURRENCY > 1).
+    ///     Inner dictionary is ConcurrentDictionary for thread-safe operations.
     /// </summary>
-    private static readonly ConcurrentDictionary<int, Dictionary<string, object>> _threadScopes = new();
+    private static readonly ConcurrentDictionary<int, ConcurrentDictionary<string, object>> _threadScopes = new();
 
     /// <summary>
     ///     Gets the scope for the current thread.
     ///     Creates a new dictionary if one doesn't exist for this thread.
     /// </summary>
     /// <value>The scope.</value>
-    private static IDictionary<string, object> Scope
+    private static ConcurrentDictionary<string, object> Scope
     {
         get
         {
             var threadId = Environment.CurrentManagedThreadId;
-            return _threadScopes.GetOrAdd(threadId, _ => new Dictionary<string, object>(StringComparer.Ordinal));
+            return _threadScopes.GetOrAdd(threadId, _ => new ConcurrentDictionary<string, object>(StringComparer.Ordinal));
         }
     }
 
@@ -58,9 +59,10 @@ public static partial class Logger
     {
         if (string.IsNullOrWhiteSpace(key))
             throw new ArgumentNullException(nameof(key));
-            
-        Scope[key] = PowertoolsLoggerHelpers.ObjectToDictionary(value) ??
+        
+        var convertedValue = PowertoolsLoggerHelpers.ObjectToDictionary(value) ??
                      throw new ArgumentNullException(nameof(value));
+        Scope[key] = convertedValue;
     }
 
     /// <summary>
@@ -91,17 +93,18 @@ public static partial class Logger
     {
         if (keys == null) return;
         foreach (var key in keys)
-            if (Scope.ContainsKey(key))
-                Scope.Remove(key);
+            Scope.TryRemove(key, out _);
     }
 
     /// <summary>
     ///     Returns all additional keys added to the log context.
+    ///     Returns a snapshot to ensure thread-safety during enumeration.
     /// </summary>
     /// <returns>IEnumerable&lt;KeyValuePair&lt;System.String, System.Object&gt;&gt;.</returns>
     public static IEnumerable<KeyValuePair<string, object>> GetAllKeys()
     {
-        return Scope.AsEnumerable();
+        // Return a snapshot to avoid concurrent modification issues
+        return Scope.ToArray();
     }
 
     /// <summary>
@@ -121,7 +124,6 @@ public static partial class Logger
     /// </summary>
     public static void RemoveKey(string key)
     {
-        if (Scope.ContainsKey(key))
-            Scope.Remove(key);
+        Scope.TryRemove(key, out _);
     }
 }


### PR DESCRIPTION
> Please provide the issue number

Issue number: #1076 

## Summary

### Changes

- Replace inner Dictionary with ConcurrentDictionary in _threadScopes to ensure thread-safe operations on scope values
- Update Scope property return type from IDictionary to ConcurrentDictionary for consistency
- Refactor SetKey method to use intermediate variable for better readability and null handling
- Replace manual ContainsKey/Remove checks with TryRemove for atomic operations in RemoveKeys and RemoveKey methods
- Update GetAllKeys to return a snapshot via ToArray() to prevent concurrent modification exceptions during enumeration
- Add documentation clarifying that inner dictionary is ConcurrentDictionary and that GetAllKeys returns a snapshot for thread-safety
- Improve code consistency by using ConcurrentDictionary methods throughout instead of mixing Dictionary and ConcurrentDictionary patterns


### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [ ] [Meets tenets criteria](https://docs.aws.amazon.com/powertools/dotnet/tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
