### PR TITLE
chore(examples): migrate examples and docs to .NET 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![aws provider](https://img.shields.io/badge/provider-AWS-orange?logo=amazon-aws&color=ff9900)
 [![Build](https://github.com/aws-powertools/powertools-lambda-dotnet/actions/workflows/build.yml/badge.svg?branch=develop)](https://github.com/aws-powertools/powertools-lambda-dotnet/actions/workflows/build.yml)
 [![codecov.io](https://codecov.io/github/aws-powertools/powertools-lambda-dotnet/branch/develop/graphs/badge.svg)](https://app.codecov.io/gh/aws-powertools/powertools-lambda-dotnet)
-[![dotnet support](https://img.shields.io/static/v1?label=dotnet&message=%20NET8.0&color=blue?style=flat-square&logo=dotnet)](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
+[![dotnet support](https://img.shields.io/static/v1?label=dotnet&message=%20NET10.0&color=blue?style=flat-square&logo=dotnet)](https://dotnet.microsoft.com/en-us/download/dotnet/10.0)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/AWS.Lambda.Powertools.Logging.svg)](https://www.nuget.org/packages?q=AWS.Lambda.Powertools) [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/aws-powertools/powertools-lambda-dotnet/badge)](https://scorecard.dev/viewer/?uri=github.com/aws-powertools/powertools-lambda-dotnet)
 [![Discord](https://img.shields.io/badge/Discord-Join_Community-7289da.svg)](https://discord.gg/B8zZKbbyET)
 
@@ -90,7 +90,7 @@ The Powertools for AWS Lambda (.NET) utilities are available as NuGet packages. 
 
 ## Examples
 
-We have provided examples focused specifically on each of the utilities. Each solution comes with an AWS Serverless Application Model (AWS SAM) templates to run your functions as a Zip package using the AWS Lambda .NET 8 managed runtime; or as a container package using the AWS base images for .NET.
+We have provided examples focused specifically on each of the utilities. Each solution comes with an AWS Serverless Application Model (AWS SAM) templates to run your functions as a Zip package using the AWS Lambda .NET 10 managed runtime; or as a container package using the AWS base images for .NET.
 
 * **[Logging example](examples/Logging/)**
 * **[Metrics example](examples/Metrics/)**

--- a/docs/migration-guide-v4.md
+++ b/docs/migration-guide-v4.md
@@ -1,0 +1,105 @@
+---
+title: Migration Guide v4
+slug: migration-guide-v4
+description: Migration guide to upgrade to v4 (.NET 10)
+---
+
+# Migration Guide to v4
+
+This guide will help you migrate to v4, which targets the .NET 10 LTS runtime.
+
+## Why upgrade
+
+* **.NET 10 is the current LTS release** - Generally available since November 2025 and supported until November 10, 2028.
+* **.NET 8 support is ending** - .NET 8 (LTS) reaches end of support on November 10, 2026. Production applications should move to .NET 10 for the extended support window.
+* **Performance and cost** - .NET 10 brings JIT and GC improvements plus expanded Native AOT support, which translate directly into faster cold starts and lower memory usage for Lambda functions.
+
+## Breaking Changes
+
+⚠️ Important: Please review these breaking changes before upgrading:
+
+* Requires .NET 10 - The Powertools packages and examples now target `net10.0`.
+* AWS Lambda managed runtime is now `dotnet10` - Update your SAM templates and function configuration accordingly.
+
+> The Powertools for AWS Lambda (.NET) libraries multi-target `net8.0` and `net10.0`, so they remain compatible with .NET 8 during your transition. The examples and recommended runtime, however, now use .NET 10.
+
+## Upgrade Steps
+
+### 1. Install the .NET 10 SDK
+
+Download and install the .NET 10 SDK from [https://dotnet.microsoft.com/download/dotnet/10.0](https://dotnet.microsoft.com/download/dotnet/10.0).
+
+Verify the installation:
+
+```bash
+dotnet --list-sdks
+```
+
+### 2. Update Target Framework
+
+Update your `.csproj` file to target .NET 10:
+
+**Before (v3):**
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+</Project>
+```
+
+**After (v4):**
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+</Project>
+```
+
+### 3. Update the Lambda Runtime
+
+Update your AWS SAM templates (and any function configuration) to use the `dotnet10` managed runtime:
+
+**Before (v3):**
+```yaml
+Resources:
+  HelloWorldFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Runtime: dotnet8
+```
+
+**After (v4):**
+```yaml
+Resources:
+  HelloWorldFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Runtime: dotnet10
+```
+
+### 4. Update Powertools Packages
+
+Update all Powertools package references to v4:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="4.0.*" />
+  <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="4.0.*" />
+  <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="4.0.*" />
+</ItemGroup>
+```
+
+### 5. Native AOT considerations
+
+When publishing with Native AOT, the build OS and architecture must match the target platform (Amazon Linux 2023). The AWS tooling (AWS Toolkit for Visual Studio, the `Amazon.Lambda.Tools` .NET global tool, and the SAM CLI) performs a container build using a .NET 10 Amazon Linux 2023 build image when `PublishAot` is set to `true`. Docker is required when packaging .NET Native AOT Lambda functions on non-Amazon Linux 2023 build environments.
+
+### 6. Build and test
+
+Rebuild and run your test suite to confirm the upgrade:
+
+```bash
+dotnet build
+dotnet test
+```

--- a/examples/AOT/AOT_Logging/src/AOT_Logging/AOT_Logging.csproj
+++ b/examples/AOT/AOT_Logging/src/AOT_Logging/AOT_Logging.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <AWSProjectType>Lambda</AWSProjectType>

--- a/examples/AOT/AOT_Logging/src/AOT_Logging/Readme.md
+++ b/examples/AOT/AOT_Logging/src/AOT_Logging/Readme.md
@@ -22,7 +22,7 @@ set to `true` to strip debugging symbols from the deployed executable to reduce 
 
 When publishing with Native AOT the build OS and Architecture must match the target platform that the application will run. For AWS Lambda that target
 platform is Amazon Linux 2023. The AWS tooling for Lambda like the AWS Toolkit for Visual Studio, .NET Global Tool Amazon.Lambda.Tools and SAM CLI will 
-perform a container build using a .NET 8 Amazon Linux 2023 build image when `PublishAot` is set to `true`. This means **docker is a requirement**
+perform a container build using a .NET 10 Amazon Linux 2023 build image when `PublishAot` is set to `true`. This means **docker is a requirement**
 when packaging .NET Native AOT Lambda functions on non-Amazon Linux 2023 build environments. To install docker go to https://www.docker.com/.
 
 ### Trimming

--- a/examples/AOT/AOT_Logging/src/AOT_Logging/aws-lambda-tools-defaults.json
+++ b/examples/AOT/AOT_Logging/src/AOT_Logging/aws-lambda-tools-defaults.json
@@ -8,7 +8,7 @@
   "profile": "",
   "region": "",
   "configuration": "Release",
-  "function-runtime": "dotnet8",
+  "function-runtime": "dotnet10",
   "function-memory-size": 512,
   "function-timeout": 30,
   "function-handler": "AOT_Logging",

--- a/examples/AOT/AOT_Logging/test/AOT_Logging.Tests/AOT_Logging.Tests.csproj
+++ b/examples/AOT/AOT_Logging/test/AOT_Logging.Tests/AOT_Logging.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>

--- a/examples/AOT/AOT_Metrics/src/AOT_Metrics/AOT_Metrics.csproj
+++ b/examples/AOT/AOT_Metrics/src/AOT_Metrics/AOT_Metrics.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <AWSProjectType>Lambda</AWSProjectType>

--- a/examples/AOT/AOT_Metrics/src/AOT_Metrics/Readme.md
+++ b/examples/AOT/AOT_Metrics/src/AOT_Metrics/Readme.md
@@ -22,7 +22,7 @@ set to `true` to strip debugging symbols from the deployed executable to reduce 
 
 When publishing with Native AOT the build OS and Architecture must match the target platform that the application will run. For AWS Lambda that target
 platform is Amazon Linux 2023. The AWS tooling for Lambda like the AWS Toolkit for Visual Studio, .NET Global Tool Amazon.Lambda.Tools and SAM CLI will 
-perform a container build using a .NET 8 Amazon Linux 2023 build image when `PublishAot` is set to `true`. This means **docker is a requirement**
+perform a container build using a .NET 10 Amazon Linux 2023 build image when `PublishAot` is set to `true`. This means **docker is a requirement**
 when packaging .NET Native AOT Lambda functions on non-Amazon Linux 2023 build environments. To install docker go to https://www.docker.com/.
 
 ### Trimming

--- a/examples/AOT/AOT_Metrics/src/AOT_Metrics/aws-lambda-tools-defaults.json
+++ b/examples/AOT/AOT_Metrics/src/AOT_Metrics/aws-lambda-tools-defaults.json
@@ -8,7 +8,7 @@
   "profile": "",
   "region": "",
   "configuration": "Release",
-  "function-runtime": "dotnet8",
+  "function-runtime": "dotnet10",
   "function-memory-size": 512,
   "function-timeout": 30,
   "function-handler": "AOT_Metrics",

--- a/examples/AOT/AOT_Metrics/test/AOT_Metrics.Tests/AOT_Metrics.Tests.csproj
+++ b/examples/AOT/AOT_Metrics/test/AOT_Metrics.Tests/AOT_Metrics.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>

--- a/examples/AOT/AOT_Tracing/src/AOT_Tracing/AOT_Tracing.csproj
+++ b/examples/AOT/AOT_Tracing/src/AOT_Tracing/AOT_Tracing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <AWSProjectType>Lambda</AWSProjectType>

--- a/examples/AOT/AOT_Tracing/src/AOT_Tracing/Readme.md
+++ b/examples/AOT/AOT_Tracing/src/AOT_Tracing/Readme.md
@@ -22,7 +22,7 @@ set to `true` to strip debugging symbols from the deployed executable to reduce 
 
 When publishing with Native AOT the build OS and Architecture must match the target platform that the application will run. For AWS Lambda that target
 platform is Amazon Linux 2023. The AWS tooling for Lambda like the AWS Toolkit for Visual Studio, .NET Global Tool Amazon.Lambda.Tools and SAM CLI will 
-perform a container build using a .NET 8 Amazon Linux 2023 build image when `PublishAot` is set to `true`. This means **docker is a requirement**
+perform a container build using a .NET 10 Amazon Linux 2023 build image when `PublishAot` is set to `true`. This means **docker is a requirement**
 when packaging .NET Native AOT Lambda functions on non-Amazon Linux 2023 build environments. To install docker go to https://www.docker.com/.
 
 ### Trimming

--- a/examples/AOT/AOT_Tracing/src/AOT_Tracing/aws-lambda-tools-defaults.json
+++ b/examples/AOT/AOT_Tracing/src/AOT_Tracing/aws-lambda-tools-defaults.json
@@ -8,7 +8,7 @@
   "profile": "",
   "region": "",
   "configuration": "Release",
-  "function-runtime": "dotnet8",
+  "function-runtime": "dotnet10",
   "function-memory-size": 512,
   "function-timeout": 30,
   "function-handler": "AOT_Tracing",

--- a/examples/AOT/AOT_Tracing/test/AOT_Tracing.Tests/AOT_Tracing.Tests.csproj
+++ b/examples/AOT/AOT_Tracing/test/AOT_Tracing.Tests/AOT_Tracing.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>

--- a/examples/BatchProcessing/README.md
+++ b/examples/BatchProcessing/README.md
@@ -28,7 +28,7 @@ To use the AWS SAM CLI, you need the following tools.
 * Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community)
 
 You will need the following for local testing.
-* .NET 8.0 - [Install .NET 8.0](https://www.microsoft.com/net/download)
+* .NET 10.0 - [Install .NET 10.0](https://www.microsoft.com/net/download)
 
 To build and deploy your application for the first time, run the following in your shell. Make sure the `template.yaml` file is in your current directory:
 

--- a/examples/BatchProcessing/src/HelloWorld/Dockerfile
+++ b/examples/BatchProcessing/src/HelloWorld/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk@sha256:c8fdd06e430de9f4ddd066b475ea350d771f341b77dd5ff4c2fafa748e3f2ef2 AS build-image
+FROM mcr.microsoft.com/dotnet/sdk@sha256:e1ffd2a92ae84c1291bc1b6887501f8af98e6331e7af6d4c8d37168c5e87a64c AS build-image
 
 ARG FUNCTION_DIR="/build"
 ARG SAM_BUILD_MODE="run"
@@ -13,9 +13,9 @@ RUN dotnet tool install -g Amazon.Lambda.Tools
 # Build and Copy artifacts depending on build mode.
 RUN mkdir -p build_artifacts
 RUN if [ "$SAM_BUILD_MODE" = "debug" ]; then dotnet lambda package --configuration Debug; else dotnet lambda package --configuration Release; fi
-RUN if [ "$SAM_BUILD_MODE" = "debug" ]; then cp -r /build/bin/Debug/net6.0/publish/* /build/build_artifacts; else cp -r /build/bin/Release/net6.0/publish/* /build/build_artifacts; fi
+RUN if [ "$SAM_BUILD_MODE" = "debug" ]; then cp -r /build/bin/Debug/net10.0/publish/* /build/build_artifacts; else cp -r /build/bin/Release/net10.0/publish/* /build/build_artifacts; fi
 
-FROM public.ecr.aws/lambda/dotnet@sha256:ec61a7f638e2a0c86d75204117cc7710bcdc70222ffc777e3fc1458287b09834
+FROM public.ecr.aws/lambda/dotnet@sha256:6a4e0d15ca7b7fa6879155f5ceef7231a19ab099756a7e36090db2bf2fde281f
 
 COPY --from=build-image /build/build_artifacts/ /var/task/
 # Command can be overwritten by providing a different command in the template directly.

--- a/examples/BatchProcessing/src/HelloWorld/HelloWorld.csproj
+++ b/examples/BatchProcessing/src/HelloWorld/HelloWorld.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/examples/BatchProcessing/template.yaml
+++ b/examples/BatchProcessing/template.yaml
@@ -7,7 +7,7 @@ Description: Example project demoing the Batch Processing Utility in Powertools 
 Globals:
   Function:
     Timeout: 20
-    Runtime: dotnet8
+    Runtime: dotnet10
     MemorySize: 1024
     Environment:
       Variables:

--- a/examples/BatchProcessing/test/HelloWorld.Test/HelloWorld.Tests.csproj
+++ b/examples/BatchProcessing/test/HelloWorld.Test/HelloWorld.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Amazon.Lambda.Core" Version="2.8.0" />

--- a/examples/Event Handler/BedrockAgentFunction/src/BedrockAgentFunction.csproj
+++ b/examples/Event Handler/BedrockAgentFunction/src/BedrockAgentFunction.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/examples/Event Handler/BedrockAgentFunction/src/aws-lambda-tools-defaults.json
+++ b/examples/Event Handler/BedrockAgentFunction/src/aws-lambda-tools-defaults.json
@@ -8,7 +8,7 @@
   "profile": "",
   "region": "",
   "configuration": "Release",
-  "function-runtime": "dotnet8",
+  "function-runtime": "dotnet10",
   "function-memory-size": 512,
   "function-timeout": 30,
   "function-handler": "BedrockAgentFunction"

--- a/examples/Idempotency/README.md
+++ b/examples/Idempotency/README.md
@@ -25,7 +25,7 @@ To use the AWS SAM CLI, you need the following tools.
 * Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community)
 
 You will need the following for local testing.
-* .NET 8.0 - [Install .NET 8.0](https://www.microsoft.com/net/download)
+* .NET 10.0 - [Install .NET 10.0](https://www.microsoft.com/net/download)
 
 To build and deploy your application for the first time, run the following in your shell. Make sure the `template.yaml` file is in your current directory:
 

--- a/examples/Idempotency/src/HelloWorld/HelloWorld.csproj
+++ b/examples/Idempotency/src/HelloWorld/HelloWorld.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/examples/Idempotency/template.yaml
+++ b/examples/Idempotency/template.yaml
@@ -18,7 +18,7 @@ Resources:
   HelloWorldFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
     Properties:
-      Runtime: dotnet6
+      Runtime: dotnet10
       CodeUri: ./src/HelloWorld/
       Handler: HelloWorld::HelloWorld.Function::FunctionHandler
       MemorySize: 256

--- a/examples/Idempotency/test/HelloWorld.Test/HelloWorld.Tests.csproj
+++ b/examples/Idempotency/test/HelloWorld.Test/HelloWorld.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Amazon.Lambda.Core" Version="2.8.0" />

--- a/examples/Kafka/Avro/src/Avro.csproj
+++ b/examples/Kafka/Avro/src/Avro.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/examples/Kafka/Avro/src/Readme.md
+++ b/examples/Kafka/Avro/src/Readme.md
@@ -21,7 +21,7 @@ examples/Kafka/Avro/src/
 
 ## Prerequisites
 
-- [Dotnet](https://dotnet.microsoft.com/en-us/download/dotnet) (dotnet8 or later)
+- [Dotnet](https://dotnet.microsoft.com/en-us/download/dotnet) (dotnet10 or later)
 - [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html)
 - [AWS CLI](https://aws.amazon.com/cli/)
 - An AWS account with appropriate permissions

--- a/examples/Kafka/Avro/src/aws-lambda-tools-defaults.json
+++ b/examples/Kafka/Avro/src/aws-lambda-tools-defaults.json
@@ -8,7 +8,7 @@
   "profile": "",
   "region": "",
   "configuration": "Release",
-  "function-runtime": "dotnet8",
+  "function-runtime": "dotnet10",
   "function-memory-size": 512,
   "function-timeout": 30,
   "function-handler": "Avro.Example"

--- a/examples/Kafka/Avro/src/template.yaml
+++ b/examples/Kafka/Avro/src/template.yaml
@@ -10,7 +10,7 @@ Globals:
   Function:
     Timeout: 15
     MemorySize: 512
-    Runtime: dotnet8
+    Runtime: dotnet10
 
 Resources:
   AvroDeserializationFunction:

--- a/examples/Kafka/Json/src/Json.csproj
+++ b/examples/Kafka/Json/src/Json.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/examples/Kafka/Json/src/Readme.md
+++ b/examples/Kafka/Json/src/Readme.md
@@ -20,7 +20,7 @@ examples/Kafka/Json/src/
 
 ## Prerequisites
 
-- [Dotnet](https://dotnet.microsoft.com/en-us/download/dotnet) (dotnet8 or later)
+- [Dotnet](https://dotnet.microsoft.com/en-us/download/dotnet) (dotnet10 or later)
 - [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html)
 - [AWS CLI](https://aws.amazon.com/cli/)
 - An AWS account with appropriate permissions

--- a/examples/Kafka/Json/src/aws-lambda-tools-defaults.json
+++ b/examples/Kafka/Json/src/aws-lambda-tools-defaults.json
@@ -8,7 +8,7 @@
   "profile": "",
   "region": "",
   "configuration": "Release",
-  "function-runtime": "dotnet8",
+  "function-runtime": "dotnet10",
   "function-memory-size": 512,
   "function-timeout": 30,
   "function-handler": "Json"

--- a/examples/Kafka/Json/src/template.yaml
+++ b/examples/Kafka/Json/src/template.yaml
@@ -10,7 +10,7 @@ Globals:
   Function:
     Timeout: 15
     MemorySize: 512
-    Runtime: dotnet8
+    Runtime: dotnet10
 
 Resources:
   JsonDeserializationFunction:

--- a/examples/Kafka/JsonClassLibrary/src/ProtoBufClassLibrary.csproj
+++ b/examples/Kafka/JsonClassLibrary/src/ProtoBufClassLibrary.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -33,7 +33,7 @@
         <Access>Public</Access>
         <ProtoCompile>True</ProtoCompile>
         <CompileOutputs>True</CompileOutputs>
-        <OutputDir>obj/Debug/net8.0/</OutputDir>
+        <OutputDir>obj/Debug/net10.0/</OutputDir>
         <Generator>MSBuild:Compile</Generator>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Protobuf>

--- a/examples/Kafka/JsonClassLibrary/src/Readme.md
+++ b/examples/Kafka/JsonClassLibrary/src/Readme.md
@@ -21,7 +21,7 @@ examples/Kafka/Protobuf/src/
 
 ## Prerequisites
 
-- [Dotnet](https://dotnet.microsoft.com/en-us/download/dotnet) (dotnet8 or later)
+- [Dotnet](https://dotnet.microsoft.com/en-us/download/dotnet) (dotnet10 or later)
 - [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html)
 - [AWS CLI](https://aws.amazon.com/cli/)
 - An AWS account with appropriate permissions
@@ -73,7 +73,7 @@ And update the `.csproj` file to include the `.proto` files.
    <Access>Public</Access>
    <ProtoCompile>True</ProtoCompile>
    <CompileOutputs>True</CompileOutputs>
-   <OutputDir>obj\Debug/net8.0/</OutputDir>
+   <OutputDir>obj\Debug/net10.0/</OutputDir>
    <Generator>MSBuild:Compile</Generator>
    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 </Protobuf>

--- a/examples/Kafka/JsonClassLibrary/src/aws-lambda-tools-defaults.json
+++ b/examples/Kafka/JsonClassLibrary/src/aws-lambda-tools-defaults.json
@@ -9,7 +9,7 @@
   "region": "",
   "configuration": "Release",
   "function-architecture": "x86_64",
-  "function-runtime": "dotnet8",
+  "function-runtime": "dotnet10",
   "function-memory-size": 512,
   "function-timeout": 30,
   "function-handler": "ProtoBufClassLibrary::ProtoBufClassLibrary.Function::FunctionHandler"

--- a/examples/Kafka/JsonClassLibrary/src/template.yaml
+++ b/examples/Kafka/JsonClassLibrary/src/template.yaml
@@ -10,7 +10,7 @@ Globals:
   Function:
     Timeout: 15
     MemorySize: 512
-    Runtime: dotnet8
+    Runtime: dotnet10
 
 Resources:
   ProtobufClassLibraryDeserializationFunction:

--- a/examples/Kafka/Protobuf/src/Protobuf.csproj
+++ b/examples/Kafka/Protobuf/src/Protobuf.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -36,7 +36,7 @@
             <ProtoCompile>True</ProtoCompile>
 
             <CompileOutputs>True</CompileOutputs>
-            <OutputDir>obj\Debug/net8.0/</OutputDir>
+            <OutputDir>obj\Debug/net10.0/</OutputDir>
             <Generator>MSBuild:Compile</Generator>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Protobuf>

--- a/examples/Kafka/Protobuf/src/Readme.md
+++ b/examples/Kafka/Protobuf/src/Readme.md
@@ -21,7 +21,7 @@ examples/Kafka/Protobuf/src/
 
 ## Prerequisites
 
-- [Dotnet](https://dotnet.microsoft.com/en-us/download/dotnet) (dotnet8 or later)
+- [Dotnet](https://dotnet.microsoft.com/en-us/download/dotnet) (dotnet10 or later)
 - [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html)
 - [AWS CLI](https://aws.amazon.com/cli/)
 - An AWS account with appropriate permissions
@@ -73,7 +73,7 @@ And update the `.csproj` file to include the `.proto` files.
    <Access>Public</Access>
    <ProtoCompile>True</ProtoCompile>
    <CompileOutputs>True</CompileOutputs>
-   <OutputDir>obj\Debug/net8.0/</OutputDir>
+   <OutputDir>obj\Debug/net10.0/</OutputDir>
    <Generator>MSBuild:Compile</Generator>
    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 </Protobuf>

--- a/examples/Kafka/Protobuf/src/aws-lambda-tools-defaults.json
+++ b/examples/Kafka/Protobuf/src/aws-lambda-tools-defaults.json
@@ -8,7 +8,7 @@
   "profile": "",
   "region": "",
   "configuration": "Release",
-  "function-runtime": "dotnet8",
+  "function-runtime": "dotnet10",
   "function-memory-size": 512,
   "function-timeout": 30,
   "function-handler": "Protobuf"

--- a/examples/Kafka/Protobuf/src/template.yaml
+++ b/examples/Kafka/Protobuf/src/template.yaml
@@ -10,7 +10,7 @@ Globals:
   Function:
     Timeout: 15
     MemorySize: 512
-    Runtime: dotnet8
+    Runtime: dotnet10
 
 Resources:
   ProtobufDeserializationFunction:

--- a/examples/Logging/README.md
+++ b/examples/Logging/README.md
@@ -25,7 +25,7 @@ To use the AWS SAM CLI, you need the following tools.
 * Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community)
 
 You will need the following for local testing.
-* .NET 8.0 - [Install .NET 8.0](https://www.microsoft.com/net/download)
+* .NET 10.0 - [Install .NET 10.0](https://www.microsoft.com/net/download)
 
 To build and deploy your application for the first time, run the following in your shell. Make sure the `template.yaml` file is in your current directory:
 

--- a/examples/Logging/src/HelloWorld/Dockerfile
+++ b/examples/Logging/src/HelloWorld/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk@sha256:c8fdd06e430de9f4ddd066b475ea350d771f341b77dd5ff4c2fafa748e3f2ef2 AS build-image
+FROM mcr.microsoft.com/dotnet/sdk@sha256:e1ffd2a92ae84c1291bc1b6887501f8af98e6331e7af6d4c8d37168c5e87a64c AS build-image
 
 ARG FUNCTION_DIR="/build"
 ARG SAM_BUILD_MODE="run"
@@ -13,9 +13,9 @@ RUN dotnet tool install -g Amazon.Lambda.Tools
 # Build and Copy artifacts depending on build mode.
 RUN mkdir -p build_artifacts
 RUN if [ "$SAM_BUILD_MODE" = "debug" ]; then dotnet lambda package --configuration Debug; else dotnet lambda package --configuration Release; fi
-RUN if [ "$SAM_BUILD_MODE" = "debug" ]; then cp -r /build/bin/Debug/net6.0/publish/* /build/build_artifacts; else cp -r /build/bin/Release/net6.0/publish/* /build/build_artifacts; fi
+RUN if [ "$SAM_BUILD_MODE" = "debug" ]; then cp -r /build/bin/Debug/net10.0/publish/* /build/build_artifacts; else cp -r /build/bin/Release/net10.0/publish/* /build/build_artifacts; fi
 
-FROM public.ecr.aws/lambda/dotnet@sha256:ec61a7f638e2a0c86d75204117cc7710bcdc70222ffc777e3fc1458287b09834
+FROM public.ecr.aws/lambda/dotnet@sha256:6a4e0d15ca7b7fa6879155f5ceef7231a19ab099756a7e36090db2bf2fde281f
 
 COPY --from=build-image /build/build_artifacts/ /var/task/
 # Command can be overwritten by providing a different command in the template directly.

--- a/examples/Logging/src/HelloWorld/HelloWorld.csproj
+++ b/examples/Logging/src/HelloWorld/HelloWorld.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/examples/Logging/template-docker.yaml
+++ b/examples/Logging/template-docker.yaml
@@ -32,7 +32,7 @@ Resources:
             Path: /hello
             Method: get
     Metadata:
-      DockerTag: dotnet6.0-v1
+      DockerTag: dotnet10.0-v1
       DockerContext: ./src/HelloWorld
       Dockerfile: Dockerfile
       DockerBuildArgs:

--- a/examples/Logging/template.yaml
+++ b/examples/Logging/template.yaml
@@ -19,7 +19,7 @@ Resources:
   HelloWorldFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
     Properties:
-      Runtime: dotnet6
+      Runtime: dotnet10
       CodeUri: ./src/HelloWorld/
       Handler: HelloWorld::HelloWorld.Function::FunctionHandler
       MemorySize: 256

--- a/examples/Logging/test/HelloWorld.Test/HelloWorld.Tests.csproj
+++ b/examples/Logging/test/HelloWorld.Test/HelloWorld.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Amazon.Lambda.Core" Version="2.8.0" />

--- a/examples/Metrics/README.md
+++ b/examples/Metrics/README.md
@@ -25,7 +25,7 @@ To use the AWS SAM CLI, you need the following tools.
 * Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community)
 
 You will need the following for local testing.
-* .NET 8.0 - [Install .NET 8.0](https://www.microsoft.com/net/download)
+* .NET 10.0 - [Install .NET 10.0](https://www.microsoft.com/net/download)
 
 To build and deploy your application for the first time, run the following in your shell. Make sure the `template.yaml` file is in your current directory:
 

--- a/examples/Metrics/src/HelloWorld/Dockerfile
+++ b/examples/Metrics/src/HelloWorld/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk@sha256:c8fdd06e430de9f4ddd066b475ea350d771f341b77dd5ff4c2fafa748e3f2ef2 AS build-image
+FROM mcr.microsoft.com/dotnet/sdk@sha256:e1ffd2a92ae84c1291bc1b6887501f8af98e6331e7af6d4c8d37168c5e87a64c AS build-image
 
 ARG FUNCTION_DIR="/build"
 ARG SAM_BUILD_MODE="run"
@@ -14,9 +14,9 @@ RUN dotnet tool install -g Amazon.Lambda.Tools
 # Build and Copy artifacts depending on build mode.
 RUN mkdir -p build_artifacts
 RUN if [ "$SAM_BUILD_MODE" = "debug" ]; then dotnet lambda package --configuration Debug; else dotnet lambda package --configuration Release; fi
-RUN if [ "$SAM_BUILD_MODE" = "debug" ]; then cp -r /build/bin/Debug/net6.0/publish/* /build/build_artifacts; else cp -r /build/bin/Release/net6.0/publish/* /build/build_artifacts; fi
+RUN if [ "$SAM_BUILD_MODE" = "debug" ]; then cp -r /build/bin/Debug/net10.0/publish/* /build/build_artifacts; else cp -r /build/bin/Release/net10.0/publish/* /build/build_artifacts; fi
 
-FROM public.ecr.aws/lambda/dotnet@sha256:ec61a7f638e2a0c86d75204117cc7710bcdc70222ffc777e3fc1458287b09834
+FROM public.ecr.aws/lambda/dotnet@sha256:6a4e0d15ca7b7fa6879155f5ceef7231a19ab099756a7e36090db2bf2fde281f
 
 COPY --from=build-image /build/build_artifacts/ /var/task/
 # Command can be overwritten by providing a different command in the template directly.

--- a/examples/Metrics/src/HelloWorld/HelloWorld.csproj
+++ b/examples/Metrics/src/HelloWorld/HelloWorld.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/examples/Metrics/template-docker.yaml
+++ b/examples/Metrics/template-docker.yaml
@@ -33,7 +33,7 @@ Resources:
             Path: /hello
             Method: get
     Metadata:
-      DockerTag: dotnet6.0-v1
+      DockerTag: dotnet10.0-v1
       DockerContext: ./src/HelloWorld
       Dockerfile: Dockerfile
       DockerBuildArgs:

--- a/examples/Metrics/template.yaml
+++ b/examples/Metrics/template.yaml
@@ -20,7 +20,7 @@ Resources:
   HelloWorldFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
     Properties:
-      Runtime: dotnet6
+      Runtime: dotnet10
       CodeUri: ./src/HelloWorld/
       Handler: HelloWorld::HelloWorld.Function::FunctionHandler
       MemorySize: 256

--- a/examples/Metrics/test/HelloWorld.Test/HelloWorld.Tests.csproj
+++ b/examples/Metrics/test/HelloWorld.Test/HelloWorld.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Amazon.Lambda.Core" Version="2.8.0" />

--- a/examples/Parameters/README.md
+++ b/examples/Parameters/README.md
@@ -25,7 +25,7 @@ To use the AWS SAM CLI, you need the following tools.
 * Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community)
 
 You will need the following for local testing.
-* .NET 8.0 - [Install .NET 8.0](https://www.microsoft.com/net/download)
+* .NET 10.0 - [Install .NET 10.0](https://www.microsoft.com/net/download)
 
 To build and deploy your application for the first time, run the following in your shell. Make sure the `template.yaml` file is in your current directory:
 

--- a/examples/Parameters/cfn/HelloWorld.Cfn/HelloWorld.Cfn.csproj
+++ b/examples/Parameters/cfn/HelloWorld.Cfn/HelloWorld.Cfn.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
         <Nullable>enable</Nullable>
         <RootNamespace>HelloWorld.Cfn</RootNamespace>

--- a/examples/Parameters/src/HelloWorld/HelloWorld.csproj
+++ b/examples/Parameters/src/HelloWorld/HelloWorld.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/examples/Parameters/template.yaml
+++ b/examples/Parameters/template.yaml
@@ -53,7 +53,7 @@ Resources:
   HelloWorldFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
     Properties:
-      Runtime: dotnet6
+      Runtime: dotnet10
       CodeUri: ./src/HelloWorld/
       Handler: HelloWorld::HelloWorld.Function::FunctionHandler
       MemorySize: 256
@@ -233,7 +233,7 @@ Resources:
   InitCustomResourcFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: dotnet6
+      Runtime: dotnet10
       CodeUri: ./cfn/HelloWorld.Cfn/
       Handler: HelloWorld.Cfn::HelloWorld.Cfn.Function::FunctionHandler
       MemorySize: 256

--- a/examples/Parameters/test/HelloWorld.Test/HelloWorld.Tests.csproj
+++ b/examples/Parameters/test/HelloWorld.Test/HelloWorld.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Amazon.Lambda.Core" Version="2.8.0" />

--- a/examples/ServerlessApi/Readme.md
+++ b/examples/ServerlessApi/Readme.md
@@ -27,7 +27,7 @@ To use the AWS SAM CLI, you need the following tools.
 * Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community)
 
 You will need the following for local testing.
-* .NET 8.0 - [Install .NET 8.0](https://www.microsoft.com/net/download)
+* .NET 10.0 - [Install .NET 10.0](https://www.microsoft.com/net/download)
 
 To build and deploy your application for the first time, run the following in your shell. Make sure the `serverless.template` file is in your current directory:
 

--- a/examples/ServerlessApi/src/LambdaPowertoolsAPI/LambdaPowertoolsAPI.csproj
+++ b/examples/ServerlessApi/src/LambdaPowertoolsAPI/LambdaPowertoolsAPI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/examples/ServerlessApi/src/LambdaPowertoolsAPI/template.yaml
+++ b/examples/ServerlessApi/src/LambdaPowertoolsAPI/template.yaml
@@ -12,7 +12,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: LambdaPowertoolsAPI::LambdaPowertoolsAPI.LambdaEntryPoint::FunctionHandlerAsync
-      Runtime: dotnet6
+      Runtime: dotnet10
       CodeUri: '.'
       MemorySize: 256
       Timeout: 30

--- a/examples/ServerlessApi/test/LambdaPowertoolsAPI.Tests/LambdaPowertoolsAPI.Tests.csproj
+++ b/examples/ServerlessApi/test/LambdaPowertoolsAPI.Tests/LambdaPowertoolsAPI.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <EnableDefaultContentItems>False</EnableDefaultContentItems>

--- a/examples/Tracing/README.md
+++ b/examples/Tracing/README.md
@@ -25,7 +25,7 @@ To use the AWS SAM CLI, you need the following tools.
 * Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community)
 
 You will need the following for local testing.
-* .NET 8.0 - [Install .NET 8.0](https://www.microsoft.com/net/download)
+* .NET 10.0 - [Install .NET 10.0](https://www.microsoft.com/net/download)
 
 To build and deploy your application for the first time, run the following in your shell. Make sure the `template.yaml` file is in your current directory:
 

--- a/examples/Tracing/src/HelloWorld/Dockerfile
+++ b/examples/Tracing/src/HelloWorld/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk@sha256:c8fdd06e430de9f4ddd066b475ea350d771f341b77dd5ff4c2fafa748e3f2ef2 AS build-image
+FROM mcr.microsoft.com/dotnet/sdk@sha256:e1ffd2a92ae84c1291bc1b6887501f8af98e6331e7af6d4c8d37168c5e87a64c AS build-image
 
 ARG FUNCTION_DIR="/build"
 ARG SAM_BUILD_MODE="run"
@@ -14,9 +14,9 @@ RUN dotnet tool install -g Amazon.Lambda.Tools
 # Build and Copy artifacts depending on build mode.
 RUN mkdir -p build_artifacts
 RUN if [ "$SAM_BUILD_MODE" = "debug" ]; then dotnet lambda package --configuration Debug; else dotnet lambda package --configuration Release; fi
-RUN if [ "$SAM_BUILD_MODE" = "debug" ]; then cp -r /build/bin/Debug/net6.0/publish/* /build/build_artifacts; else cp -r /build/bin/Release/net6.0/publish/* /build/build_artifacts; fi
+RUN if [ "$SAM_BUILD_MODE" = "debug" ]; then cp -r /build/bin/Debug/net10.0/publish/* /build/build_artifacts; else cp -r /build/bin/Release/net10.0/publish/* /build/build_artifacts; fi
 
-FROM public.ecr.aws/lambda/dotnet@sha256:ec61a7f638e2a0c86d75204117cc7710bcdc70222ffc777e3fc1458287b09834
+FROM public.ecr.aws/lambda/dotnet@sha256:6a4e0d15ca7b7fa6879155f5ceef7231a19ab099756a7e36090db2bf2fde281f
 
 COPY --from=build-image /build/build_artifacts/ /var/task/
 # Command can be overwritten by providing a different command in the template directly.

--- a/examples/Tracing/src/HelloWorld/HelloWorld.csproj
+++ b/examples/Tracing/src/HelloWorld/HelloWorld.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/examples/Tracing/template-docker.yaml
+++ b/examples/Tracing/template-docker.yaml
@@ -32,7 +32,7 @@ Resources:
             Path: /hello
             Method: get
     Metadata:
-      DockerTag: dotnet6.0-v1
+      DockerTag: dotnet10.0-v1
       DockerContext: ./src/HelloWorld
       Dockerfile: Dockerfile
       DockerBuildArgs:

--- a/examples/Tracing/template.yaml
+++ b/examples/Tracing/template.yaml
@@ -30,7 +30,7 @@ Resources:
   HelloWorldFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
     Properties:
-      Runtime: dotnet6
+      Runtime: dotnet10
       CodeUri: ./src/HelloWorld/
       Handler: HelloWorld::HelloWorld.Function::FunctionHandler
       MemorySize: 256

--- a/examples/Tracing/test/HelloWorld.Test/HelloWorld.Tests.csproj
+++ b/examples/Tracing/test/HelloWorld.Test/HelloWorld.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Amazon.Lambda.Core" Version="2.8.0" />


### PR DESCRIPTION
Issue number: #1268

Closes #1268

## Summary

### Changes

Migrates all **example projects** and documentation from .NET 8 (with some lingering .NET 6 runtimes) to **.NET 10**, and adds a v4 migration guide. This PR intentionally does **not** touch the production libraries under `libraries/src/` — those already multi-target `net8.0;net10.0`.

- **Target framework:** all example `.csproj` `net8.0` → `net10.0`
- **SAM templates:** `Runtime` `dotnet6`/`dotnet8` → `dotnet10`
- **Deploy config:** `aws-lambda-tools-defaults.json` `function-runtime` → `dotnet10`
- **Container examples:**
  - Dockerfile base images repinned to real .NET 10 digests — MCR `dotnet/sdk:10.0` and ECR Public `lambda/dotnet:10.x` (both multi-arch amd64+arm64), resolved directly from the registries
  - publish path `net6.0` → `net10.0`
  - `DockerTag` `dotnet6.0-v1` → `dotnet10.0-v1`
- **Kafka:** Protobuf `OutputDir` `net8.0` → `net10.0`
- **Docs:** example READMEs (`.NET 8.0` → `.NET 10.0`, `dotnet8` → `dotnet10`), root README badge + managed-runtime text, and a new `docs/migration-guide-v4.md`

Several SAM templates were previously on `dotnet6` while their `.csproj` were already `net8.0` (pre-existing inconsistency), now aligned on `dotnet10`.

### User experience

**Before:** copying an example gives a project targeting `net8.0` (or a SAM template still on the `dotnet6`/`dotnet8` managed runtime), pointed at a runtime about to reach end of support.

**After:** examples target `net10.0` and deploy on the `dotnet10` managed runtime out of the box, aligned with the current LTS runtime and with the libraries that already support net10.0.

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://docs.aws.amazon.com/powertools/dotnet/tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)

### Testing

- .NET 10 SDK 10.0.400 confirmed locally
- Example test suites pass on `net10.0` — **26 tests, 0 failures**: Logging (1), Metrics (1), Tracing (1), BatchProcessing (13), Parameters (6), ServerlessApi (1), AOT Logging/Metrics/Tracing (1 each)
- Container base-image digests verified buildable via Finch (multi-stage build with both images succeeded; SDK image reports 10.0.400)

**Known limitation:** the Idempotency example test is an integration test that spins up DynamoDB Local via Testcontainers (Docker). It could not be executed locally (no Docker daemon). The code compiles cleanly on `net10.0`; only the test infrastructure was unavailable — please validate in CI.

<details>
<summary>Is this a breaking change?</summary>

No. This changes only the example projects and documentation; no production library code is modified.

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.

