### PR TITLE
feat: add TenantId to default logger properties

### DIFF
--- a/libraries/src/AWS.Lambda.Powertools.Logging/Internal/LoggingConstants.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Internal/LoggingConstants.cs
@@ -111,4 +111,9 @@ internal static class LoggingConstants
     ///     Constant for key exception
     /// </summary>
     internal const string KeyException = "Exception";
+
+    /// <summary>
+    ///   Constant for key tenant id
+    /// </summary>    
+    public const string KeyFunctionTenantId = "TenantId";
 }

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Internal/LoggingLambdaContext.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Internal/LoggingLambdaContext.cs
@@ -92,8 +92,7 @@ internal class LoggingLambdaContext
             LogGroupName = x.LogGroupName,
             LogStreamName = x.LogStreamName,
             MemoryLimitInMB = x.MemoryLimitInMB,
-            TenantId =x.TenantId,
-
+            TenantId = x.TenantId,
         };
         return true;
     }

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Internal/LoggingLambdaContext.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Internal/LoggingLambdaContext.cs
@@ -54,6 +54,11 @@ internal class LoggingLambdaContext
     internal int MemoryLimitInMB { get; private set; }
 
     /// <summary>
+    /// The tenant ID associated with the Lambda invocation.
+    /// </summary>
+    internal string TenantId { get; private set; }
+
+    /// <summary>
     ///     The instance
     /// </summary>
     internal static LoggingLambdaContext Instance { get; private set; }
@@ -86,7 +91,9 @@ internal class LoggingLambdaContext
             InvokedFunctionArn = x.InvokedFunctionArn,
             LogGroupName = x.LogGroupName,
             LogStreamName = x.LogStreamName,
-            MemoryLimitInMB = x.MemoryLimitInMB
+            MemoryLimitInMB = x.MemoryLimitInMB,
+            TenantId =x.TenantId,
+
         };
         return true;
     }

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Internal/PowertoolsLogger.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Internal/PowertoolsLogger.cs
@@ -457,6 +457,9 @@ internal sealed class PowertoolsLogger : ILogger
         logEntry.TryAdd(LoggingConstants.KeyFunctionArn, context.InvokedFunctionArn);
         logEntry.TryAdd(LoggingConstants.KeyFunctionRequestId, context.AwsRequestId);
         logEntry.TryAdd(LoggingConstants.KeyFunctionVersion, context.FunctionVersion);
+        
+        if(!string.IsNullOrEmpty(context.TenantId))
+            logEntry.TryAdd(LoggingConstants.KeyFunctionTenantId, context.TenantId);
     }
 
     /// <summary>
@@ -474,6 +477,7 @@ internal sealed class PowertoolsLogger : ILogger
             MemoryLimitInMB = context.MemoryLimitInMB,
             InvokedFunctionArn = context.InvokedFunctionArn,
             AwsRequestId = context.AwsRequestId,
+            TenantId = context.TenantId
         };
     }
 

--- a/libraries/src/AWS.Lambda.Powertools.Logging/LogEntryLambdaContext.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/LogEntryLambdaContext.cs
@@ -53,4 +53,9 @@ public class LogEntryLambdaContext
     /// CloudWatch actions.
     /// </summary>
     public string InvokedFunctionArn { get; internal set; }
+
+    /// <summary>
+    /// Tenancy ID associated with the Lambda invocation.
+    /// </summary>
+    public string TenantId { get; set; }
 }

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Attributes/LoggingAttributeTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Attributes/LoggingAttributeTest.cs
@@ -120,6 +120,72 @@ namespace AWS.Lambda.Powertools.Logging.Tests.Attributes
         }
         
         [Fact]
+        public void OnEntry_When_TenantId_Exist_Log()
+        {
+            // Arrange
+            var consoleOut = GetConsoleOutput();
+            var correlationId = Guid.NewGuid().ToString();
+            Logger.Configure(options =>
+            {
+                options.LogOutput = consoleOut;
+            });
+            
+            var context = new TestLambdaContext()
+            {
+                TenantId = "Tenant-12345",
+            };
+    
+            var testObj = new TestObject
+            {
+                Headers = new Header
+                {
+                    MyRequestIdHeader = correlationId
+                }
+            };
+            
+            // Act
+            _testHandlers.LogEvent(testObj, context);
+    
+            consoleOut.Received(1).WriteLine(
+                Arg.Is<string>(i => i.Contains("TenantId\":\"Tenant-12345"))
+            );
+        }
+        
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        public void OnEntry_When_TenantId_Does_Not_Exist_Dont_Log(string tenantId)
+        {
+            // Arrange
+            var consoleOut = GetConsoleOutput();
+            var correlationId = Guid.NewGuid().ToString();
+            Logger.Configure(options =>
+            {
+                options.LogOutput = consoleOut;
+            });
+            
+            var context = new TestLambdaContext()
+            {
+                TenantId = tenantId,
+            };
+    
+            var testObj = new TestObject
+            {
+                Headers = new Header
+                {
+                    MyRequestIdHeader = correlationId
+                }
+            };
+            
+            // Act
+            _testHandlers.LogEvent(testObj, context);
+    
+            consoleOut.DidNotReceive().WriteLine(
+                Arg.Is<string>(i => i.Contains("\"TenantId\""))
+            );
+        }
+        
+        [Fact]
         public void OnEntry_WhenEventArgExist_LogEvent_False_Should_Not_Log()
         {
             // Arrange

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Context/LambdaContextTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Context/LambdaContextTest.cs
@@ -23,7 +23,8 @@ public class LambdaContextTest
              InvokedFunctionArn = Guid.NewGuid().ToString(),
              LogGroupName = Guid.NewGuid().ToString(),
              LogStreamName = Guid.NewGuid().ToString(),
-             MemoryLimitInMB = new Random().Next()
+             MemoryLimitInMB = new Random().Next(),
+             TenantId = Guid.NewGuid().ToString()
          };
          
          var args = Substitute.For<AspectEventArgs>();
@@ -52,6 +53,7 @@ public class LambdaContextTest
          Assert.Equal(LoggingLambdaContext.Instance.LogGroupName, lambdaContext.LogGroupName);
          Assert.Equal(LoggingLambdaContext.Instance.LogStreamName, lambdaContext.LogStreamName);
          Assert.Equal(LoggingLambdaContext.Instance.MemoryLimitInMB, lambdaContext.MemoryLimitInMB);
+         Assert.Equal(LoggingLambdaContext.Instance.TenantId, lambdaContext.TenantId);
          LoggingLambdaContext.Clear();
          Assert.Null(LoggingLambdaContext.Instance);
      }
@@ -120,7 +122,8 @@ public class LambdaContextTest
              InvokedFunctionArn = Guid.NewGuid().ToString(),
              LogGroupName = Guid.NewGuid().ToString(),
              LogStreamName = Guid.NewGuid().ToString(),
-             MemoryLimitInMB = new Random().Next()
+             MemoryLimitInMB = new Random().Next(),
+             TenantId = Guid.NewGuid().ToString()
          };
          
          var args = Substitute.For<AspectEventArgs>();

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Handlers/HandlerTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Handlers/HandlerTests.cs
@@ -107,7 +107,8 @@ public class HandlerTests
             FunctionName = "test-function",
             FunctionVersion = "1",
             AwsRequestId = "123",
-            InvokedFunctionArn = "arn:aws:lambda:us-east-1:123456789012:function:test-function"
+            InvokedFunctionArn = "arn:aws:lambda:us-east-1:123456789012:function:test-function",
+            TenantId = "tenant-123"
         });
 
         handler.TestMethodCorrelation(new ExampleClass
@@ -131,6 +132,7 @@ public class HandlerTests
         Assert.Contains("\"Custom-key\": \"custom-value\"", logOutput);
         Assert.Contains("\"FunctionName\": \"test-function\"", logOutput);
         Assert.Contains("\"SamplingRate\": 0.002", logOutput);
+        Assert.Contains("\"TenantId\": \"tenant-123\"", logOutput);
     }
 
     [Fact]


### PR DESCRIPTION


Issue number:  #1109

## Summary
Adds the TenantId from ILambdaContext to the default logger properties to support
AWS Lambda Tenant Isolation observability.

### Changes

- Added TenantId property to LoggingLambdaContext
- Propagated TenantId from ILambdaContext during context extraction
- Extended existing tests to validate TenantId extraction

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://docs.aws.amazon.com/powertools/dotnet/tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
