### PR TITLE
feat(logging): add ExtraKeys to logger

### DIFF
--- a/docs/core/logging.md
+++ b/docs/core/logging.md
@@ -714,6 +714,9 @@ Keys are automatically removed when the scope ends, eliminating the need to manu
 !!! tip "When to use ExtraKeys vs AppendKey"
     Use `ExtraKeys` when you need keys for a specific operation or code block. Use `AppendKey` when keys should persist for the entire Lambda invocation.
 
+!!! warning "Key overwrite behavior"
+    If a key already exists when entering an `ExtraKeys` scope, it will be overwritten and then **removed** when the scope ends. The original value is not restored. Use unique key names within `ExtraKeys` scopes to avoid unexpected behavior.
+
 !!! info "Async safe"
     `ExtraKeys` is safe to use across `async/await` boundaries. Keys will correctly flow through asynchronous operations within the same execution context.
 

--- a/docs/core/logging.md
+++ b/docs/core/logging.md
@@ -604,10 +604,122 @@ You can remove any additional key from entry using `Logger.RemoveKeys()`.
     }
     ```
 
-## Extra Keys
+### Temporary keys with ExtraKeys
 
-Extra keys allow you to append additional keys to a log entry. Unlike `AppendKey`, extra keys will only apply to the
-current log entry.
+The `ExtraKeys` method allows temporary modification of the Logger's context without manual cleanup. It's useful for adding context keys to specific workflows while maintaining the logger's overall state.
+
+Keys are automatically removed when the scope ends, eliminating the need to manually call `AppendKey` and `RemoveKeys`.
+
+=== "Using Dictionary"
+
+    ```c# hl_lines="12-16"
+    /**
+     * Handler for requests to Lambda function.
+     */
+    public class Function
+    {
+        [Logging]
+        public async Task<APIGatewayProxyResponse> FunctionHandler
+            (APIGatewayProxyRequest apigProxyEvent, ILambdaContext context)
+        {
+            var orderId = apigProxyEvent.PathParameters["orderId"];
+            
+            using (Logger.ExtraKeys(new Dictionary<string, object> { { "orderId", orderId } }))
+            {
+                Logger.LogInformation("Processing order");
+                await ProcessOrderAsync(orderId);
+                Logger.LogInformation("Order processed"); // orderId included
+            }
+            // orderId is automatically removed
+            
+            Logger.LogInformation("Continuing without orderId");
+        }
+    }
+    ```
+
+=== "Using Tuples"
+
+    ```c# hl_lines="12-16"
+    /**
+     * Handler for requests to Lambda function.
+     */
+    public class Function
+    {
+        [Logging]
+        public async Task<APIGatewayProxyResponse> FunctionHandler
+            (APIGatewayProxyRequest apigProxyEvent, ILambdaContext context)
+        {
+            var orderId = apigProxyEvent.PathParameters["orderId"];
+            
+            using (Logger.ExtraKeys(("orderId", orderId), ("customerId", "customer-123")))
+            {
+                Logger.LogInformation("Processing order");
+                await ProcessOrderAsync(orderId);
+                Logger.LogInformation("Order processed"); // orderId and customerId included
+            }
+            // Both keys are automatically removed
+        }
+    }
+    ```
+
+=== "Nested Scopes"
+
+    ```c# hl_lines="10-19"
+    /**
+     * Handler for requests to Lambda function.
+     */
+    public class Function
+    {
+        [Logging]
+        public async Task<APIGatewayProxyResponse> FunctionHandler
+            (APIGatewayProxyRequest apigProxyEvent, ILambdaContext context)
+        {
+            using (Logger.ExtraKeys(("requestId", context.AwsRequestId)))
+            {
+                Logger.LogInformation("Starting request"); // requestId included
+                
+                using (Logger.ExtraKeys(("step", "validation")))
+                {
+                    Logger.LogInformation("Validating"); // requestId AND step included
+                }
+                // step removed, requestId still present
+                
+                Logger.LogInformation("Request complete"); // only requestId
+            }
+        }
+    }
+    ```
+
+=== "Example CloudWatch Logs excerpt"
+
+    ```json hl_lines="14 15"
+    {
+        "level": "Information",
+        "message": "Processing order",
+        "timestamp": "2024-01-15T10:30:00.0000000Z",
+        "service": "order-service",
+        "cold_start": true,
+        "function_name": "OrderProcessor",
+        "function_memory_size": 256,
+        "function_arn": "arn:aws:lambda:eu-west-1:123456789:function:OrderProcessor",
+        "function_request_id": "abc-123-def",
+        "function_version": "$LATEST",
+        "xray_trace_id": "1-abc-123",
+        "name": "AWS.Lambda.Powertools.Logging.Logger",
+        "order_id": "order-456",
+        "customer_id": "customer-123"
+    }
+    ```
+
+!!! tip "When to use ExtraKeys vs AppendKey"
+    Use `ExtraKeys` when you need keys for a specific operation or code block. Use `AppendKey` when keys should persist for the entire Lambda invocation.
+
+!!! info "Async safe"
+    `ExtraKeys` is safe to use across `async/await` boundaries. Keys will correctly flow through asynchronous operations within the same execution context.
+
+## Extra Keys (Single Log Entry)
+
+Extra keys can also be added to a single log entry using message templates. Unlike `AppendKey` or `ExtraKeys()`, these keys will only apply to the current log entry.
 
 Extra keys argument is available for all log levels' methods, as implemented in the standard logging library - e.g.
 Logger.Information, Logger.Warning.

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Logger.Scope.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Logger.Scope.cs
@@ -169,6 +169,16 @@ public static partial class Logger
     /// </summary>
     /// <param name="keys">The keys to add temporarily.</param>
     /// <returns>An IDisposable that removes the keys when disposed.</returns>
+    /// <remarks>
+    ///     <para>
+    ///         <b>Important:</b> If a key already exists in the context, it will be overwritten
+    ///         and then removed when the scope is disposed. The original value is NOT restored.
+    ///     </para>
+    ///     <para>
+    ///         For example, if "orderId" = "A" exists and you create a scope with "orderId" = "B",
+    ///         disposing the scope will remove "orderId" entirely, not restore it to "A".
+    ///     </para>
+    /// </remarks>
     /// <example>
     /// <code>
     /// using (Logger.ExtraKeys(new Dictionary&lt;string, object&gt; { {"orderId", "123"} }))
@@ -191,6 +201,12 @@ public static partial class Logger
     /// </summary>
     /// <param name="keys">The keys to add temporarily as tuples.</param>
     /// <returns>An IDisposable that removes the keys when disposed.</returns>
+    /// <remarks>
+    ///     <para>
+    ///         <b>Important:</b> If a key already exists in the context, it will be overwritten
+    ///         and then removed when the scope is disposed. The original value is NOT restored.
+    ///     </para>
+    /// </remarks>
     /// <example>
     /// <code>
     /// using (Logger.ExtraKeys(("orderId", "123"), ("customerId", "456")))

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Logger.Scope.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Logger.Scope.cs
@@ -11,24 +11,63 @@ namespace AWS.Lambda.Powertools.Logging;
 public static partial class Logger
 {
     /// <summary>
-    ///     Thread-safe dictionary for per-thread scope storage.
-    ///     Uses ManagedThreadId as key to ensure isolation when Lambda processes
-    ///     multiple concurrent requests (AWS_LAMBDA_MAX_CONCURRENCY > 1).
-    ///     Inner dictionary is ConcurrentDictionary for thread-safe operations.
+    ///     AsyncLocal storage for per-invocation scope.
+    ///     Uses AsyncLocal to ensure keys flow correctly across async/await boundaries.
+    ///     
+    ///     In Lambda's multi-threaded mode, each invocation starts with a fresh execution
+    ///     context, providing natural isolation between concurrent invocations.
+    ///     Keys added via AppendKey flow across async/await within the same invocation.
     /// </summary>
-    private static readonly ConcurrentDictionary<int, ConcurrentDictionary<string, object>> _threadScopes = new();
+    private static readonly AsyncLocal<ConcurrentDictionary<string, object>> _asyncScope = new();
 
     /// <summary>
-    ///     Gets the scope for the current thread.
-    ///     Creates a new dictionary if one doesn't exist for this thread.
+    ///     Gets the scope for the current async execution context.
+    ///     Creates a new dictionary if one doesn't exist for this context.
     /// </summary>
     /// <value>The scope.</value>
     private static ConcurrentDictionary<string, object> Scope
     {
         get
         {
-            var threadId = Environment.CurrentManagedThreadId;
-            return _threadScopes.GetOrAdd(threadId, _ => new ConcurrentDictionary<string, object>(StringComparer.Ordinal));
+            var scope = _asyncScope.Value;
+            if (scope == null)
+            {
+                scope = new ConcurrentDictionary<string, object>(StringComparer.Ordinal);
+                _asyncScope.Value = scope;
+            }
+            return scope;
+        }
+    }
+    
+    /// <summary>
+    ///     Creates a new isolated scope for the current execution context.
+    ///     Used internally to simulate Lambda invocation isolation in tests.
+    /// </summary>
+    /// <returns>An IDisposable that restores the previous scope when disposed.</returns>
+    internal static IDisposable UseScope()
+    {
+        return new LoggerScopeContext();
+    }
+
+    /// <summary>
+    ///     Manages a new isolated scope context.
+    /// </summary>
+    private sealed class LoggerScopeContext : IDisposable
+    {
+        private readonly ConcurrentDictionary<string, object> _previousScope;
+        private bool _disposed;
+
+        public LoggerScopeContext()
+        {
+            _previousScope = _asyncScope.Value;
+            _asyncScope.Value = new ConcurrentDictionary<string, object>(StringComparer.Ordinal);
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            _asyncScope.Value = _previousScope;
         }
     }
 
@@ -49,7 +88,8 @@ public static partial class Logger
     }
 
     /// <summary>
-    ///     Appending additional key to the log context.
+    ///     Appends a key-value pair to the log context.
+    ///     Keys persist across async/await boundaries within the same execution context.
     /// </summary>
     /// <param name="key">The key.</param>
     /// <param name="value">The value.</param>
@@ -66,7 +106,7 @@ public static partial class Logger
     }
 
     /// <summary>
-    ///     Appending additional key to the log context.
+    ///     Appends multiple keys to the log context.
     /// </summary>
     /// <param name="keys">The list of keys.</param>
     public static void AppendKeys(IEnumerable<KeyValuePair<string, object>> keys)
@@ -76,7 +116,7 @@ public static partial class Logger
     }
 
     /// <summary>
-    ///     Appending additional key to the log context.
+    ///     Appends multiple keys to the log context.
     /// </summary>
     /// <param name="keys">The list of keys.</param>
     public static void AppendKeys(IEnumerable<KeyValuePair<string, string>> keys)
@@ -86,7 +126,7 @@ public static partial class Logger
     }
 
     /// <summary>
-    ///     Remove additional keys from the log context.
+    ///     Removes keys from the log context.
     /// </summary>
     /// <param name="keys">The list of keys.</param>
     public static void RemoveKeys(params string[] keys)
@@ -97,7 +137,7 @@ public static partial class Logger
     }
 
     /// <summary>
-    ///     Returns all additional keys added to the log context.
+    ///     Returns all keys added to the log context.
     ///     Returns a snapshot to ensure thread-safety during enumeration.
     /// </summary>
     /// <returns>IEnumerable&lt;KeyValuePair&lt;System.String, System.Object&gt;&gt;.</returns>
@@ -108,15 +148,11 @@ public static partial class Logger
     }
 
     /// <summary>
-    ///     Removes all additional keys from the log context for the current thread.
+    ///     Removes all keys from the log context for the current execution context.
     /// </summary>
     internal static void RemoveAllKeys()
     {
-        var threadId = Environment.CurrentManagedThreadId;
-        if (_threadScopes.TryGetValue(threadId, out var scope))
-        {
-            scope.Clear();
-        }
+        _asyncScope.Value?.Clear();
     }
     
     /// <summary>
@@ -125,5 +161,80 @@ public static partial class Logger
     public static void RemoveKey(string key)
     {
         Scope.TryRemove(key, out _);
+    }
+
+    /// <summary>
+    ///     Adds temporary keys to the log context that are automatically removed when disposed.
+    ///     Safe to use across async/await boundaries.
+    /// </summary>
+    /// <param name="keys">The keys to add temporarily.</param>
+    /// <returns>An IDisposable that removes the keys when disposed.</returns>
+    /// <example>
+    /// <code>
+    /// using (Logger.ExtraKeys(new Dictionary&lt;string, object&gt; { {"orderId", "123"} }))
+    /// {
+    ///     await ProcessOrderAsync();
+    ///     Logger.LogInformation("Order processed"); // includes orderId
+    /// }
+    /// // orderId is automatically removed
+    /// </code>
+    /// </example>
+    public static IDisposable ExtraKeys(IEnumerable<KeyValuePair<string, object>> keys)
+    {
+        if (keys == null) throw new ArgumentNullException(nameof(keys));
+        return new LoggerExtraKeysScope(keys);
+    }
+
+    /// <summary>
+    ///     Adds temporary keys to the log context that are automatically removed when disposed.
+    ///     Safe to use across async/await boundaries.
+    /// </summary>
+    /// <param name="keys">The keys to add temporarily as tuples.</param>
+    /// <returns>An IDisposable that removes the keys when disposed.</returns>
+    /// <example>
+    /// <code>
+    /// using (Logger.ExtraKeys(("orderId", "123"), ("customerId", "456")))
+    /// {
+    ///     Logger.LogInformation("Processing"); // includes orderId and customerId
+    /// }
+    /// </code>
+    /// </example>
+    public static IDisposable ExtraKeys(params (string Key, object Value)[] keys)
+    {
+        if (keys == null) throw new ArgumentNullException(nameof(keys));
+        return new LoggerExtraKeysScope(keys.Select(k => new KeyValuePair<string, object>(k.Key, k.Value)));
+    }
+
+    /// <summary>
+    ///     Scope that manages temporary logging keys.
+    ///     Keys are added on construction and removed on disposal.
+    /// </summary>
+    private sealed class LoggerExtraKeysScope : IDisposable
+    {
+        private readonly string[] _keysToRemove;
+        private bool _disposed;
+
+        public LoggerExtraKeysScope(IEnumerable<KeyValuePair<string, object>> keys)
+        {
+            var keyList = new List<string>();
+            
+            foreach (var (key, value) in keys)
+            {
+                if (string.IsNullOrWhiteSpace(key)) continue;
+                
+                AppendKey(key, value);
+                keyList.Add(key);
+            }
+            
+            _keysToRemove = keyList.ToArray();
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            
+            RemoveKeys(_keysToRemove);
+        }
     }
 }

--- a/libraries/src/AWS.Lambda.Powertools.Logging/PowertoolsLoggerExtensions.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/PowertoolsLoggerExtensions.cs
@@ -255,6 +255,12 @@ public static class PowertoolsLoggerExtensions
     /// <param name="logger">The logger instance.</param>
     /// <param name="keys">The keys to add temporarily.</param>
     /// <returns>An IDisposable that removes the keys when disposed.</returns>
+    /// <remarks>
+    ///     <para>
+    ///         <b>Important:</b> If a key already exists in the context, it will be overwritten
+    ///         and then removed when the scope is disposed. The original value is NOT restored.
+    ///     </para>
+    /// </remarks>
     /// <example>
     /// <code>
     /// using (logger.ExtraKeys(new Dictionary&lt;string, object&gt; { {"orderId", "123"} }))
@@ -277,6 +283,12 @@ public static class PowertoolsLoggerExtensions
     /// <param name="logger">The logger instance.</param>
     /// <param name="keys">The keys to add temporarily as tuples.</param>
     /// <returns>An IDisposable that removes the keys when disposed.</returns>
+    /// <remarks>
+    ///     <para>
+    ///         <b>Important:</b> If a key already exists in the context, it will be overwritten
+    ///         and then removed when the scope is disposed. The original value is NOT restored.
+    ///     </para>
+    /// </remarks>
     /// <example>
     /// <code>
     /// using (logger.ExtraKeys(("orderId", "123"), ("customerId", "456")))

--- a/libraries/src/AWS.Lambda.Powertools.Logging/PowertoolsLoggerExtensions.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/PowertoolsLoggerExtensions.cs
@@ -248,6 +248,48 @@ public static class PowertoolsLoggerExtensions
         Logger.RemoveKey(key);
     }
 
+    /// <summary>
+    ///     Adds temporary keys to the log context that are automatically removed when disposed.
+    ///     Safe to use across async/await boundaries.
+    /// </summary>
+    /// <param name="logger">The logger instance.</param>
+    /// <param name="keys">The keys to add temporarily.</param>
+    /// <returns>An IDisposable that removes the keys when disposed.</returns>
+    /// <example>
+    /// <code>
+    /// using (logger.ExtraKeys(new Dictionary&lt;string, object&gt; { {"orderId", "123"} }))
+    /// {
+    ///     await ProcessOrderAsync();
+    ///     logger.LogInformation("Order processed"); // includes orderId
+    /// }
+    /// // orderId is automatically removed
+    /// </code>
+    /// </example>
+    public static IDisposable ExtraKeys(this ILogger logger, IEnumerable<KeyValuePair<string, object>> keys)
+    {
+        return Logger.ExtraKeys(keys);
+    }
+
+    /// <summary>
+    ///     Adds temporary keys to the log context that are automatically removed when disposed.
+    ///     Safe to use across async/await boundaries.
+    /// </summary>
+    /// <param name="logger">The logger instance.</param>
+    /// <param name="keys">The keys to add temporarily as tuples.</param>
+    /// <returns>An IDisposable that removes the keys when disposed.</returns>
+    /// <example>
+    /// <code>
+    /// using (logger.ExtraKeys(("orderId", "123"), ("customerId", "456")))
+    /// {
+    ///     logger.LogInformation("Processing"); // includes orderId and customerId
+    /// }
+    /// </code>
+    /// </example>
+    public static IDisposable ExtraKeys(this ILogger logger, params (string Key, object Value)[] keys)
+    {
+        return Logger.ExtraKeys(keys);
+    }
+
     // Replace the buffer methods with direct calls to the manager
 
     /// <summary>

--- a/libraries/tests/AWS.Lambda.Powertools.ConcurrencyTests/Logging/AsyncSafetyTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.ConcurrencyTests/Logging/AsyncSafetyTests.cs
@@ -1,0 +1,234 @@
+using AWS.Lambda.Powertools.Logging;
+using Xunit;
+
+namespace AWS.Lambda.Powertools.ConcurrencyTests.Logging;
+
+/// <summary>
+/// Tests for validating async safety of Logger keys.
+/// These tests verify that keys flow correctly across async/await boundaries
+/// using AsyncLocal storage.
+/// </summary>
+public class AsyncSafetyTests
+{
+    /// <summary>
+    /// Verifies that keys persist across await boundaries within the same execution context.
+    /// This is the critical test for AsyncLocal correctness.
+    /// </summary>
+    [Fact]
+    public async Task AppendKey_AcrossAwaitBoundary_ShouldPersist()
+    {
+        // Arrange
+        ClearAllLoggerState();
+        var testKey = "async_test_key";
+        var testValue = "async_test_value";
+
+        // Act
+        Logger.AppendKey(testKey, testValue);
+        
+        // Force thread switch
+        await Task.Delay(10).ConfigureAwait(false);
+        await Task.Yield();
+        
+        // Assert - key should still be present after await
+        var keys = Logger.GetAllKeys().ToDictionary(k => k.Key, k => k.Value);
+        
+        Assert.True(keys.ContainsKey(testKey), "Key should persist across await boundary");
+        Assert.Equal(testValue, keys[testKey]);
+        
+        // Cleanup
+        Logger.RemoveKey(testKey);
+    }
+
+    /// <summary>
+    /// Verifies that keys persist across multiple await boundaries.
+    /// </summary>
+    [Fact]
+    public async Task AppendKey_AcrossMultipleAwaits_ShouldPersist()
+    {
+        // Arrange
+        ClearAllLoggerState();
+        var keys = new Dictionary<string, string>
+        {
+            { "key1", "value1" },
+            { "key2", "value2" },
+            { "key3", "value3" }
+        };
+
+        // Act - add keys with awaits in between
+        Logger.AppendKey("key1", "value1");
+        await Task.Delay(5).ConfigureAwait(false);
+        
+        Logger.AppendKey("key2", "value2");
+        await Task.Yield();
+        
+        Logger.AppendKey("key3", "value3");
+        await Task.Delay(5).ConfigureAwait(false);
+
+        // Assert
+        var allKeys = Logger.GetAllKeys().ToDictionary(k => k.Key, k => k.Value);
+        
+        foreach (var (key, value) in keys)
+        {
+            Assert.True(allKeys.ContainsKey(key), $"Key '{key}' should persist");
+            Assert.Equal(value, allKeys[key]);
+        }
+
+        // Cleanup
+        Logger.RemoveKeys(keys.Keys.ToArray());
+    }
+
+    /// <summary>
+    /// Verifies that parallel async operations maintain isolated scopes.
+    /// Uses Logger.UseScope() to simulate Lambda multi-threaded mode.
+    /// </summary>
+    [Theory]
+    [InlineData(5)]
+    [InlineData(10)]
+    [InlineData(20)]
+    public async Task ParallelAsyncOperations_ShouldMaintainIsolation(int parallelCount)
+    {
+        // Arrange
+        var results = new AsyncIsolationResult[parallelCount];
+        var startSignal = new TaskCompletionSource<bool>();
+
+        // Act
+        var tasks = Enumerable.Range(0, parallelCount).Select(async index =>
+        {
+            var uniqueKey = $"parallel_key_{index}";
+            var uniqueValue = $"parallel_value_{index}";
+
+            await startSignal.Task; // Wait for all tasks to be ready
+
+            // Simulate Lambda invocation starting fresh with isolated scope
+            using (Logger.UseScope())
+            {
+                Logger.AppendKey(uniqueKey, uniqueValue);
+                
+                // Multiple awaits to force potential thread switches
+                await Task.Delay(Random.Shared.Next(5, 20)).ConfigureAwait(false);
+                await Task.Yield();
+                await Task.Delay(Random.Shared.Next(5, 20)).ConfigureAwait(false);
+
+                var allKeys = Logger.GetAllKeys().ToDictionary(k => k.Key, k => k.Value);
+
+                results[index] = new AsyncIsolationResult
+                {
+                    Index = index,
+                    ExpectedKey = uniqueKey,
+                    ExpectedValue = uniqueValue,
+                    AllKeys = allKeys,
+                    HasOwnKey = allKeys.ContainsKey(uniqueKey),
+                    OwnKeyValue = allKeys.TryGetValue(uniqueKey, out var val) ? val?.ToString() : null
+                };
+
+                Logger.RemoveKey(uniqueKey);
+            }
+        }).ToArray();
+
+        // Start all tasks simultaneously
+        startSignal.SetResult(true);
+        await Task.WhenAll(tasks);
+
+        // Assert
+        foreach (var result in results)
+        {
+            Assert.True(result.HasOwnKey, $"Task {result.Index} should have its own key");
+            Assert.Equal(result.ExpectedValue, result.OwnKeyValue);
+            
+            // Verify no other task's keys leaked in
+            var foreignKeys = result.AllKeys.Keys
+                .Where(k => k.StartsWith("parallel_key_") && k != result.ExpectedKey)
+                .ToList();
+            
+            Assert.Empty(foreignKeys);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that nested async calls maintain the same scope.
+    /// </summary>
+    [Fact]
+    public async Task NestedAsyncCalls_ShouldShareScope()
+    {
+        // Arrange
+        ClearAllLoggerState();
+        var outerKey = "outer_key";
+        var innerKey = "inner_key";
+
+        // Act
+        Logger.AppendKey(outerKey, "outer_value");
+        
+        await NestedAsyncMethod(innerKey);
+        
+        // Assert - both keys should be present
+        var allKeys = Logger.GetAllKeys().ToDictionary(k => k.Key, k => k.Value);
+        
+        Assert.True(allKeys.ContainsKey(outerKey), "Outer key should be present");
+        Assert.True(allKeys.ContainsKey(innerKey), "Inner key should be present after nested call");
+
+        // Cleanup
+        Logger.RemoveKeys(outerKey, innerKey);
+    }
+
+    private async Task NestedAsyncMethod(string key)
+    {
+        await Task.Delay(5).ConfigureAwait(false);
+        Logger.AppendKey(key, "inner_value");
+        await Task.Delay(5).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Verifies ConfigureAwait(false) doesn't break key persistence.
+    /// </summary>
+    [Fact]
+    public async Task ConfigureAwaitFalse_ShouldNotBreakKeyPersistence()
+    {
+        // Arrange
+        ClearAllLoggerState();
+        var testKey = "configureawait_test";
+
+        // Act
+        Logger.AppendKey(testKey, "before_await");
+        
+        await Task.Delay(10).ConfigureAwait(false);
+        
+        var keysAfterAwait = Logger.GetAllKeys().ToDictionary(k => k.Key, k => k.Value);
+        
+        // Modify after ConfigureAwait(false)
+        Logger.AppendKey(testKey, "after_await");
+        
+        await Task.Delay(10).ConfigureAwait(false);
+        
+        var keysFinal = Logger.GetAllKeys().ToDictionary(k => k.Key, k => k.Value);
+
+        // Assert
+        Assert.True(keysAfterAwait.ContainsKey(testKey));
+        Assert.True(keysFinal.ContainsKey(testKey));
+        Assert.Equal("after_await", keysFinal[testKey]);
+
+        // Cleanup
+        Logger.RemoveKey(testKey);
+    }
+
+    private static void ClearAllLoggerState()
+    {
+        var existingKeys = Logger.GetAllKeys()
+            .Select(k => k.Key)
+            .Where(k => !string.IsNullOrEmpty(k))
+            .ToArray();
+        if (existingKeys.Length > 0)
+        {
+            Logger.RemoveKeys(existingKeys);
+        }
+    }
+
+    private class AsyncIsolationResult
+    {
+        public int Index { get; set; }
+        public string ExpectedKey { get; set; } = string.Empty;
+        public string ExpectedValue { get; set; } = string.Empty;
+        public Dictionary<string, object> AllKeys { get; set; } = new();
+        public bool HasOwnKey { get; set; }
+        public string? OwnKeyValue { get; set; }
+    }
+}

--- a/libraries/tests/AWS.Lambda.Powertools.ConcurrencyTests/Logging/ExtraKeysTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.ConcurrencyTests/Logging/ExtraKeysTests.cs
@@ -1,0 +1,342 @@
+using AWS.Lambda.Powertools.Logging;
+using Xunit;
+
+namespace AWS.Lambda.Powertools.ConcurrencyTests.Logging;
+
+/// <summary>
+/// Tests for the ExtraKeys feature which provides scoped temporary logging keys.
+/// Keys added via ExtraKeys are automatically removed when the scope is disposed.
+/// </summary>
+public class ExtraKeysTests
+{
+    /// <summary>
+    /// Verifies basic ExtraKeys functionality - keys are added and removed on dispose.
+    /// </summary>
+    [Fact]
+    public void ExtraKeys_BasicUsage_ShouldAddAndRemoveKeys()
+    {
+        // Arrange
+        ClearAllLoggerState();
+        var testKey = "extra_key";
+        var testValue = "extra_value";
+
+        // Act & Assert - key present inside scope
+        using (Logger.ExtraKeys(new Dictionary<string, object> { { testKey, testValue } }))
+        {
+            var keysInScope = Logger.GetAllKeys().ToDictionary(k => k.Key, k => k.Value);
+            Assert.True(keysInScope.ContainsKey(testKey));
+            Assert.Equal(testValue, keysInScope[testKey]);
+        }
+
+        // Assert - key removed after scope
+        var keysAfterScope = Logger.GetAllKeys().ToDictionary(k => k.Key, k => k.Value);
+        Assert.False(keysAfterScope.ContainsKey(testKey));
+    }
+
+    /// <summary>
+    /// Verifies ExtraKeys with tuple syntax.
+    /// </summary>
+    [Fact]
+    public void ExtraKeys_TupleSyntax_ShouldWork()
+    {
+        // Arrange
+        ClearAllLoggerState();
+
+        // Act & Assert
+        using (Logger.ExtraKeys(("key1", "value1"), ("key2", 42), ("key3", true)))
+        {
+            var keys = Logger.GetAllKeys().ToDictionary(k => k.Key, k => k.Value);
+            Assert.Equal(3, keys.Count);
+            Assert.Equal("value1", keys["key1"]);
+            Assert.Equal(42, keys["key2"]);
+            Assert.Equal(true, keys["key3"]);
+        }
+
+        var keysAfter = Logger.GetAllKeys().ToDictionary(k => k.Key, k => k.Value);
+        Assert.Empty(keysAfter);
+    }
+
+    /// <summary>
+    /// Verifies ExtraKeys works correctly across await boundaries.
+    /// </summary>
+    [Fact]
+    public async Task ExtraKeys_AcrossAwaitBoundary_ShouldPersistAndCleanup()
+    {
+        // Arrange
+        ClearAllLoggerState();
+        var testKey = "async_extra_key";
+
+        // Act
+        using (Logger.ExtraKeys(new Dictionary<string, object> { { testKey, "async_value" } }))
+        {
+            // Key should be present before await
+            var keysBefore = Logger.GetAllKeys().ToDictionary(k => k.Key, k => k.Value);
+            Assert.True(keysBefore.ContainsKey(testKey));
+
+            await Task.Delay(10).ConfigureAwait(false);
+            await Task.Yield();
+
+            // Key should still be present after await
+            var keysAfterAwait = Logger.GetAllKeys().ToDictionary(k => k.Key, k => k.Value);
+            Assert.True(keysAfterAwait.ContainsKey(testKey));
+        }
+
+        // Key should be removed after dispose
+        var keysAfterDispose = Logger.GetAllKeys().ToDictionary(k => k.Key, k => k.Value);
+        Assert.False(keysAfterDispose.ContainsKey(testKey));
+    }
+
+    /// <summary>
+    /// Verifies nested ExtraKeys scopes work correctly.
+    /// </summary>
+    [Fact]
+    public void ExtraKeys_NestedScopes_ShouldWorkCorrectly()
+    {
+        // Arrange
+        ClearAllLoggerState();
+
+        // Act & Assert
+        using (Logger.ExtraKeys(("outer", "outer_value")))
+        {
+            var keysOuter = Logger.GetAllKeys().ToDictionary(k => k.Key, k => k.Value);
+            Assert.Single(keysOuter);
+            Assert.Equal("outer_value", keysOuter["outer"]);
+
+            using (Logger.ExtraKeys(("inner", "inner_value")))
+            {
+                var keysInner = Logger.GetAllKeys().ToDictionary(k => k.Key, k => k.Value);
+                Assert.Equal(2, keysInner.Count);
+                Assert.Equal("outer_value", keysInner["outer"]);
+                Assert.Equal("inner_value", keysInner["inner"]);
+            }
+
+            // Inner key should be removed, outer should remain
+            var keysAfterInner = Logger.GetAllKeys().ToDictionary(k => k.Key, k => k.Value);
+            Assert.Single(keysAfterInner);
+            Assert.Equal("outer_value", keysAfterInner["outer"]);
+            Assert.False(keysAfterInner.ContainsKey("inner"));
+        }
+
+        // All keys should be removed
+        var keysFinal = Logger.GetAllKeys().ToDictionary(k => k.Key, k => k.Value);
+        Assert.Empty(keysFinal);
+    }
+
+    /// <summary>
+    /// Verifies ExtraKeys overwrites existing keys and removes them on dispose.
+    /// Following Python's behavior: keys added in scope are removed, even if they existed before.
+    /// </summary>
+    [Fact]
+    public void ExtraKeys_OverwriteExistingKey_ShouldRemoveOnDispose()
+    {
+        // Arrange
+        ClearAllLoggerState();
+        var sharedKey = "shared_key";
+        
+        Logger.AppendKey(sharedKey, "original_value");
+
+        // Act
+        using (Logger.ExtraKeys(new Dictionary<string, object> { { sharedKey, "temporary_value" } }))
+        {
+            var keysInScope = Logger.GetAllKeys().ToDictionary(k => k.Key, k => k.Value);
+            Assert.Equal("temporary_value", keysInScope[sharedKey]);
+        }
+
+        // Assert - key is removed (following Python's behavior)
+        var keysAfter = Logger.GetAllKeys().ToDictionary(k => k.Key, k => k.Value);
+        Assert.False(keysAfter.ContainsKey(sharedKey));
+    }
+
+    /// <summary>
+    /// Verifies ExtraKeys with multiple keys.
+    /// </summary>
+    [Fact]
+    public void ExtraKeys_MultipleKeys_ShouldAllBeAddedAndRemoved()
+    {
+        // Arrange
+        ClearAllLoggerState();
+        var testKeys = new Dictionary<string, object>
+        {
+            { "key1", "value1" },
+            { "key2", 123 },
+            { "key3", true },
+            { "key4", new { nested = "object" } }
+        };
+
+        // Act & Assert
+        using (Logger.ExtraKeys(testKeys))
+        {
+            var keysInScope = Logger.GetAllKeys().ToDictionary(k => k.Key, k => k.Value);
+            Assert.Equal(4, keysInScope.Count);
+        }
+
+        var keysAfter = Logger.GetAllKeys().ToDictionary(k => k.Key, k => k.Value);
+        Assert.Empty(keysAfter);
+    }
+
+    /// <summary>
+    /// Verifies ExtraKeys is safe with concurrent async operations.
+    /// Uses Logger.UseScope() to simulate Lambda multi-threaded mode.
+    /// </summary>
+    [Theory]
+    [InlineData(5)]
+    [InlineData(10)]
+    public async Task ExtraKeys_ConcurrentAsyncOperations_ShouldMaintainIsolation(int parallelCount)
+    {
+        // Arrange
+        var results = new ExtraKeysAsyncResult[parallelCount];
+        var startSignal = new TaskCompletionSource<bool>();
+
+        // Act
+        var tasks = Enumerable.Range(0, parallelCount).Select(async index =>
+        {
+            var uniqueKey = $"concurrent_extra_{index}";
+            var uniqueValue = $"value_{index}";
+
+            await startSignal.Task; // Wait for all tasks to be ready
+
+            // Simulate Lambda invocation starting fresh with isolated scope
+            using (Logger.UseScope())
+            {
+                using (Logger.ExtraKeys((uniqueKey, uniqueValue)))
+                {
+                    await Task.Delay(Random.Shared.Next(10, 30)).ConfigureAwait(false);
+
+                    var keysInScope = Logger.GetAllKeys().ToDictionary(k => k.Key, k => k.Value);
+
+                    results[index] = new ExtraKeysAsyncResult
+                    {
+                        Index = index,
+                        ExpectedKey = uniqueKey,
+                        ExpectedValue = uniqueValue,
+                        KeysInScope = keysInScope,
+                        HasOwnKey = keysInScope.ContainsKey(uniqueKey)
+                    };
+
+                    await Task.Delay(Random.Shared.Next(5, 15)).ConfigureAwait(false);
+                }
+
+                // Verify key is removed after scope
+                var keysAfterScope = Logger.GetAllKeys().ToDictionary(k => k.Key, k => k.Value);
+                results[index].KeyRemovedAfterScope = !keysAfterScope.ContainsKey(uniqueKey);
+            }
+        }).ToArray();
+
+        // Start all tasks simultaneously
+        startSignal.SetResult(true);
+        await Task.WhenAll(tasks);
+
+        // Assert
+        foreach (var result in results)
+        {
+            Assert.True(result.HasOwnKey, $"Task {result.Index} should have its key in scope");
+            Assert.True(result.KeyRemovedAfterScope, $"Task {result.Index} key should be removed after scope");
+
+            // Verify no other task's keys leaked in
+            var foreignKeys = result.KeysInScope.Keys
+                .Where(k => k.StartsWith("concurrent_extra_") && k != result.ExpectedKey)
+                .ToList();
+
+            Assert.Empty(foreignKeys);
+        }
+    }
+
+    /// <summary>
+    /// Verifies ExtraKeys handles exceptions correctly - keys should still be removed.
+    /// </summary>
+    [Fact]
+    public void ExtraKeys_WithException_ShouldStillRemoveKeys()
+    {
+        // Arrange
+        ClearAllLoggerState();
+        var testKey = "exception_test_key";
+
+        // Act
+        try
+        {
+            using (Logger.ExtraKeys((testKey, "value")))
+            {
+                var keysInScope = Logger.GetAllKeys().ToDictionary(k => k.Key, k => k.Value);
+                Assert.True(keysInScope.ContainsKey(testKey));
+
+                throw new InvalidOperationException("Test exception");
+            }
+        }
+        catch (InvalidOperationException)
+        {
+            // Expected
+        }
+
+        // Assert - key should still be removed despite exception
+        var keysAfter = Logger.GetAllKeys().ToDictionary(k => k.Key, k => k.Value);
+        Assert.False(keysAfter.ContainsKey(testKey));
+    }
+
+    /// <summary>
+    /// Verifies ExtraKeys handles null/empty keys gracefully.
+    /// </summary>
+    [Fact]
+    public void ExtraKeys_WithEmptyKeys_ShouldNotThrow()
+    {
+        // Arrange
+        ClearAllLoggerState();
+
+        // Act & Assert - should not throw
+        using (Logger.ExtraKeys(new Dictionary<string, object>()))
+        {
+            var keys = Logger.GetAllKeys().ToDictionary(k => k.Key, k => k.Value);
+            Assert.Empty(keys);
+        }
+    }
+
+    /// <summary>
+    /// Verifies ExtraKeys throws on null input.
+    /// </summary>
+    [Fact]
+    public void ExtraKeys_WithNullInput_ShouldThrow()
+    {
+        Assert.Throws<ArgumentNullException>(() => 
+            Logger.ExtraKeys((IEnumerable<KeyValuePair<string, object>>)null!));
+    }
+
+    /// <summary>
+    /// Verifies double dispose is safe.
+    /// </summary>
+    [Fact]
+    public void ExtraKeys_DoubleDispose_ShouldBeSafe()
+    {
+        // Arrange
+        ClearAllLoggerState();
+        var scope = Logger.ExtraKeys(("key", "value"));
+
+        // Act - dispose twice
+        scope.Dispose();
+        scope.Dispose(); // Should not throw
+
+        // Assert
+        var keys = Logger.GetAllKeys().ToDictionary(k => k.Key, k => k.Value);
+        Assert.Empty(keys);
+    }
+
+    private static void ClearAllLoggerState()
+    {
+        var existingKeys = Logger.GetAllKeys()
+            .Select(k => k.Key)
+            .Where(k => !string.IsNullOrEmpty(k))
+            .ToArray();
+        if (existingKeys.Length > 0)
+        {
+            Logger.RemoveKeys(existingKeys);
+        }
+    }
+
+    private class ExtraKeysAsyncResult
+    {
+        public int Index { get; set; }
+        public string ExpectedKey { get; set; } = string.Empty;
+        public string ExpectedValue { get; set; } = string.Empty;
+        public Dictionary<string, object> KeysInScope { get; set; } = new();
+        public bool HasOwnKey { get; set; }
+        public bool KeyRemovedAfterScope { get; set; }
+    }
+}

--- a/libraries/tests/AWS.Lambda.Powertools.ConcurrencyTests/Logging/KeyIsolationTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.ConcurrencyTests/Logging/KeyIsolationTests.cs
@@ -63,6 +63,7 @@ public class KeyIsolationTests
 
     /// <summary>
     /// Verifies that concurrent invocations don't leak keys to each other.
+    /// Uses Logger.UseScope() to simulate Lambda multi-threaded mode where each invocation starts fresh.
     /// </summary>
     [Theory]
     [InlineData(2)]
@@ -81,25 +82,29 @@ public class KeyIsolationTests
             int invocationIndex = i;
             tasks[i] = Task.Run(() =>
             {
-                var invocationId = Guid.NewGuid().ToString();
-                var uniqueKey = $"invocation_{invocationId}";
-
-                barrier.SignalAndWait();
-
-                Logger.AppendKey(uniqueKey, invocationId);
-
-                Thread.Sleep(Random.Shared.Next(1, 10));
-
-                var allKeys = Logger.GetAllKeys().ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
-
-                results[invocationIndex] = new ConcurrentInvocationResult
+                // Simulate Lambda invocation starting fresh with isolated scope
+                using (Logger.UseScope())
                 {
-                    InvocationId = invocationId,
-                    UniqueKey = uniqueKey,
-                    AllKeysAtEnd = allKeys
-                };
+                    var invocationId = Guid.NewGuid().ToString();
+                    var uniqueKey = $"invocation_{invocationId}";
 
-                Logger.RemoveKeys(uniqueKey);
+                    barrier.SignalAndWait();
+
+                    Logger.AppendKey(uniqueKey, invocationId);
+
+                    Thread.Sleep(Random.Shared.Next(1, 10));
+
+                    var allKeys = Logger.GetAllKeys().ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+
+                    results[invocationIndex] = new ConcurrentInvocationResult
+                    {
+                        InvocationId = invocationId,
+                        UniqueKey = uniqueKey,
+                        AllKeysAtEnd = allKeys
+                    };
+
+                    Logger.RemoveKeys(uniqueKey);
+                }
             });
         }
 
@@ -119,6 +124,7 @@ public class KeyIsolationTests
 
     /// <summary>
     /// Verifies that GetAllKeys returns only the calling invocation's keys.
+    /// Uses Logger.UseScope() to simulate Lambda multi-threaded mode.
     /// </summary>
     [Theory]
     [InlineData(2, 3)]
@@ -137,31 +143,35 @@ public class KeyIsolationTests
             int invocationIndex = i;
             tasks[i] = Task.Run(() =>
             {
-                var invocationId = Guid.NewGuid().ToString();
-                var appendedKeys = new Dictionary<string, object>();
-
-                barrier.SignalAndWait();
-
-                for (int k = 0; k < keysPerInvocation; k++)
+                // Simulate Lambda invocation starting fresh with isolated scope
+                using (Logger.UseScope())
                 {
-                    var key = $"inv_{invocationId}_key_{k}";
-                    var value = $"value_{k}_{invocationId}";
-                    Logger.AppendKey(key, value);
-                    appendedKeys[key] = value;
+                    var invocationId = Guid.NewGuid().ToString();
+                    var appendedKeys = new Dictionary<string, object>();
+
+                    barrier.SignalAndWait();
+
+                    for (int k = 0; k < keysPerInvocation; k++)
+                    {
+                        var key = $"inv_{invocationId}_key_{k}";
+                        var value = $"value_{k}_{invocationId}";
+                        Logger.AppendKey(key, value);
+                        appendedKeys[key] = value;
+                    }
+
+                    Thread.Sleep(Random.Shared.Next(1, 10));
+
+                    var allKeysResult = Logger.GetAllKeys().ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+
+                    results[invocationIndex] = new GetAllKeysResult
+                    {
+                        InvocationId = invocationId,
+                        AppendedKeys = appendedKeys,
+                        GetAllKeysResult_Keys = allKeysResult
+                    };
+
+                    Logger.RemoveKeys(appendedKeys.Keys.ToArray());
                 }
-
-                Thread.Sleep(Random.Shared.Next(1, 10));
-
-                var allKeysResult = Logger.GetAllKeys().ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
-
-                results[invocationIndex] = new GetAllKeysResult
-                {
-                    InvocationId = invocationId,
-                    AppendedKeys = appendedKeys,
-                    GetAllKeysResult_Keys = allKeysResult
-                };
-
-                Logger.RemoveKeys(appendedKeys.Keys.ToArray());
             });
         }
 
@@ -192,6 +202,7 @@ public class KeyIsolationTests
 
     /// <summary>
     /// Verifies that concurrent invocations using the same key name maintain separate values.
+    /// Uses Logger.UseScope() to simulate Lambda multi-threaded mode.
     /// </summary>
     [Theory]
     [InlineData(2)]
@@ -211,26 +222,30 @@ public class KeyIsolationTests
             int invocationIndex = i;
             tasks[i] = Task.Run(() =>
             {
-                var invocationId = Guid.NewGuid().ToString();
-                var uniqueValue = $"unique_value_{invocationId}";
-
-                barrier.SignalAndWait();
-
-                Logger.AppendKey(sharedKeyName, uniqueValue);
-
-                Thread.Sleep(Random.Shared.Next(1, 15));
-
-                var allKeys = Logger.GetAllKeys().ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
-                var retrievedValue = allKeys.TryGetValue(sharedKeyName, out var val) ? val?.ToString() : null;
-
-                results[invocationIndex] = new SameNameKeyResult
+                // Simulate Lambda invocation starting fresh with isolated scope
+                using (Logger.UseScope())
                 {
-                    InvocationId = invocationId,
-                    ExpectedValue = uniqueValue,
-                    RetrievedValue = retrievedValue
-                };
+                    var invocationId = Guid.NewGuid().ToString();
+                    var uniqueValue = $"unique_value_{invocationId}";
 
-                Logger.RemoveKeys(sharedKeyName);
+                    barrier.SignalAndWait();
+
+                    Logger.AppendKey(sharedKeyName, uniqueValue);
+
+                    Thread.Sleep(Random.Shared.Next(1, 15));
+
+                    var allKeys = Logger.GetAllKeys().ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+                    var retrievedValue = allKeys.TryGetValue(sharedKeyName, out var val) ? val?.ToString() : null;
+
+                    results[invocationIndex] = new SameNameKeyResult
+                    {
+                        InvocationId = invocationId,
+                        ExpectedValue = uniqueValue,
+                        RetrievedValue = retrievedValue
+                    };
+
+                    Logger.RemoveKeys(sharedKeyName);
+                }
             });
         }
 
@@ -244,6 +259,7 @@ public class KeyIsolationTests
 
     /// <summary>
     /// Verifies that ClearState on one invocation doesn't affect another active invocation.
+    /// Uses Logger.UseScope() to simulate Lambda multi-threaded mode.
     /// </summary>
     [Theory]
     [InlineData(10)]
@@ -260,44 +276,52 @@ public class KeyIsolationTests
 
         var shortTask = Task.Run(() =>
         {
-            var invocationId = Guid.NewGuid().ToString();
-            var uniqueKey = $"short_inv_{invocationId}";
+            // Simulate Lambda invocation starting fresh with isolated scope
+            using (Logger.UseScope())
+            {
+                var invocationId = Guid.NewGuid().ToString();
+                var uniqueKey = $"short_inv_{invocationId}";
 
-            shortInvocationResult.InvocationId = invocationId;
-            shortInvocationResult.UniqueKey = uniqueKey;
+                shortInvocationResult.InvocationId = invocationId;
+                shortInvocationResult.UniqueKey = uniqueKey;
 
-            barrier.SignalAndWait();
+                barrier.SignalAndWait();
 
-            Logger.AppendKey(uniqueKey, invocationId);
-            shortInvocationResult.KeyAppended = true;
+                Logger.AppendKey(uniqueKey, invocationId);
+                shortInvocationResult.KeyAppended = true;
 
-            Thread.Sleep(shortDuration);
+                Thread.Sleep(shortDuration);
 
-            var keysToRemove = Logger.GetAllKeys().Select(k => k.Key).ToArray();
-            Logger.RemoveKeys(keysToRemove);
-            shortInvocationResult.ClearStateCalled = true;
+                var keysToRemove = Logger.GetAllKeys().Select(k => k.Key).ToArray();
+                Logger.RemoveKeys(keysToRemove);
+                shortInvocationResult.ClearStateCalled = true;
+            }
         });
 
         var longTask = Task.Run(() =>
         {
-            var invocationId = Guid.NewGuid().ToString();
-            var uniqueKey = $"long_inv_{invocationId}";
+            // Simulate Lambda invocation starting fresh with isolated scope
+            using (Logger.UseScope())
+            {
+                var invocationId = Guid.NewGuid().ToString();
+                var uniqueKey = $"long_inv_{invocationId}";
 
-            longInvocationResult.InvocationId = invocationId;
-            longInvocationResult.UniqueKey = uniqueKey;
+                longInvocationResult.InvocationId = invocationId;
+                longInvocationResult.UniqueKey = uniqueKey;
 
-            barrier.SignalAndWait();
+                barrier.SignalAndWait();
 
-            Logger.AppendKey(uniqueKey, invocationId);
-            longInvocationResult.KeyAppended = true;
+                Logger.AppendKey(uniqueKey, invocationId);
+                longInvocationResult.KeyAppended = true;
 
-            Thread.Sleep(longDuration);
+                Thread.Sleep(longDuration);
 
-            var allKeys = Logger.GetAllKeys().ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
-            longInvocationResult.KeysAfterOtherClear = allKeys;
-            longInvocationResult.OwnKeyStillPresent = allKeys.ContainsKey(uniqueKey);
+                var allKeys = Logger.GetAllKeys().ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+                longInvocationResult.KeysAfterOtherClear = allKeys;
+                longInvocationResult.OwnKeyStillPresent = allKeys.ContainsKey(uniqueKey);
 
-            Logger.RemoveKeys(uniqueKey);
+                Logger.RemoveKeys(uniqueKey);
+            }
         });
 
         Task.WaitAll(shortTask, longTask);
@@ -363,8 +387,8 @@ public class KeyIsolationTests
     /// Root cause was Logger.Scope being a static Dictionary&lt;string, object&gt;
     /// which is not thread-safe for concurrent read/write operations.
     /// 
-    /// The fix uses per-thread scope storage via ConcurrentDictionary&lt;int, Dictionary&gt;
-    /// keyed by ManagedThreadId.
+    /// The fix uses AsyncLocal&lt;ConcurrentDictionary&gt; for per-execution-context
+    /// scope storage, ensuring isolation and async/await safety.
     /// </summary>
     [Fact]
     public async Task ConcurrentAccess_ForeachOnGetAllKeys_ShouldNotThrowException()
@@ -415,8 +439,8 @@ public class KeyIsolationTests
     /// When Thread A enumerated via GetAllKeys() while Thread B modified via AppendKey()/RemoveKey(),
     /// it would throw "Collection was modified; enumeration operation may not execute."
     /// 
-    /// The fix uses per-thread scope storage via ConcurrentDictionary&lt;int, Dictionary&gt;
-    /// keyed by ManagedThreadId, ensuring each thread has its own isolated dictionary.
+    /// The fix uses AsyncLocal&lt;ConcurrentDictionary&gt; for per-execution-context
+    /// scope storage, ensuring isolation and async/await safety.
     /// </summary>
     [Theory]
     [InlineData(100)]
@@ -505,7 +529,8 @@ public class KeyIsolationTests
 
     /// <summary>
     /// Stress test: Multiple threads simultaneously performing all Logger operations.
-    /// This validates that the thread-per-scope implementation handles high concurrency.
+    /// This validates that the AsyncLocal implementation handles high concurrency.
+    /// Uses Logger.UseScope() to simulate Lambda multi-threaded mode.
     /// </summary>
     [Theory]
     [InlineData(3, 100)]
@@ -523,36 +548,40 @@ public class KeyIsolationTests
         {
             try
             {
-                barrier.SignalAndWait();
-                
-                for (int i = 0; i < operationsPerThread; i++)
+                // Simulate Lambda invocation starting fresh with isolated scope
+                using (Logger.UseScope())
                 {
-                    // Mix of all operations
-                    var keyName = $"thread_{threadIndex}_key_{i % 5}";
+                    barrier.SignalAndWait();
                     
-                    // AppendKey
-                    Logger.AppendKey(keyName, $"value_{i}");
-                    
-                    // GetAllKeys with enumeration
-                    var keys = Logger.GetAllKeys().ToList();
-                    
-                    // Log (internally calls GetAllKeys)
-                    Logger.LogDebug($"Thread {threadIndex} iteration {i}, keys: {keys.Count}");
-                    
-                    // RemoveKey
-                    if (i % 2 == 0)
+                    for (int i = 0; i < operationsPerThread; i++)
                     {
-                        Logger.RemoveKey(keyName);
-                    }
-                    
-                    // RemoveKeys (batch)
-                    if (i % 10 == 0)
-                    {
-                        var keysToRemove = Logger.GetAllKeys()
-                            .Select(k => k.Key)
-                            .Where(k => k.StartsWith($"thread_{threadIndex}_"))
-                            .ToArray();
-                        Logger.RemoveKeys(keysToRemove);
+                        // Mix of all operations
+                        var keyName = $"thread_{threadIndex}_key_{i % 5}";
+                        
+                        // AppendKey
+                        Logger.AppendKey(keyName, $"value_{i}");
+                        
+                        // GetAllKeys with enumeration
+                        var keys = Logger.GetAllKeys().ToList();
+                        
+                        // Log (internally calls GetAllKeys)
+                        Logger.LogDebug($"Thread {threadIndex} iteration {i}, keys: {keys.Count}");
+                        
+                        // RemoveKey
+                        if (i % 2 == 0)
+                        {
+                            Logger.RemoveKey(keyName);
+                        }
+                        
+                        // RemoveKeys (batch)
+                        if (i % 10 == 0)
+                        {
+                            var keysToRemove = Logger.GetAllKeys()
+                                .Select(k => k.Key)
+                                .Where(k => k.StartsWith($"thread_{threadIndex}_"))
+                                .ToArray();
+                            Logger.RemoveKeys(keysToRemove);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
> Please provide the issue number

Issue number: #1037 

## Summary

### Changes

- Add ExtraKeys() method to Logger for temporary key management within scopes
- Implement AsyncLocal-based scope storage to support async/await boundaries
- Replace thread-based scope isolation with async execution context isolation
- Add LoggerScopeContext disposable for automatic key cleanup on scope exit
- Support multiple overloads: Dictionary, params tuples, and nested scopes
- Add documentation with examples for Dictionary, Tuples, and nested usage
- Add AsyncSafetyTests to verify keys flow correctly across async operations
- Add ExtraKeysTests to validate temporary key isolation and cleanup
- Update KeyIsolationTests for new async-based scope implementation

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [ ] [Meets tenets criteria](https://docs.aws.amazon.com/powertools/dotnet/tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
