### PR TITLE
fix(common): graceful fallback when LambdaTraceProvider is unavailable

### DIFF
--- a/libraries/src/AWS.Lambda.Powertools.Common/Core/PowertoolsConfigurations.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Common/Core/PowertoolsConfigurations.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using Amazon.Lambda.Core;
 using AWS.Lambda.Powertools.Common.Core;
 
@@ -32,9 +33,10 @@ public class PowertoolsConfigurations : IPowertoolsConfigurations
 
     /// <summary>
     ///     Whether LambdaTraceProvider is available in the loaded Amazon.Lambda.Core assembly.
-    ///     Null means not yet checked, true/false is the cached result.
+    ///     0 = not yet checked, 1 = available, -1 = unavailable.
+    ///     Stored as int for atomic reads/writes via Volatile.
     /// </summary>
-    private static bool? _isTraceProviderAvailable;
+    private static int _traceProviderState; // 0 = unknown, 1 = available, -1 = unavailable
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="PowertoolsConfigurations" /> class.
@@ -225,22 +227,24 @@ public class PowertoolsConfigurations : IPowertoolsConfigurations
 
     private static string GetTraceId(Func<string> fallback)
     {
-        if (_isTraceProviderAvailable == true)
+        var state = Volatile.Read(ref _traceProviderState);
+
+        if (state == 1)
             return GetTraceIdFromProvider();
 
-        if (_isTraceProviderAvailable == false)
+        if (state == -1)
             return fallback();
 
         // First call — probe whether LambdaTraceProvider exists in the loaded runtime
         try
         {
             var traceId = GetTraceIdFromProvider();
-            _isTraceProviderAvailable = true;
+            Volatile.Write(ref _traceProviderState, 1);
             return traceId;
         }
         catch (TypeLoadException)
         {
-            _isTraceProviderAvailable = false;
+            Volatile.Write(ref _traceProviderState, -1);
             return fallback();
         }
     }

--- a/libraries/src/AWS.Lambda.Powertools.Common/Core/PowertoolsConfigurations.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Common/Core/PowertoolsConfigurations.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using Amazon.Lambda.Core;
 using AWS.Lambda.Powertools.Common.Core;
 
@@ -27,6 +29,12 @@ public class PowertoolsConfigurations : IPowertoolsConfigurations
     ///     The instance
     /// </summary>
     private static IPowertoolsConfigurations _instance;
+
+    /// <summary>
+    ///     Whether LambdaTraceProvider is available in the loaded Amazon.Lambda.Core assembly.
+    ///     Null means not yet checked, true/false is the cached result.
+    /// </summary>
+    private static bool? _isTraceProviderAvailable;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="PowertoolsConfigurations" /> class.
@@ -165,10 +173,12 @@ public class PowertoolsConfigurations : IPowertoolsConfigurations
 
     /// <summary>
     ///     Gets the X-Ray trace identifier.
+    ///     Uses LambdaTraceProvider.CurrentTraceId when available (Amazon.Lambda.Core >= 2.8.0)
+    ///     for correct trace ID isolation in concurrent Lambda executions (LMI).
+    ///     Falls back to the _X_AMZN_TRACE_ID environment variable for older runtimes.
     /// </summary>
     /// <value>The X-Ray trace identifier.</value>
-    public string XRayTraceId =>
-        LambdaTraceProvider.CurrentTraceId;
+    public string XRayTraceId => GetTraceId();
 
     /// <summary>
     ///     Gets a value indicating whether this instance is Lambda.
@@ -212,4 +222,37 @@ public class PowertoolsConfigurations : IPowertoolsConfigurations
     /// <inheritdoc />
     public string AwsInitializationType =>
         GetEnvironmentVariable(Constants.AWSInitializationTypeEnv);
+
+    private string GetTraceId()
+    {
+        if (_isTraceProviderAvailable == true)
+            return GetTraceIdFromProvider();
+
+        if (_isTraceProviderAvailable == false)
+            return GetEnvironmentVariable(Constants.XrayTraceIdEnv);
+
+        // First call — probe whether LambdaTraceProvider exists in the loaded runtime
+        try
+        {
+            var traceId = GetTraceIdFromProvider();
+            _isTraceProviderAvailable = true;
+            return traceId;
+        }
+        catch (TypeLoadException)
+        {
+            _isTraceProviderAvailable = false;
+            return GetEnvironmentVariable(Constants.XrayTraceIdEnv);
+        }
+    }
+
+    /// <summary>
+    ///     Isolated call to LambdaTraceProvider.CurrentTraceId.
+    ///     Must not be inlined so that the TypeLoadException is thrown only
+    ///     when this method is invoked, not when the caller is compiled.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static string GetTraceIdFromProvider()
+    {
+        return LambdaTraceProvider.CurrentTraceId;
+    }
 }

--- a/libraries/src/AWS.Lambda.Powertools.Common/Core/PowertoolsConfigurations.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Common/Core/PowertoolsConfigurations.cs
@@ -178,7 +178,7 @@ public class PowertoolsConfigurations : IPowertoolsConfigurations
     ///     Falls back to the _X_AMZN_TRACE_ID environment variable for older runtimes.
     /// </summary>
     /// <value>The X-Ray trace identifier.</value>
-    public string XRayTraceId => GetTraceId();
+    public string XRayTraceId => GetTraceId(() => GetEnvironmentVariable(Constants.XrayTraceIdEnv));
 
     /// <summary>
     ///     Gets a value indicating whether this instance is Lambda.
@@ -223,13 +223,13 @@ public class PowertoolsConfigurations : IPowertoolsConfigurations
     public string AwsInitializationType =>
         GetEnvironmentVariable(Constants.AWSInitializationTypeEnv);
 
-    private string GetTraceId()
+    private static string GetTraceId(Func<string> fallback)
     {
         if (_isTraceProviderAvailable == true)
             return GetTraceIdFromProvider();
 
         if (_isTraceProviderAvailable == false)
-            return GetEnvironmentVariable(Constants.XrayTraceIdEnv);
+            return fallback();
 
         // First call — probe whether LambdaTraceProvider exists in the loaded runtime
         try
@@ -241,7 +241,7 @@ public class PowertoolsConfigurations : IPowertoolsConfigurations
         catch (TypeLoadException)
         {
             _isTraceProviderAvailable = false;
-            return GetEnvironmentVariable(Constants.XrayTraceIdEnv);
+            return fallback();
         }
     }
 

--- a/libraries/tests/AWS.Lambda.Powertools.Common.Tests/Core/PowertoolsConfigurationsTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Common.Tests/Core/PowertoolsConfigurationsTest.cs
@@ -534,5 +534,87 @@ namespace AWS.Lambda.Powertools.Common.Tests
         }
         
         #endregion
+
+        #region XRayTraceId Tests
+
+        [Fact]
+        public void XRayTraceId_WhenLambdaTraceProviderAvailable_ReturnsTraceId()
+        {
+            // Arrange
+            var environment = Substitute.For<IPowertoolsEnvironment>();
+            var configurations = new PowertoolsConfigurations(environment);
+
+            // Reset cached state so the probe runs fresh
+            ResetTraceProviderState();
+
+            // Act - LambdaTraceProvider is available in test env (Amazon.Lambda.Core 2.8.0)
+            var result = configurations.XRayTraceId;
+
+            // Assert - should not throw and should not fall back to env var
+            environment.DidNotReceive()
+                .GetEnvironmentVariable(Arg.Is<string>(i => i == Constants.XrayTraceIdEnv));
+        }
+
+        [Fact]
+        public void XRayTraceId_WhenLambdaTraceProviderUnavailable_FallsBackToEnvironmentVariable()
+        {
+            // Arrange
+            var traceId = "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1";
+            var environment = Substitute.For<IPowertoolsEnvironment>();
+            environment.GetEnvironmentVariable(Constants.XrayTraceIdEnv).Returns(traceId);
+            var configurations = new PowertoolsConfigurations(environment);
+
+            // Simulate LambdaTraceProvider not being available (older Amazon.Lambda.Core)
+            SetTraceProviderAvailable(false);
+
+            // Act
+            var result = configurations.XRayTraceId;
+
+            // Assert
+            environment.Received(1)
+                .GetEnvironmentVariable(Arg.Is<string>(i => i == Constants.XrayTraceIdEnv));
+            Assert.Equal(traceId, result);
+        }
+
+        [Fact]
+        public void XRayTraceId_CachesTraceProviderAvailability_OnSubsequentCalls()
+        {
+            // Arrange
+            var environment = Substitute.For<IPowertoolsEnvironment>();
+            var configurations = new PowertoolsConfigurations(environment);
+
+            // Simulate LambdaTraceProvider not being available
+            SetTraceProviderAvailable(false);
+
+            var traceId1 = "Root=1-aaa;Parent=bbb;Sampled=1";
+            var traceId2 = "Root=1-ccc;Parent=ddd;Sampled=1";
+            environment.GetEnvironmentVariable(Constants.XrayTraceIdEnv).Returns(traceId1, traceId2);
+
+            // Act
+            var result1 = configurations.XRayTraceId;
+            var result2 = configurations.XRayTraceId;
+
+            // Assert - should go straight to env var on second call (cached false)
+            environment.Received(2)
+                .GetEnvironmentVariable(Arg.Is<string>(i => i == Constants.XrayTraceIdEnv));
+            Assert.Equal(traceId1, result1);
+            Assert.Equal(traceId2, result2);
+        }
+
+        private static void ResetTraceProviderState()
+        {
+            var field = typeof(PowertoolsConfigurations).GetField("_isTraceProviderAvailable",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+            field?.SetValue(null, null);
+        }
+
+        private static void SetTraceProviderAvailable(bool available)
+        {
+            var field = typeof(PowertoolsConfigurations).GetField("_isTraceProviderAvailable",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+            field?.SetValue(null, (bool?)available);
+        }
+
+        #endregion
     }
 }

--- a/libraries/tests/AWS.Lambda.Powertools.Common.Tests/Core/PowertoolsConfigurationsTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Common.Tests/Core/PowertoolsConfigurationsTest.cs
@@ -540,79 +540,106 @@ namespace AWS.Lambda.Powertools.Common.Tests
         [Fact]
         public void XRayTraceId_WhenLambdaTraceProviderAvailable_ReturnsTraceId()
         {
-            // Arrange
-            var environment = Substitute.For<IPowertoolsEnvironment>();
-            var configurations = new PowertoolsConfigurations(environment);
-
-            // Reset cached state so the probe runs fresh
             ResetTraceProviderState();
 
-            // Act - LambdaTraceProvider is available in test env (Amazon.Lambda.Core 2.8.0)
-            var result = configurations.XRayTraceId;
+            try
+            {
+                // Arrange
+                var environment = Substitute.For<IPowertoolsEnvironment>();
+                var configurations = new PowertoolsConfigurations(environment);
 
-            // Assert - should not throw and should not fall back to env var
-            environment.DidNotReceive()
-                .GetEnvironmentVariable(Arg.Is<string>(i => i == Constants.XrayTraceIdEnv));
+                // Act - LambdaTraceProvider is available in test env (Amazon.Lambda.Core 2.8.0)
+                // Returns null/empty in test env (no active Lambda trace), but should not throw
+                var result = configurations.XRayTraceId;
+
+                // Assert - should not fall back to env var (provider was used instead)
+                environment.DidNotReceive()
+                    .GetEnvironmentVariable(Arg.Is<string>(i => i == Constants.XrayTraceIdEnv));
+            }
+            finally
+            {
+                ResetTraceProviderState();
+            }
         }
 
         [Fact]
         public void XRayTraceId_WhenLambdaTraceProviderUnavailable_FallsBackToEnvironmentVariable()
         {
-            // Arrange
-            var traceId = "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1";
-            var environment = Substitute.For<IPowertoolsEnvironment>();
-            environment.GetEnvironmentVariable(Constants.XrayTraceIdEnv).Returns(traceId);
-            var configurations = new PowertoolsConfigurations(environment);
+            ResetTraceProviderState();
 
-            // Simulate LambdaTraceProvider not being available (older Amazon.Lambda.Core)
-            SetTraceProviderAvailable(false);
+            try
+            {
+                // Arrange
+                var traceId = "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1";
+                var environment = Substitute.For<IPowertoolsEnvironment>();
+                environment.GetEnvironmentVariable(Constants.XrayTraceIdEnv).Returns(traceId);
+                var configurations = new PowertoolsConfigurations(environment);
 
-            // Act
-            var result = configurations.XRayTraceId;
+                // Simulate LambdaTraceProvider not being available (older Amazon.Lambda.Core)
+                SetTraceProviderState(-1);
 
-            // Assert
-            environment.Received(1)
-                .GetEnvironmentVariable(Arg.Is<string>(i => i == Constants.XrayTraceIdEnv));
-            Assert.Equal(traceId, result);
+                // Act
+                var result = configurations.XRayTraceId;
+
+                // Assert
+                environment.Received(1)
+                    .GetEnvironmentVariable(Arg.Is<string>(i => i == Constants.XrayTraceIdEnv));
+                Assert.Equal(traceId, result);
+            }
+            finally
+            {
+                ResetTraceProviderState();
+            }
         }
 
         [Fact]
-        public void XRayTraceId_CachesTraceProviderAvailability_OnSubsequentCalls()
+        public void XRayTraceId_WhenProviderCachedUnavailable_UsesEnvVarOnSubsequentCalls()
         {
-            // Arrange
-            var environment = Substitute.For<IPowertoolsEnvironment>();
-            var configurations = new PowertoolsConfigurations(environment);
+            ResetTraceProviderState();
 
-            // Simulate LambdaTraceProvider not being available
-            SetTraceProviderAvailable(false);
+            try
+            {
+                // Arrange
+                var environment = Substitute.For<IPowertoolsEnvironment>();
+                var configurations = new PowertoolsConfigurations(environment);
 
-            var traceId1 = "Root=1-aaa;Parent=bbb;Sampled=1";
-            var traceId2 = "Root=1-ccc;Parent=ddd;Sampled=1";
-            environment.GetEnvironmentVariable(Constants.XrayTraceIdEnv).Returns(traceId1, traceId2);
+                // Simulate LambdaTraceProvider not being available (cached)
+                SetTraceProviderState(-1);
 
-            // Act
-            var result1 = configurations.XRayTraceId;
-            var result2 = configurations.XRayTraceId;
+                var traceId1 = "Root=1-aaa;Parent=bbb;Sampled=1";
+                var traceId2 = "Root=1-ccc;Parent=ddd;Sampled=1";
+                environment.GetEnvironmentVariable(Constants.XrayTraceIdEnv).Returns(traceId1, traceId2);
 
-            // Assert - should go straight to env var on second call (cached false)
-            environment.Received(2)
-                .GetEnvironmentVariable(Arg.Is<string>(i => i == Constants.XrayTraceIdEnv));
-            Assert.Equal(traceId1, result1);
-            Assert.Equal(traceId2, result2);
+                // Act
+                var result1 = configurations.XRayTraceId;
+                var result2 = configurations.XRayTraceId;
+
+                // Assert - should go straight to env var on both calls (cached unavailable)
+                environment.Received(2)
+                    .GetEnvironmentVariable(Arg.Is<string>(i => i == Constants.XrayTraceIdEnv));
+                Assert.Equal(traceId1, result1);
+                Assert.Equal(traceId2, result2);
+            }
+            finally
+            {
+                ResetTraceProviderState();
+            }
         }
 
         private static void ResetTraceProviderState()
         {
-            var field = typeof(PowertoolsConfigurations).GetField("_isTraceProviderAvailable",
+            var field = typeof(PowertoolsConfigurations).GetField("_traceProviderState",
                 System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-            field?.SetValue(null, null);
+            Assert.NotNull(field);
+            field.SetValue(null, 0);
         }
 
-        private static void SetTraceProviderAvailable(bool available)
+        private static void SetTraceProviderState(int state)
         {
-            var field = typeof(PowertoolsConfigurations).GetField("_isTraceProviderAvailable",
+            var field = typeof(PowertoolsConfigurations).GetField("_traceProviderState",
                 System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-            field?.SetValue(null, (bool?)available);
+            Assert.NotNull(field);
+            field.SetValue(null, state);
         }
 
         #endregion


### PR DESCRIPTION
fixes #1173

## Summary

### Changes

Fixes `TypeLoadException` for customers on `Amazon.Lambda.Core < 2.8.0` who upgrade Powertools Logging to 3.1.0+.

`XRayTraceId` now probes for `LambdaTraceProvider.CurrentTraceId` on first access via a `[MethodImpl(NoInlining)]` isolated method, caches the result, and falls back to the `_X_AMZN_TRACE_ID` environment variable when the type is unavailable. No reflection — AOT-compatible.

### User experience

**Before:** Customers on `Amazon.Lambda.Core < 2.8.0` get a `TypeLoadException` at runtime when the logger tries to resolve `LambdaTraceProvider`.

**After:** The logger gracefully falls back to reading the `_X_AMZN_TRACE_ID` environment variable (matching pre-3.1.0 behaviour). Customers on `Amazon.Lambda.Core >= 2.8.0` continue to get correct per-invocation trace ID isolation for LMI.

## Checklist

* [x] [Meets tenets criteria](https://docs.aws.amazon.com/powertools/dotnet/tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.