### PR TITLE
chore: add .NET 10.0 support and update target frameworks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           dotnet-version: |
             8.0.x
+            10.0.x
 
       - name: Install dependencies
         run: dotnet restore
@@ -36,7 +37,7 @@ jobs:
         run: dotnet build --configuration Release --no-restore /tl
 
       - name: Test & Code Coverage
-        run: dotnet test --no-restore --filter "Category!=E2E" --collect:"XPlat Code Coverage" --results-directory ./codecov --verbosity normal
+        run: dotnet test --no-restore --filter "Category!=E2E" --collect:"XPlat Code Coverage" --results-directory ./codecov
 
       - name: Codecov
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # 5.5.2

--- a/.github/workflows/examples-tests.yml
+++ b/.github/workflows/examples-tests.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           dotnet-version: |
             8.0.x
+            10.0.x
 
       - name: Install dependencies
         run: dotnet restore

--- a/.github/workflows/publish-artifacts-examples-tests.yml
+++ b/.github/workflows/publish-artifacts-examples-tests.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           dotnet-version: |
             8.0.x
+            10.0.x
 
       - name: Build libraries
         run: dotnet build ./libraries/ --configuration Release
@@ -64,6 +65,7 @@ jobs:
         with:
           dotnet-version: |
             8.0.x
+            10.0.x
 
       - name: Download packages
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # 6.0.0
@@ -123,6 +125,7 @@ jobs:
         with:
           dotnet-version: |
             8.0.x
+            10.0.x
 
       - name: Setup GitHub Packages source
         run: |

--- a/libraries/src/AWS.Lambda.Powertools.EventHandler.Resolvers.BedrockAgentFunction.AspNetCore/AWS.Lambda.Powertools.EventHandler.Resolvers.BedrockAgentFunction.AspNetCore.csproj
+++ b/libraries/src/AWS.Lambda.Powertools.EventHandler.Resolvers.BedrockAgentFunction.AspNetCore/AWS.Lambda.Powertools.EventHandler.Resolvers.BedrockAgentFunction.AspNetCore.csproj
@@ -6,7 +6,6 @@
         <Description>Powertools for AWS Lambda (.NET) - Event Handler Bedrock Agent Function Resolver AspNetCore package.</Description>
         <AssemblyName>AWS.Lambda.Powertools.EventHandler.Resolvers.BedrockAgentFunction.AspNetCore</AssemblyName>
         <RootNamespace>AWS.Lambda.Powertools.EventHandler.Resolvers.BedrockAgentFunction.AspNetCore</RootNamespace>
-        <TargetFrameworks>net8.0</TargetFrameworks>
         <TargetMultiFramework>false</TargetMultiFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/libraries/src/AWS.Lambda.Powertools.EventHandler.Resolvers.BedrockAgentFunction/AWS.Lambda.Powertools.EventHandler.Resolvers.BedrockAgentFunction.csproj
+++ b/libraries/src/AWS.Lambda.Powertools.EventHandler.Resolvers.BedrockAgentFunction/AWS.Lambda.Powertools.EventHandler.Resolvers.BedrockAgentFunction.csproj
@@ -4,7 +4,6 @@
     <PropertyGroup>
         <PackageId>AWS.Lambda.Powertools.EventHandler.Resolvers.BedrockAgentFunction</PackageId>
         <Description>Powertools for AWS Lambda (.NET) - Event Handler Bedrock Agent Function Resolver package.</Description>
-        <TargetFrameworks>net8.0</TargetFrameworks>
         <TargetMultiFramework>false</TargetMultiFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/libraries/src/AWS.Lambda.Powertools.EventHandler/AWS.Lambda.Powertools.EventHandler.csproj
+++ b/libraries/src/AWS.Lambda.Powertools.EventHandler/AWS.Lambda.Powertools.EventHandler.csproj
@@ -6,7 +6,6 @@
         <Description>Powertools for AWS Lambda (.NET) - Event Handler package.</Description>
         <AssemblyName>AWS.Lambda.Powertools.EventHandler</AssemblyName>
         <RootNamespace>AWS.Lambda.Powertools.EventHandler</RootNamespace>
-        <TargetFrameworks>net8.0</TargetFrameworks>
         <TargetMultiFramework>false</TargetMultiFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/libraries/src/AWS.Lambda.Powertools.Kafka.Avro/AWS.Lambda.Powertools.Kafka.Avro.csproj
+++ b/libraries/src/AWS.Lambda.Powertools.Kafka.Avro/AWS.Lambda.Powertools.Kafka.Avro.csproj
@@ -7,7 +7,6 @@
         <Description>Powertools for AWS Lambda (.NET) - Kafka Avro consumer package.</Description>
         <AssemblyName>AWS.Lambda.Powertools.Kafka.Avro</AssemblyName>
         <RootNamespace>AWS.Lambda.Powertools.Kafka.Avro</RootNamespace>
-        <TargetFrameworks>net8.0</TargetFrameworks>
         <TargetMultiFramework>false</TargetMultiFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/libraries/src/AWS.Lambda.Powertools.Kafka.Json/AWS.Lambda.Powertools.Kafka.Json.csproj
+++ b/libraries/src/AWS.Lambda.Powertools.Kafka.Json/AWS.Lambda.Powertools.Kafka.Json.csproj
@@ -6,7 +6,6 @@
         <Description>Powertools for AWS Lambda (.NET) - Kafka Json consumer package.</Description>
         <AssemblyName>AWS.Lambda.Powertools.Kafka.Json</AssemblyName>
         <RootNamespace>AWS.Lambda.Powertools.Kafka.Json</RootNamespace>
-        <TargetFrameworks>net8.0</TargetFrameworks>
         <TargetMultiFramework>false</TargetMultiFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/libraries/src/AWS.Lambda.Powertools.Kafka.Protobuf/AWS.Lambda.Powertools.Kafka.Protobuf.csproj
+++ b/libraries/src/AWS.Lambda.Powertools.Kafka.Protobuf/AWS.Lambda.Powertools.Kafka.Protobuf.csproj
@@ -6,7 +6,6 @@
         <Description>Powertools for AWS Lambda (.NET) - Kafka Protobuf consumer package.</Description>
         <AssemblyName>AWS.Lambda.Powertools.Kafka.Protobuf</AssemblyName>
         <RootNamespace>AWS.Lambda.Powertools.Kafka.Protobuf</RootNamespace>
-        <TargetFrameworks>net8.0</TargetFrameworks>
         <TargetMultiFramework>false</TargetMultiFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/libraries/src/AWS.Lambda.Powertools.Kafka/AWS.Lambda.Powertools.Kafka.csproj
+++ b/libraries/src/AWS.Lambda.Powertools.Kafka/AWS.Lambda.Powertools.Kafka.csproj
@@ -6,7 +6,6 @@
         <Description>Powertools for AWS Lambda (.NET) - Kafka consumer package.</Description>
         <AssemblyName>AWS.Lambda.Powertools.Kafka</AssemblyName>
         <RootNamespace>AWS.Lambda.Powertools.Kafka</RootNamespace>
-        <TargetFrameworks>net8.0</TargetFrameworks>
         <TargetMultiFramework>false</TargetMultiFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/libraries/src/AWS.Lambda.Powertools.Metrics.AspNetCore/AWS.Lambda.Powertools.Metrics.AspNetCore.csproj
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics.AspNetCore/AWS.Lambda.Powertools.Metrics.AspNetCore.csproj
@@ -6,7 +6,6 @@
         <Description>Powertools for AWS Lambda (.NET) - Metrics AspNetCore package.</Description>
         <AssemblyName>AWS.Lambda.Powertools.Metrics.AspNetCore</AssemblyName>
         <RootNamespace>AWS.Lambda.Powertools.Metrics.AspNetCore</RootNamespace>
-        <TargetFrameworks>net8.0</TargetFrameworks>
         <TargetMultiFramework>false</TargetMultiFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/libraries/src/Directory.Build.props
+++ b/libraries/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <LangVersion>default</LangVersion>
         <!-- Version is generated when packaging the individual csproj -->
         <Version>$(Version)</Version>

--- a/libraries/tests/AWS.Lambda.Powertools.EventHandler.Tests/AWS.Lambda.Powertools.EventHandler.Tests.csproj
+++ b/libraries/tests/AWS.Lambda.Powertools.EventHandler.Tests/AWS.Lambda.Powertools.EventHandler.Tests.csproj
@@ -5,7 +5,6 @@
     <PropertyGroup>
         <AssemblyName>AWS.Lambda.Powertools.EventHandler.Tests</AssemblyName>
         <RootNamespace>AWS.Lambda.Powertools.EventHandler.Tests</RootNamespace>
-        <TargetFrameworks>net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/libraries/tests/AWS.Lambda.Powertools.Kafka.Tests/AWS.Lambda.Powertools.Kafka.Tests.csproj
+++ b/libraries/tests/AWS.Lambda.Powertools.Kafka.Tests/AWS.Lambda.Powertools.Kafka.Tests.csproj
@@ -5,7 +5,6 @@
     <PropertyGroup>
         <AssemblyName>AWS.Lambda.Powertools.Kafka.Tests</AssemblyName>
         <RootNamespace>AWS.Lambda.Powertools.Kafka.Tests</RootNamespace>
-        <TargetFrameworks>net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/libraries/tests/AWS.Lambda.Powertools.Metrics.AspNetCore.Tests/AWS.Lambda.Powertools.Metrics.AspNetCore.Tests.csproj
+++ b/libraries/tests/AWS.Lambda.Powertools.Metrics.AspNetCore.Tests/AWS.Lambda.Powertools.Metrics.AspNetCore.Tests.csproj
@@ -4,7 +4,6 @@
     <PropertyGroup>
         <AssemblyName>AWS.Lambda.Powertools.Metrics.AspNetCore.Tests</AssemblyName>
         <RootNamespace>AWS.Lambda.Powertools.Metrics.AspNetCore.Tests</RootNamespace>
-        <TargetFrameworks>net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/libraries/tests/AWS.Lambda.Powertools.Metrics.AspNetCore.Tests/MetricsEndpointExtensionsTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Metrics.AspNetCore.Tests/MetricsEndpointExtensionsTests.cs
@@ -32,7 +32,7 @@ public class MetricsEndpointExtensionsTests : IDisposable
 
         var app = builder.Build();
 
-        app.MapGet("/test", () => Results.Ok(new { success = true })).WithMetrics();
+        app.MapGet("/test", () => Results.Text("ok")).WithMetrics();
 
         await app.StartAsync();
         var client = app.GetTestClient();
@@ -82,7 +82,7 @@ public class MetricsEndpointExtensionsTests : IDisposable
             await next();
         });
 
-        app.MapGet("/test", () => Results.Ok(new { success = true })).WithMetrics();
+        app.MapGet("/test", () => Results.Text("ok")).WithMetrics();
 
         await app.StartAsync();
         var client = app.GetTestClient();
@@ -135,7 +135,7 @@ public class MetricsEndpointExtensionsTests : IDisposable
             await next();
         });
 
-        app.MapGet("/test", () => Results.Ok(new { success = true })).WithMetrics();
+        app.MapGet("/test", () => Results.Text("ok")).WithMetrics();
 
         await app.StartAsync();
         var client = app.GetTestClient();

--- a/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/TracingAttributeTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/TracingAttributeTest.cs
@@ -177,22 +177,43 @@ namespace AWS.Lambda.Powertools.Tracing.Tests
     }
 
     [Collection("TracingTests")]
-    public class TracingAttributeLambdaEnvironmentTest
+    public class TracingAttributeLambdaEnvironmentTest : IDisposable
     {
         private readonly HandlerFunctions _handler;
+        private Segment _testSegment;
     
         public TracingAttributeLambdaEnvironmentTest()
         {
             _handler = new HandlerFunctions();
+            
+            // Clean up any existing X-Ray context before test
+            CleanupXRayContext();
+        }
+        
+        private static void CleanupXRayContext()
+        {
+            // Clear environment to ensure we're not in Lambda mode
+            Environment.SetEnvironmentVariable("LAMBDA_TASK_ROOT", null);
+            
+            try
+            {
+                AWSXRayRecorder.Instance.TraceContext.ClearEntity();
+            }
+            catch
+            {
+                // Ignore if no entity exists
+            }
+            
+            XRayRecorder.ResetInstance();
         }
         
         [Fact]
         public void Tracing_WhenOutsideOfLambdaEnv_DisablesTracing()
         {
-            // Arrange
-            
-            // Need to manually create the initial segment
-            AWSXRayRecorder.Instance.BeginSegment("foo");
+            // Arrange - Create segment directly without using BeginSegment to avoid Facade Segment issues
+            _testSegment = new Segment("foo");
+            _testSegment.SetStartTimeToNow();
+            AWSXRayRecorder.Instance.TraceContext.SetEntity(_testSegment);
     
             // Act
             // Cold Start Execution
@@ -205,8 +226,23 @@ namespace AWS.Lambda.Powertools.Tracing.Tests
             Assert.Empty(segmentCold.Annotations);
             Assert.False(segmentCold.IsSubsegmentsAdded);
             Assert.False(segmentCold.IsMetadataAdded);
-
-            AWSXRayRecorder.Instance.EndSegment();
+        }
+        
+        public void Dispose()
+        {
+            try
+            {
+                if (_testSegment != null)
+                {
+                    _testSegment.SetEndTimeToNow();
+                }
+                AWSXRayRecorder.Instance.TraceContext.ClearEntity();
+            }
+            catch
+            {
+                // Ignore cleanup errors
+            }
+            XRayRecorder.ResetInstance();
         }
     }
     

--- a/libraries/tests/Directory.Build.props
+++ b/libraries/tests/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
     <ItemGroup>


### PR DESCRIPTION
> Please provide the issue number

Issue number: #1103 

## Summary

### Changes

- Add .NET 10.0.x to build, examples-tests, and publish-artifacts workflows
- Remove explicit TargetFrameworks declarations from project files to use Directory.Build.props
- Update EventHandler, Kafka, and Metrics packages to inherit framework targets
- Remove verbose flag from test command to reduce output noise
- Consolidate framework configuration management across all libraries and tests
- Enable .NET 10.0 support while maintaining backward compatibility with .NET 8.0

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [ ] [Meets tenets criteria](https://docs.aws.amazon.com/powertools/dotnet/tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
