### PR TITLE
fix(logging): POWERTOOLS_LOG_LEVEL=Trace/Debug no longer ignored

### DIFF
--- a/libraries/src/AWS.Lambda.Powertools.Logging/Internal/Helpers/LoggerFactoryHelper.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Internal/Helpers/LoggerFactoryHelper.cs
@@ -45,6 +45,13 @@ internal static class LoggerFactoryHelper
                 builder.AddFilter(null, configuration.MinimumLogLevel);
                 builder.SetMinimumLevel(configuration.MinimumLogLevel);
             }
+            else
+            {
+                // No explicit level configured — let everything through the factory
+                // so the provider can filter based on POWERTOOLS_LOG_LEVEL env var
+                builder.AddFilter(null, LogLevel.Trace);
+                builder.SetMinimumLevel(LogLevel.Trace);
+            }
         });
         
         LoggerFactoryHolder.SetFactory(factory);

--- a/libraries/src/AWS.Lambda.Powertools.Logging/PowertoolsLoggingBuilderExtensions.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/PowertoolsLoggingBuilderExtensions.cs
@@ -97,6 +97,10 @@ public static class PowertoolsLoggingBuilderExtensions
         builder.Services.TryAddSingleton<ILogger>(provider =>
             provider.GetRequiredService<ILoggerFactory>().CreatePowertoolsLogger());
 
+        // Default the factory minimum to Trace so the framework doesn't filter
+        // before our provider. The provider handles env-var-derived level filtering.
+        builder.SetMinimumLevel(LogLevel.Trace);
+
         builder.Services.TryAddEnumerable(
             ServiceDescriptor.Singleton<ILoggerProvider, PowertoolsLoggerProvider>(provider =>
             {
@@ -174,7 +178,6 @@ public static class PowertoolsLoggingBuilderExtensions
         var options = new PowertoolsLoggerConfiguration();
         configure(options);
 
-        // IMPORTANT: Set the minimum level directly on the builder
         if (options.MinimumLogLevel != LogLevel.None)
         {
             builder.SetMinimumLevel(options.MinimumLogLevel);

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Attributes/LoggingAttributeTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Attributes/LoggingAttributeTest.cs
@@ -727,6 +727,44 @@ namespace AWS.Lambda.Powertools.Logging.Tests.Attributes
                 s.Contains("\"message\":\"This should NOT be logged\"")));
         }
         
+        [Theory]
+        // Reproduces issue #1205 test matrix
+        [InlineData(null,            "information,warning,error,critical", "trace,debug")]
+        [InlineData("Trace",         "trace,debug,information,warning,error,critical", "")]
+        [InlineData("Debug",         "debug,information,warning,error,critical", "trace")]
+        [InlineData("Information",   "information,warning,error,critical", "trace,debug")]
+        [InlineData("Warning",       "warning,error,critical", "trace,debug,information")]
+        [InlineData("Error",         "error,critical", "trace,debug,information,warning")]
+        [InlineData("Critical",      "critical", "trace,debug,information,warning,error")]
+        public void LoggingAttribute_ShouldRespectEnvVarLogLevel(string envLogLevel, string expectedCsv, string missingCsv)
+        {
+            // Reproduces issue #1205: POWERTOOLS_LOG_LEVEL=Trace/Debug ignored when using [Logging] attribute
+            Environment.SetEnvironmentVariable("POWERTOOLS_LOG_LEVEL", envLogLevel);
+
+            var consoleOut = new TestLoggerOutput();
+            Logger.Configure(options =>
+            {
+                options.LogOutput = consoleOut;
+            });
+
+            _testHandlers.TestMethodAllLevels();
+
+            var logOutput = consoleOut.ToString();
+
+            foreach (var level in expectedCsv.Split(','))
+            {
+                Assert.Contains($"LEVELTEST {level}", logOutput);
+            }
+
+            if (!string.IsNullOrEmpty(missingCsv))
+            {
+                foreach (var level in missingCsv.Split(','))
+                {
+                    Assert.DoesNotContain($"LEVELTEST {level}", logOutput);
+                }
+            }
+        }
+
         public void Dispose()
         {
             ResetAllState();

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Handlers/HandlerTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Handlers/HandlerTests.cs
@@ -517,6 +517,98 @@ public class HandlerTests
         }
     }
 
+    [Theory]
+    [InlineData("Trace", "LEVELTEST trace", true)]
+    [InlineData("Trace", "LEVELTEST debug", true)]
+    [InlineData("Trace", "LEVELTEST information", true)]
+    [InlineData("Debug", "LEVELTEST debug", true)]
+    [InlineData("Debug", "LEVELTEST information", true)]
+    [InlineData("Debug", "LEVELTEST trace", false)]
+    [InlineData("Information", "LEVELTEST trace", false)]
+    [InlineData("Information", "LEVELTEST debug", false)]
+    [InlineData("Information", "LEVELTEST information", true)]
+    public void PowertoolsLogLevel_EnvVar_ShouldFilterCorrectly(string envLogLevel, string expectedMessage, bool shouldAppear)
+    {
+        var originalLogLevel = Environment.GetEnvironmentVariable("POWERTOOLS_LOG_LEVEL");
+
+        try
+        {
+            Environment.SetEnvironmentVariable("POWERTOOLS_LOG_LEVEL", envLogLevel);
+
+            var output = new TestLoggerOutput();
+            Logger.Reset();
+            Logger.Configure(options =>
+            {
+                options.LogOutput = output;
+                options.Service = "LevelTestService";
+            });
+
+            Logger.LogTrace("LEVELTEST trace");
+            Logger.LogDebug("LEVELTEST debug");
+            Logger.LogInformation("LEVELTEST information");
+
+            var logOutput = output.ToString();
+            _output.WriteLine(logOutput);
+
+            if (shouldAppear)
+            {
+                Assert.Contains(expectedMessage, logOutput);
+            }
+            else
+            {
+                Assert.DoesNotContain(expectedMessage, logOutput);
+            }
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("POWERTOOLS_LOG_LEVEL", originalLogLevel);
+            Logger.Reset();
+        }
+    }
+
+    [Fact]
+    public void PowertoolsLogLevel_Trace_ViaLoggerFactory_ShouldEmitAllLevels()
+    {
+        var originalLogLevel = Environment.GetEnvironmentVariable("POWERTOOLS_LOG_LEVEL");
+
+        try
+        {
+            Environment.SetEnvironmentVariable("POWERTOOLS_LOG_LEVEL", "Trace");
+
+            var output = new TestLoggerOutput();
+            var logger = LoggerFactory.Create(builder =>
+            {
+                builder.AddPowertoolsLogger(config =>
+                {
+                    config.Service = "LevelTestService";
+                    config.LogOutput = output;
+                });
+            }).CreatePowertoolsLogger();
+
+            logger.LogTrace("LEVELTEST trace");
+            logger.LogDebug("LEVELTEST debug");
+            logger.LogInformation("LEVELTEST information");
+            logger.LogWarning("LEVELTEST warning");
+            logger.LogError("LEVELTEST error");
+            logger.LogCritical("LEVELTEST critical");
+
+            var logOutput = output.ToString();
+            _output.WriteLine(logOutput);
+
+            Assert.Contains("LEVELTEST trace", logOutput);
+            Assert.Contains("LEVELTEST debug", logOutput);
+            Assert.Contains("LEVELTEST information", logOutput);
+            Assert.Contains("LEVELTEST warning", logOutput);
+            Assert.Contains("LEVELTEST error", logOutput);
+            Assert.Contains("LEVELTEST critical", logOutput);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("POWERTOOLS_LOG_LEVEL", originalLogLevel);
+            Logger.Reset();
+        }
+    }
+
     /// <summary>
     /// Test with 0% sampling rate to ensure info logs are not elevated
     /// </summary>

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Handlers/TestHandlers.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/Handlers/TestHandlers.cs
@@ -24,6 +24,17 @@ class TestHandlers
     {
     }
 
+    [Logging(ClearState = true)]
+    public void TestMethodAllLevels()
+    {
+        Logger.LogTrace("LEVELTEST trace");
+        Logger.LogDebug("LEVELTEST debug");
+        Logger.LogInformation("LEVELTEST information");
+        Logger.LogWarning("LEVELTEST warning");
+        Logger.LogError("LEVELTEST error");
+        Logger.LogCritical("LEVELTEST critical");
+    }
+
     [Logging(LogEvent = true)]
     public void LogEventNoArgs()
     {


### PR DESCRIPTION
> Please provide the issue number

Issue number: #1205
fixes: #1205



## Summary

### Changes

When no explicit `MinimumLogLevel` was configured (the default `LogLevel.None`), the `Microsoft.Extensions.Logging` factory kept its default minimum of `Information`, silently filtering Trace/Debug messages before they reached `PowertoolsLoggerProvider`. The provider correctly read `POWERTOOLS_LOG_LEVEL` from the environment and set its own minimum, but the factory-level filter had already short-circuited `ILogger.IsEnabled()` for Trace/Debug.

**Fix:** Set the factory minimum to `LogLevel.Trace` when no explicit level is configured, so all messages pass through to the provider which handles env-var-derived filtering.

**Files changed:**
- `LoggerFactoryHelper.CreateAndConfigureFactory` — added `else` clause for `MinimumLogLevel == None`
- `PowertoolsLoggingBuilderExtensions.AddPowertoolsLogger` — set `Trace` as default factory minimum

### User experience

**Before:** Setting `POWERTOOLS_LOG_LEVEL=Trace` or `POWERTOOLS_LOG_LEVEL=Debug` had no effect — Trace and Debug calls were silently dropped. Only `Information` and above would emit.

**After:** Setting `POWERTOOLS_LOG_LEVEL=Trace` emits all levels (Trace, Debug, Information, Warning, Error, Critical). Setting `POWERTOOLS_LOG_LEVEL=Debug` emits Debug and above. All levels now work as documented.

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://docs.aws.amazon.com/powertools/dotnet/tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.