### PR TITLE
chore: update .NET runtime support to 10.0 and remove 6.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -58,9 +58,10 @@ body:
     attributes:
       label: AWS Lambda function runtime
       options:
-        - dotnet6
         - dotnet8
         - dotnet8 (AOT)
+        - dotnet10
+        - dotnet10 (AOT)
     validations:
       required: true
   - type: textarea

--- a/docs/getting-started/logger/aot.md
+++ b/docs/getting-started/logger/aot.md
@@ -209,7 +209,7 @@ Alternatively, you can use Docker directly for more control:
 
 ```bash
 # Create a build container using Amazon's provided image
-docker run --rm -v $(pwd):/workspace -w /workspace public.ecr.aws/sam/build-dotnet8:latest-x86_64 \
+docker run --rm -v $(pwd):/workspace -w /workspace public.ecr.aws/sam/build-dotnet10:latest-x86_64 \
     bash -c "cd src/PowertoolsAotLoggerDemo && dotnet publish -c Release -r linux-x64 -o publish"
 
 # Deploy using the AWS CLI
@@ -227,7 +227,7 @@ aws lambda create-function \
 
 ```powershell
 # Create a build container using Amazon's provided image
-docker run --rm -v ${PWD}:/workspace -w /workspace public.ecr.aws/sam/build-dotnet8:latest-x86_64 `
+docker run --rm -v ${PWD}:/workspace -w /workspace public.ecr.aws/sam/build-dotnet10:latest-x86_64 `
     bash -c "cd src/PowertoolsAotLoggerDemo && dotnet publish -c Release -r linux-x64 -o publish"
 
 # Deploy using the AWS CLI

--- a/libraries/tests/e2e/InfraShared/FunctionConstruct.cs
+++ b/libraries/tests/e2e/InfraShared/FunctionConstruct.cs
@@ -13,7 +13,7 @@ public class FunctionConstruct : Construct
         var framework = "net8.0";
         var distPath = $"{props.DistPath}/deploy_{props.Architecture.Name}_{props.Runtime.Name}.zip";
         var command = props.IsAot
-            ? $"dotnet-lambda package -pl {props.SourcePath} -cmd ../../../ -o {distPath} -farch {props.Architecture.Name} -cifb public.ecr.aws/sam/build-dotnet8"
+            ? $"dotnet-lambda package -pl {props.SourcePath} -cmd ../../../ -o {distPath} -farch {props.Architecture.Name} -cifb public.ecr.aws/sam/build-dotnet10"
             : $"dotnet-lambda package -pl {props.SourcePath} -o {distPath} -f {framework} -farch {props.Architecture.Name}";
         
         Console.WriteLine(command);


### PR DESCRIPTION
> Please provide the issue number

Issue number: #1103 

## Summary

### Changes

- Remove dotnet6 from bug report issue template runtime options
- Add dotnet10 and dotnet10 (AOT) to supported runtime options
- Update Docker build image references from dotnet8 to dotnet10 in AOT logger documentation
- Align documentation and issue templates with .NET 10.0 support addition

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [ ] [Meets tenets criteria](https://docs.aws.amazon.com/powertools/dotnet/tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
